### PR TITLE
docs(i18n): fully translate all 10 localized READMEs

### DIFF
--- a/README_AR.md
+++ b/README_AR.md
@@ -1,19 +1,194 @@
 <p align="center">
-  <a href="https://teamatonce.com"><img src="frontend/public/assets/logo.png" alt="Team@Once" width="80"></a>
+  <a href="https://teamatonce.com">
+    <img src="frontend/public/assets/logo.png" alt="Team@Once" width="80">
+  </a>
   <h1 align="center">Team@Once</h1>
   <p align="center"><strong>منصة مفتوحة المصدر لتعهيد التطوير البرمجي بالذكاء الاصطناعي</strong></p>
+  <p align="center">ثورة في تعهيد تطوير البرمجيات من خلال الأتمتة الذكية والعمليات الشفافة والتعاون السلس.</p>
+</p>
+
+<p align="center">
+  <a href="https://github.com/teamatonce/teamatonce/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue.svg" alt="License"></a>
+  <a href="https://github.com/teamatonce/teamatonce/stargazers"><img src="https://img.shields.io/github/stars/teamatonce/teamatonce?style=social" alt="GitHub Stars"></a>
+  <a href="https://github.com/teamatonce/teamatonce/issues"><img src="https://img.shields.io/github/issues/teamatonce/teamatonce" alt="Issues"></a>
+</p>
+
+<p align="center">
+  <a href="https://teamatonce.com">الموقع</a> |
+  <a href="#البدء-السريع">البدء السريع</a> |
+  <a href="#الميزات">الميزات</a> |
+  <a href="https://github.com/teamatonce/teamatonce/discussions">النقاشات</a> |
+  <a href="CONTRIBUTING.md">المساهمة</a>
+</p>
+
+<p align="center">
+  <a href="./README.md">English</a> |
+  <a href="./README_JA.md">日本語</a> |
+  <a href="./README_ZH.md">中文</a> |
+  <a href="./README_KO.md">한국어</a> |
+  <a href="./README_ES.md">Español</a> |
+  <a href="./README_FR.md">Français</a> |
+  <a href="./README_DE.md">Deutsch</a> |
+  <a href="./README_PT-BR.md">Português</a> |
+  <a href="./README_AR.md">العربية</a> |
+  <a href="./README_HI.md">हिन्दी</a> |
+  <a href="./README_RU.md">Русский</a>
 </p>
 
 ---
 
-<p align="center"><a href="./README.md">English</a> | <a href="./README_JA.md">日本語</a> | <a href="./README_ZH.md">中文</a> | <a href="./README_KO.md">한국어</a> | <a href="./README_ES.md">Español</a> | <a href="./README_FR.md">Français</a> | <a href="./README_DE.md">Deutsch</a> | <a href="./README_PT-BR.md">Português</a> | <a href="./README_AR.md">العربية</a> | <a href="./README_HI.md">हिन्दी</a> | <a href="./README_RU.md">Русский</a></p>
-
 ## ما هو Team@Once؟
 
-منصة سوق مفتوحة المصدر لتعهيد التطوير البرمجي مدعومة بالذكاء الاصطناعي — مطابقة ذكية للفرق، مدفوعات ضمان، تقييمات مهارات، ومسارات تعلم.
+Team@Once هي منصة مفتوحة المصدر لتعهيد التطوير البرمجي مدعومة بالذكاء الاصطناعي، تقضي على المخاطر التقليدية من خلال الأتمتة الذكية، والتقييمات المدعومة بالذكاء الاصطناعي، والمدفوعات المحتجزة (Escrow)، وإدارة المشاريع في الوقت الفعلي.
 
-راجع [الملف التمهيدي بالإنجليزية](./README.md) لمزيد من التفاصيل.
+## لماذا Team@Once؟ (مقارنة)
+
+| الميزة | Team@Once | Upwork | Toptal | Fiverr | Deel |
+|--------|-----------|--------|--------|--------|------|
+| **المطابقة بالذكاء الاصطناعي** | ✅ NLP + مطابقة ذكية | ❌ | ⚠️ فحص يدوي | ❌ | ❌ |
+| **إدارة مشاريع مدمجة** | ✅ Kanban، مراحل، تتبع الوقت | ⚠️ أساسي | ❌ | ❌ | ❌ |
+| **المدفوعات المحتجزة** | ✅ قائمة على المراحل | ✅ | ✅ | ✅ | ❌ |
+| **تعاون بالفيديو** | ✅ مكالمات مدمجة + مشاركة الشاشة | ❌ | ❌ | ❌ | ❌ |
+| **تقييم المهارات** | ✅ مُولَّدة بالذكاء الاصطناعي + شهادات | ⚠️ اختبارات أساسية | ✅ صارمة | ⚠️ أساسي | ❌ |
+| **مسارات التعلم** | ✅ دورات + شهادات | ❌ | ❌ | ❌ | ❌ |
+| **محادثة فورية** | ✅ قنوات + مشاركة الملفات | ⚠️ أساسي | ❌ | ⚠️ أساسي | ❌ |
+| **مساحات عمل الفريق** | ✅ تنظيم متعدد المشاريع | ❌ | ❌ | ❌ | ❌ |
+| **محرك البيانات** | ✅ زاحف اكتشاف الشركات | ❌ | ❌ | ❌ | ❌ |
+| **العقود الذكية** | ✅ إنشاء تلقائي + توقيع إلكتروني | ⚠️ أساسي | ❌ | ⚠️ أساسي | ✅ |
+| **الوصول عبر API** | ✅ REST API كامل | ⚠️ جزئي | ❌ | ❌ | ✅ |
+| **استضافة ذاتية** | ✅ Docker Compose | ❌ | ❌ | ❌ | ❌ |
+| **مفتوح المصدر** | ✅ AGPL 3.0 | ❌ | ❌ | ❌ | ❌ |
+| **رسوم المنصة** | 🟢 3-5% | 💰 10-20% | 💰 ~2x زيادة | 💰 20% | 💰 مخصص |
+| **تعدد اللغات** | ✅ 11 لغة | ✅ | ✅ | ✅ | ✅ |
+
+## الميزات
+
+### السوق
+- **ملفات الشركات** -- عرض المحافظ ومهارات الفريق والشهادات
+- **المطابقة بالذكاء الاصطناعي** -- مطابقة ذكية بين الشركات والمشاريع بناءً على المهارات والسجل
+- **محرك البيانات** -- زحف الويب وخط أنابيب لاكتشاف الشركات وإثرائها
+- **المدفوعات المحتجزة** -- مدفوعات آمنة قائمة على المراحل عبر Stripe
+
+### التعلم والشهادات
+- **إدارة الدورات** -- إنشاء وإدارة الدورات التقنية مع الوحدات والدروس
+- **تقييمات الذكاء الاصطناعي** -- اختبارات وتقييمات مهارات مُولَّدة بالذكاء الاصطناعي
+- **الشهادات** -- شهادات إنجاز قابلة للتحقق
+- **مسارات التعلم** -- مسارات منظمة لتطوير المهارات
+- **الإنجازات** -- تلعيب مع شارات وتتبع التقدم
+
+### التعاون
+- **إدارة المشاريع** -- تتبع المشاريع بالمراحل والمخرجات
+- **منتديات النقاش** -- نقاشات مجتمعية ومشاركة المعرفة
+- **إشعارات فورية** -- تحديثات حية مدعومة بـ WebSocket
+- **المدونة** -- إدارة محتوى المقالات والأدلة
+- **مجموعات الدراسة** -- مساحات تعلم تعاونية
+
+### المنصة
+- **تكامل الذكاء الاصطناعي** -- توليد وتحليل المحتوى بقوة OpenAI
+- **البحث** -- بحث متجهي عبر Qdrant لاكتشاف المحتوى دلاليًا
+- **تعدد اللغات** -- دعم التدويل (i18n)
+- **لوحة تحكم المسؤول** -- إدارة المنصة والتحليلات
+- **تحسين محركات البحث** -- عرض من جانب الخادم وتحسين البيانات الوصفية
+
+## المكدس التقني
+
+| الطبقة | التقنية |
+|--------|---------|
+| **الخلفية** | NestJS 11, TypeScript, PostgreSQL (raw SQL), Redis, Qdrant, Socket.io |
+| **الواجهة الأمامية** | React 19, Vite, TypeScript, Tailwind CSS, Radix UI, Zustand |
+| **الذكاء الاصطناعي** | OpenAI (GPT-4o-mini, embeddings) |
+| **المدفوعات** | Stripe (الحجز، الاشتراكات) |
+| **البحث** | Qdrant (بحث متجهي) |
+
+## المتطلبات الأساسية
+
+- **Node.js** >= 18
+- **Docker** (مُوصى به) أو PostgreSQL 15+ و Redis و Qdrant مثبتة محليًا
+
+## البدء السريع
+
+### 1. تشغيل الخدمات
+
+أسهل طريقة لتشغيل PostgreSQL و Redis و Qdrant هي باستخدام Docker:
+
+```bash
+git clone https://github.com/teamatonce/teamatonce.git
+cd teamatonce
+docker compose up -d
+```
+
+هذا يُشغّل جميع الخدمات المطلوبة ببيانات اعتماد تتوافق مع `.env.example` مباشرةً.
+
+<details>
+<summary>بدون Docker (إعداد يدوي)</summary>
+
+قم بتثبيت وتشغيل PostgreSQL و Redis و Qdrant بنفسك، ثم حدّث `backend/.env` بتفاصيل الاتصال الخاصة بك:
+
+```bash
+# PostgreSQL — إنشاء قاعدة بيانات التطوير
+createdb -U postgres teamatonce_dev
+
+# حدّث DATABASE_PASSWORD في backend/.env ليتوافق مع كلمة مرور PostgreSQL الخاصة بك
+```
+
+</details>
+
+### 2. الخلفية
+
+```bash
+cd backend
+cp .env.example .env    # بيانات الاعتماد تتوافق مع docker-compose.yml مسبقًا
+npm install
+npm run migrate
+npm run start:dev
+```
+
+### 3. الواجهة الأمامية (نافذة طرفية جديدة)
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+## هيكل المشروع
+
+```
+teamatonce/
+├── backend/              # واجهة NestJS API (34 وحدة)
+│   ├── src/modules/      # auth, company, courses, assessments, ai, search,
+│   │                     # escrow, certificates, learning-paths, blog, ...
+│   └── migrations/       # ترحيلات PostgreSQL
+├── frontend/             # React + Vite + Tailwind
+│   └── src/
+└── .github/workflows/    # CI/CD
+```
+
+## المساهمون
+
+شكرًا لجميع الأشخاص الرائعين الذين ساهموا في Team@Once!
+
+<a href="https://github.com/teamatonce/teamatonce/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=teamatonce/teamatonce&anon=1&max=100&columns=10" />
+</a>
+
+هل تريد أن ترى صورتك هنا؟ اطّلع على [دليل المساهمة](CONTRIBUTING.md) وابدأ المساهمة اليوم!
+
+## نشاط المشروع
+
+<p align="center">
+  <img src="https://img.shields.io/github/stars/teamatonce/teamatonce?style=for-the-badge&logo=github&color=yellow" alt="Stars">
+  <img src="https://img.shields.io/github/forks/teamatonce/teamatonce?style=for-the-badge&logo=github&color=blue" alt="Forks">
+  <img src="https://img.shields.io/github/contributors/teamatonce/teamatonce?style=for-the-badge&logo=github&color=green" alt="Contributors">
+  <img src="https://img.shields.io/github/last-commit/teamatonce/teamatonce?style=for-the-badge&logo=github&color=orange" alt="Last Commit">
+</p>
+
+## الأمان
+
+يرجى الإبلاغ عن الثغرات الأمنية بشكل مسؤول. راجع [SECURITY.md](SECURITY.md).
 
 ## الترخيص
 
-[GNU AGPL 3.0](LICENSE)
+هذا المشروع مرخص بموجب [رخصة GNU Affero العمومية الإصدار 3.0](LICENSE).
+
+حقوق النشر 2025 مساهمو Team@Once.

--- a/README_DE.md
+++ b/README_DE.md
@@ -3,20 +3,196 @@
     <img src="frontend/public/assets/logo.png" alt="Team@Once" width="80">
   </a>
   <h1 align="center">Team@Once</h1>
-  <p align="center"><strong>KI-gesteuerte Entwicklungs-Outsourcing-Plattform</strong></p>
-  <p align="center">Revolutionierung des Software-Entwicklungs-Outsourcings.</p>
+  <p align="center">
+    <strong>Open-Source KI-gestützte Entwicklungs-Outsourcing-Plattform</strong>
+  </p>
+  <p align="center">
+    Revolutionierung des Software-Entwicklungs-Outsourcings durch intelligente Automatisierung, transparente Prozesse und nahtlose Zusammenarbeit.
+  </p>
 </p>
 
 <p align="center">
-  <a href="./README.md">English</a> | <a href="./README_JA.md">日本語</a> | <a href="./README_ZH.md">中文</a> | <a href="./README_KO.md">한국어</a> | <a href="./README_ES.md">Español</a> | <a href="./README_FR.md">Français</a> | <a href="./README_DE.md">Deutsch</a> | <a href="./README_PT-BR.md">Português</a> | <a href="./README_RU.md">Русский</a>
+  <a href="https://github.com/teamatonce/teamatonce/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue.svg" alt="Lizenz"></a>
+  <a href="https://github.com/teamatonce/teamatonce/stargazers"><img src="https://img.shields.io/github/stars/teamatonce/teamatonce?style=social" alt="GitHub Sterne"></a>
+  <a href="https://github.com/teamatonce/teamatonce/issues"><img src="https://img.shields.io/github/issues/teamatonce/teamatonce" alt="Issues"></a>
+</p>
+
+<p align="center">
+  <a href="https://teamatonce.com">Webseite</a> |
+  <a href="#schnellstart">Schnellstart</a> |
+  <a href="#funktionen">Funktionen</a> |
+  <a href="https://github.com/teamatonce/teamatonce/discussions">Diskussionen</a> |
+  <a href="CONTRIBUTING.md">Mitwirken</a>
+</p>
+
+<p align="center">
+  <a href="./README.md">English</a> |
+  <a href="./README_JA.md">日本語</a> |
+  <a href="./README_ZH.md">中文</a> |
+  <a href="./README_KO.md">한국어</a> |
+  <a href="./README_ES.md">Español</a> |
+  <a href="./README_FR.md">Français</a> |
+  <a href="./README_DE.md">Deutsch</a> |
+  <a href="./README_PT-BR.md">Português</a> |
+  <a href="./README_AR.md">العربية</a> |
+  <a href="./README_HI.md">हिन्दी</a> |
+  <a href="./README_RU.md">Русский</a>
 </p>
 
 ---
 
-<p align="center"><a href="./README.md">English</a> | <a href="./README_JA.md">日本語</a> | <a href="./README_ZH.md">中文</a> | <a href="./README_KO.md">한국어</a> | <a href="./README_ES.md">Español</a> | <a href="./README_FR.md">Français</a> | <a href="./README_DE.md">Deutsch</a> | <a href="./README_PT-BR.md">Português</a> | <a href="./README_AR.md">العربية</a> | <a href="./README_HI.md">हिन्दी</a> | <a href="./README_RU.md">Русский</a></p>
+## Was ist Team@Once?
 
-[English README](./README.md)
+Team@Once ist ein Open-Source KI-gesteuerter Entwicklungs-Outsourcing-Marktplatz, der traditionelle Risiken durch intelligente Automatisierung, KI-gestützte Bewertungen, Treuhandzahlungen und Echtzeit-Projektmanagement beseitigt.
 
-## License
+## Warum Team@Once? (Vergleich)
 
-[GNU AGPL 3.0](LICENSE)
+| Funktion | Team@Once | Upwork | Toptal | Fiverr | Deel |
+|----------|-----------|--------|--------|--------|------|
+| **KI-gestütztes Matching** | ✅ NLP + intelligentes Matching | ❌ | ⚠️ Manuelle Prüfung | ❌ | ❌ |
+| **Integriertes Projektmanagement** | ✅ Kanban, Meilensteine, Zeiterfassung | ⚠️ Grundlegend | ❌ | ❌ | ❌ |
+| **Treuhandzahlungen** | ✅ Meilensteinbasiert | ✅ | ✅ | ✅ | ❌ |
+| **Video-Zusammenarbeit** | ✅ Integrierte Anrufe + Bildschirmfreigabe | ❌ | ❌ | ❌ | ❌ |
+| **Kompetenzbewertungen** | ✅ KI-generiert + Zertifikate | ⚠️ Grundlegende Tests | ✅ Rigoros | ⚠️ Grundlegend | ❌ |
+| **Lernpfade** | ✅ Kurse + Zertifizierungen | ❌ | ❌ | ❌ | ❌ |
+| **Echtzeit-Chat** | ✅ Kanäle + Dateifreigabe | ⚠️ Grundlegend | ❌ | ⚠️ Grundlegend | ❌ |
+| **Team-Arbeitsbereiche** | ✅ Multi-Projekt-Organisation | ❌ | ❌ | ❌ | ❌ |
+| **Daten-Engine** | ✅ Unternehmens-Discovery-Crawler | ❌ | ❌ | ❌ | ❌ |
+| **Intelligente Verträge** | ✅ Auto-generiert + E-Signatur | ⚠️ Grundlegend | ❌ | ⚠️ Grundlegend | ✅ |
+| **API-Zugang** | ✅ Vollständige REST-API | ⚠️ Teilweise | ❌ | ❌ | ✅ |
+| **Selbst gehostet** | ✅ Docker Compose | ❌ | ❌ | ❌ | ❌ |
+| **Open Source** | ✅ AGPL 3.0 | ❌ | ❌ | ❌ | ❌ |
+| **Plattformgebühr** | 🟢 3-5% | 💰 10-20% | 💰 ~2x Aufschlag | 💰 20% | 💰 Individuell |
+| **i18n** | ✅ 11 Sprachen | ✅ | ✅ | ✅ | ✅ |
+
+## Funktionen
+
+### Marktplatz
+- **Unternehmensprofile** -- Portfolios, Teamfähigkeiten und Zertifizierungen präsentieren
+- **KI-gestütztes Matching** -- Intelligente Zuordnung von Unternehmen zu Projekten basierend auf Fähigkeiten und Erfolgsbilanz
+- **Daten-Engine** -- Web-Crawling und Pipeline zur Unternehmenserkennung und -anreicherung
+- **Treuhandzahlungen** -- Sichere meilensteinbasierte Zahlungen über Stripe
+
+### Lernen und Zertifizierung
+- **Kursverwaltung** -- Technische Kurse mit Modulen und Lektionen erstellen und verwalten
+- **KI-Bewertungen** -- KI-generierte Quizze und Kompetenzbewertungen
+- **Zertifikate** -- Überprüfbare Leistungszertifikate
+- **Lernpfade** -- Strukturierte Kompetenzentwicklungswege
+- **Erfolge** -- Gamification mit Abzeichen und Fortschrittsverfolgung
+
+### Zusammenarbeit
+- **Projektmanagement** -- Projekte mit Meilensteinen und Liefergegenständen verfolgen
+- **Diskussionsforen** -- Community-Diskussionen und Wissensaustausch
+- **Echtzeit-Benachrichtigungen** -- WebSocket-basierte Live-Updates
+- **Blog** -- Content-Management für Artikel und Anleitungen
+- **Lerngruppen** -- Kollaborative Lernräume
+
+### Plattform
+- **KI-Integration** -- OpenAI-gestützte Inhaltsgenerierung und Analyse
+- **Suche** -- Qdrant-Vektorsuche für semantische Inhaltserkennung
+- **Mehrsprachigkeit** -- i18n-Unterstützung
+- **Admin-Dashboard** -- Plattformverwaltung und Analysen
+- **SEO** -- Serverseitiges Rendering und Metadaten-Optimierung
+
+## Technologie-Stack
+
+| Schicht | Technologie |
+|---------|-------------|
+| **Backend** | NestJS 11, TypeScript, PostgreSQL (raw SQL), Redis, Qdrant, Socket.io |
+| **Frontend** | React 19, Vite, TypeScript, Tailwind CSS, Radix UI, Zustand |
+| **KI** | OpenAI (GPT-4o-mini, Embeddings) |
+| **Zahlungen** | Stripe (Treuhand, Abonnements) |
+| **Suche** | Qdrant (Vektorsuche) |
+
+## Voraussetzungen
+
+- **Node.js** >= 18
+- **Docker** (empfohlen) oder PostgreSQL 15+, Redis und Qdrant lokal installiert
+
+## Schnellstart
+
+### 1. Dienste starten
+
+Der einfachste Weg, PostgreSQL, Redis und Qdrant auszuführen, ist mit Docker:
+
+```bash
+git clone https://github.com/teamatonce/teamatonce.git
+cd teamatonce
+docker compose up -d
+```
+
+Dies startet alle erforderlichen Dienste mit Zugangsdaten, die sofort mit `.env.example` übereinstimmen.
+
+<details>
+<summary>Ohne Docker (manuelle Einrichtung)</summary>
+
+Installieren und starten Sie PostgreSQL, Redis und Qdrant selbst und aktualisieren Sie dann `backend/.env` mit Ihren Verbindungsdetails:
+
+```bash
+# PostgreSQL — Entwicklungsdatenbank erstellen
+createdb -U postgres teamatonce_dev
+
+# DATABASE_PASSWORD in backend/.env an Ihr PostgreSQL-Passwort anpassen
+```
+
+</details>
+
+### 2. Backend
+
+```bash
+cd backend
+cp .env.example .env    # Zugangsdaten stimmen bereits mit docker-compose.yml überein
+npm install
+npm run migrate
+npm run start:dev
+```
+
+### 3. Frontend (neues Terminal)
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+## Projektstruktur
+
+```
+teamatonce/
+├── backend/              # NestJS API (34 Module)
+│   ├── src/modules/      # auth, company, courses, assessments, ai, search,
+│   │                     # escrow, certificates, learning-paths, blog, ...
+│   └── migrations/       # PostgreSQL-Migrationen
+├── frontend/             # React + Vite + Tailwind
+│   └── src/
+└── .github/workflows/    # CI/CD
+```
+
+## Mitwirkende
+
+Vielen Dank an alle großartigen Menschen, die zu Team@Once beigetragen haben! 🎉
+
+<a href="https://github.com/teamatonce/teamatonce/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=teamatonce/teamatonce&anon=1&max=100&columns=10" />
+</a>
+
+Möchten Sie Ihr Gesicht hier sehen? Schauen Sie sich unseren [Leitfaden zum Mitwirken](CONTRIBUTING.md) an und beginnen Sie noch heute!
+
+## Projektaktivität
+
+<p align="center">
+  <img src="https://img.shields.io/github/stars/teamatonce/teamatonce?style=for-the-badge&logo=github&color=yellow" alt="Sterne">
+  <img src="https://img.shields.io/github/forks/teamatonce/teamatonce?style=for-the-badge&logo=github&color=blue" alt="Forks">
+  <img src="https://img.shields.io/github/contributors/teamatonce/teamatonce?style=for-the-badge&logo=github&color=green" alt="Mitwirkende">
+  <img src="https://img.shields.io/github/last-commit/teamatonce/teamatonce?style=for-the-badge&logo=github&color=orange" alt="Letzter Commit">
+</p>
+
+## Sicherheit
+
+Bitte melden Sie Sicherheitslücken verantwortungsvoll. Siehe [SECURITY.md](SECURITY.md).
+
+## Lizenz
+
+Dieses Projekt ist lizenziert unter der [GNU Affero General Public License v3.0](LICENSE).
+
+Copyright 2025 Team@Once Contributors.

--- a/README_ES.md
+++ b/README_ES.md
@@ -3,20 +3,196 @@
     <img src="frontend/public/assets/logo.png" alt="Team@Once" width="80">
   </a>
   <h1 align="center">Team@Once</h1>
-  <p align="center"><strong>Plataforma de subcontratacion de desarrollo impulsada por IA</strong></p>
-  <p align="center">Revolucionando la subcontratacion de desarrollo de software.</p>
+  <p align="center">
+    <strong>Plataforma de externalización de desarrollo impulsada por IA de código abierto</strong>
+  </p>
+  <p align="center">
+    Revolucionando la externalización del desarrollo de software mediante automatización inteligente, procesos transparentes y colaboración fluida.
+  </p>
 </p>
 
 <p align="center">
-  <a href="./README.md">English</a> | <a href="./README_JA.md">日本語</a> | <a href="./README_ZH.md">中文</a> | <a href="./README_KO.md">한국어</a> | <a href="./README_ES.md">Español</a> | <a href="./README_FR.md">Français</a> | <a href="./README_DE.md">Deutsch</a> | <a href="./README_PT-BR.md">Português</a> | <a href="./README_RU.md">Русский</a>
+  <a href="https://github.com/teamatonce/teamatonce/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue.svg" alt="Licencia"></a>
+  <a href="https://github.com/teamatonce/teamatonce/stargazers"><img src="https://img.shields.io/github/stars/teamatonce/teamatonce?style=social" alt="Estrellas en GitHub"></a>
+  <a href="https://github.com/teamatonce/teamatonce/issues"><img src="https://img.shields.io/github/issues/teamatonce/teamatonce" alt="Issues"></a>
+</p>
+
+<p align="center">
+  <a href="https://teamatonce.com">Sitio Web</a> |
+  <a href="#inicio-rápido">Inicio Rápido</a> |
+  <a href="#características">Características</a> |
+  <a href="https://github.com/teamatonce/teamatonce/discussions">Discusiones</a> |
+  <a href="CONTRIBUTING.md">Contribuir</a>
+</p>
+
+<p align="center">
+  <a href="./README.md">English</a> |
+  <a href="./README_JA.md">日本語</a> |
+  <a href="./README_ZH.md">中文</a> |
+  <a href="./README_KO.md">한국어</a> |
+  <a href="./README_ES.md">Español</a> |
+  <a href="./README_FR.md">Français</a> |
+  <a href="./README_DE.md">Deutsch</a> |
+  <a href="./README_PT-BR.md">Português</a> |
+  <a href="./README_AR.md">العربية</a> |
+  <a href="./README_HI.md">हिन्दी</a> |
+  <a href="./README_RU.md">Русский</a>
 </p>
 
 ---
 
-<p align="center"><a href="./README.md">English</a> | <a href="./README_JA.md">日本語</a> | <a href="./README_ZH.md">中文</a> | <a href="./README_KO.md">한국어</a> | <a href="./README_ES.md">Español</a> | <a href="./README_FR.md">Français</a> | <a href="./README_DE.md">Deutsch</a> | <a href="./README_PT-BR.md">Português</a> | <a href="./README_AR.md">العربية</a> | <a href="./README_HI.md">हिन्दी</a> | <a href="./README_RU.md">Русский</a></p>
+## ¿Qué es Team@Once?
 
-[English README](./README.md)
+Team@Once es un mercado de externalización de desarrollo impulsado por IA de código abierto que elimina los riesgos tradicionales mediante automatización inteligente, evaluaciones impulsadas por IA, pagos en custodia y gestión de proyectos en tiempo real.
 
-## License
+## ¿Por qué Team@Once? (Comparación)
 
-[GNU AGPL 3.0](LICENSE)
+| Característica | Team@Once | Upwork | Toptal | Fiverr | Deel |
+|----------------|-----------|--------|--------|--------|------|
+| **Emparejamiento con IA** | ✅ NLP + emparejamiento inteligente | ❌ | ⚠️ Selección manual | ❌ | ❌ |
+| **Gestión de Proyectos Integrada** | ✅ Kanban, hitos, seguimiento de tiempo | ⚠️ Básico | ❌ | ❌ | ❌ |
+| **Pagos en Custodia** | ✅ Basados en hitos | ✅ | ✅ | ✅ | ❌ |
+| **Colaboración por Video** | ✅ Llamadas integradas + pantalla compartida | ❌ | ❌ | ❌ | ❌ |
+| **Evaluaciones de Habilidades** | ✅ Generadas por IA + certificados | ⚠️ Tests básicos | ✅ Rigurosos | ⚠️ Básicos | ❌ |
+| **Rutas de Aprendizaje** | ✅ Cursos + certificaciones | ❌ | ❌ | ❌ | ❌ |
+| **Chat en Tiempo Real** | ✅ Canales + compartir archivos | ⚠️ Básico | ❌ | ⚠️ Básico | ❌ |
+| **Espacios de Trabajo en Equipo** | ✅ Organización multiproyecto | ❌ | ❌ | ❌ | ❌ |
+| **Motor de Datos** | ✅ Rastreador de descubrimiento de empresas | ❌ | ❌ | ❌ | ❌ |
+| **Contratos Inteligentes** | ✅ Auto-generados + firma electrónica | ⚠️ Básico | ❌ | ⚠️ Básico | ✅ |
+| **Acceso API** | ✅ API REST completa | ⚠️ Parcial | ❌ | ❌ | ✅ |
+| **Auto-alojado** | ✅ Docker Compose | ❌ | ❌ | ❌ | ❌ |
+| **Código Abierto** | ✅ AGPL 3.0 | ❌ | ❌ | ❌ | ❌ |
+| **Comisión de Plataforma** | 🟢 3-5% | 💰 10-20% | 💰 ~2x recargo | 💰 20% | 💰 Personalizado |
+| **i18n** | ✅ 11 idiomas | ✅ | ✅ | ✅ | ✅ |
+
+## Características
+
+### Mercado
+- **Perfiles de Empresa** -- Muestra portafolios, habilidades del equipo y certificaciones
+- **Emparejamiento con IA** -- Emparejamiento inteligente empresa-proyecto basado en habilidades y trayectoria
+- **Motor de Datos** -- Rastreo web y pipeline para descubrimiento y enriquecimiento de empresas
+- **Pagos en Custodia** -- Pagos seguros basados en hitos a través de Stripe
+
+### Aprendizaje y Certificación
+- **Gestión de Cursos** -- Crea y gestiona cursos técnicos con módulos y lecciones
+- **Evaluaciones con IA** -- Cuestionarios y evaluaciones de habilidades generados por IA
+- **Certificados** -- Certificados de logros verificables
+- **Rutas de Aprendizaje** -- Rutas estructuradas de desarrollo de habilidades
+- **Logros** -- Gamificación con insignias y seguimiento de progreso
+
+### Colaboración
+- **Gestión de Proyectos** -- Seguimiento de proyectos con hitos y entregables
+- **Foros de Discusión** -- Discusiones comunitarias e intercambio de conocimientos
+- **Notificaciones en Tiempo Real** -- Actualizaciones en vivo mediante WebSocket
+- **Blog** -- Gestión de contenido para artículos y guías
+- **Grupos de Estudio** -- Espacios de aprendizaje colaborativo
+
+### Plataforma
+- **Integración de IA** -- Generación y análisis de contenido impulsado por OpenAI
+- **Búsqueda** -- Búsqueda vectorial con Qdrant para descubrimiento semántico de contenido
+- **Multiidioma** -- Soporte i18n
+- **Panel de Administración** -- Administración de la plataforma y analíticas
+- **SEO** -- Renderizado del lado del servidor y optimización de metadatos
+
+## Stack Tecnológico
+
+| Capa | Tecnología |
+|------|------------|
+| **Backend** | NestJS 11, TypeScript, PostgreSQL (SQL directo), Redis, Qdrant, Socket.io |
+| **Frontend** | React 19, Vite, TypeScript, Tailwind CSS, Radix UI, Zustand |
+| **IA** | OpenAI (GPT-4o-mini, embeddings) |
+| **Pagos** | Stripe (custodia, suscripciones) |
+| **Búsqueda** | Qdrant (búsqueda vectorial) |
+
+## Requisitos previos
+
+- **Node.js** >= 18
+- **Docker** (recomendado) o PostgreSQL 15+, Redis y Qdrant instalados localmente
+
+## Inicio Rápido
+
+### 1. Iniciar servicios
+
+La forma más sencilla de ejecutar PostgreSQL, Redis y Qdrant es con Docker:
+
+```bash
+git clone https://github.com/teamatonce/teamatonce.git
+cd teamatonce
+docker compose up -d
+```
+
+Esto inicia todos los servicios requeridos con credenciales que coinciden con `.env.example` de forma predeterminada.
+
+<details>
+<summary>Sin Docker (configuración manual)</summary>
+
+Instala e inicia PostgreSQL, Redis y Qdrant por tu cuenta, luego actualiza `backend/.env` con tus datos de conexión:
+
+```bash
+# PostgreSQL — crear la base de datos de desarrollo
+createdb -U postgres teamatonce_dev
+
+# Actualiza DATABASE_PASSWORD en backend/.env para que coincida con tu contraseña de PostgreSQL
+```
+
+</details>
+
+### 2. Backend
+
+```bash
+cd backend
+cp .env.example .env    # las credenciales ya coinciden con docker-compose.yml
+npm install
+npm run migrate
+npm run start:dev
+```
+
+### 3. Frontend (nueva terminal)
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+## Estructura del Proyecto
+
+```
+teamatonce/
+├── backend/              # API NestJS (34 módulos)
+│   ├── src/modules/      # auth, company, courses, assessments, ai, search,
+│   │                     # escrow, certificates, learning-paths, blog, ...
+│   └── migrations/       # Migraciones de PostgreSQL
+├── frontend/             # React + Vite + Tailwind
+│   └── src/
+└── .github/workflows/    # CI/CD
+```
+
+## Contribuidores
+
+¡Gracias a todas las personas increíbles que han contribuido a Team@Once! 🎉
+
+<a href="https://github.com/teamatonce/teamatonce/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=teamatonce/teamatonce&anon=1&max=100&columns=10" />
+</a>
+
+¿Quieres ver tu rostro aquí? ¡Consulta nuestra [Guía de Contribución](CONTRIBUTING.md) y comienza a contribuir hoy!
+
+## Actividad del Proyecto
+
+<p align="center">
+  <img src="https://img.shields.io/github/stars/teamatonce/teamatonce?style=for-the-badge&logo=github&color=yellow" alt="Estrellas">
+  <img src="https://img.shields.io/github/forks/teamatonce/teamatonce?style=for-the-badge&logo=github&color=blue" alt="Forks">
+  <img src="https://img.shields.io/github/contributors/teamatonce/teamatonce?style=for-the-badge&logo=github&color=green" alt="Contribuidores">
+  <img src="https://img.shields.io/github/last-commit/teamatonce/teamatonce?style=for-the-badge&logo=github&color=orange" alt="Último Commit">
+</p>
+
+## Seguridad
+
+Por favor, reporta las vulnerabilidades de seguridad de manera responsable. Consulta [SECURITY.md](SECURITY.md).
+
+## Licencia
+
+Este proyecto está licenciado bajo la [GNU Affero General Public License v3.0](LICENSE).
+
+Copyright 2025 Team@Once Contributors.

--- a/README_FR.md
+++ b/README_FR.md
@@ -3,20 +3,192 @@
     <img src="frontend/public/assets/logo.png" alt="Team@Once" width="80">
   </a>
   <h1 align="center">Team@Once</h1>
-  <p align="center"><strong>Plateforme d'externalisation de developpement pilotee par l'IA</strong></p>
-  <p align="center">Revolutionner l'externalisation du developpement logiciel.</p>
+  <p align="center"><strong>Plateforme open-source d'externalisation de développement propulsée par l'IA</strong></p>
+  <p align="center">Révolutionner l'externalisation du développement logiciel grâce à l'automatisation intelligente, des processus transparents et une collaboration fluide.</p>
 </p>
 
 <p align="center">
-  <a href="./README.md">English</a> | <a href="./README_JA.md">日本語</a> | <a href="./README_ZH.md">中文</a> | <a href="./README_KO.md">한국어</a> | <a href="./README_ES.md">Español</a> | <a href="./README_FR.md">Français</a> | <a href="./README_DE.md">Deutsch</a> | <a href="./README_PT-BR.md">Português</a> | <a href="./README_RU.md">Русский</a>
+  <a href="https://github.com/teamatonce/teamatonce/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue.svg" alt="Licence"></a>
+  <a href="https://github.com/teamatonce/teamatonce/stargazers"><img src="https://img.shields.io/github/stars/teamatonce/teamatonce?style=social" alt="Étoiles GitHub"></a>
+  <a href="https://github.com/teamatonce/teamatonce/issues"><img src="https://img.shields.io/github/issues/teamatonce/teamatonce" alt="Issues"></a>
+</p>
+
+<p align="center">
+  <a href="https://teamatonce.com">Site web</a> |
+  <a href="#démarrage-rapide">Démarrage Rapide</a> |
+  <a href="#fonctionnalités">Fonctionnalités</a> |
+  <a href="https://github.com/teamatonce/teamatonce/discussions">Discussions</a> |
+  <a href="CONTRIBUTING.md">Contribuer</a>
+</p>
+
+<p align="center">
+  <a href="./README.md">English</a> |
+  <a href="./README_JA.md">日本語</a> |
+  <a href="./README_ZH.md">中文</a> |
+  <a href="./README_KO.md">한국어</a> |
+  <a href="./README_ES.md">Español</a> |
+  <a href="./README_FR.md">Français</a> |
+  <a href="./README_DE.md">Deutsch</a> |
+  <a href="./README_PT-BR.md">Português</a> |
+  <a href="./README_AR.md">العربية</a> |
+  <a href="./README_HI.md">हिन्दी</a> |
+  <a href="./README_RU.md">Русский</a>
 </p>
 
 ---
 
-<p align="center"><a href="./README.md">English</a> | <a href="./README_JA.md">日本語</a> | <a href="./README_ZH.md">中文</a> | <a href="./README_KO.md">한국어</a> | <a href="./README_ES.md">Español</a> | <a href="./README_FR.md">Français</a> | <a href="./README_DE.md">Deutsch</a> | <a href="./README_PT-BR.md">Português</a> | <a href="./README_AR.md">العربية</a> | <a href="./README_HI.md">हिन्दी</a> | <a href="./README_RU.md">Русский</a></p>
+## Qu'est-ce que Team@Once ?
 
-[English README](./README.md)
+Team@Once est une place de marché open-source d'externalisation de développement propulsée par l'IA qui élimine les risques traditionnels grâce à l'automatisation intelligente, les évaluations assistées par IA, les paiements sous séquestre et la gestion de projet en temps réel.
 
-## License
+## Pourquoi Team@Once ? (Comparaison)
 
-[GNU AGPL 3.0](LICENSE)
+| Fonctionnalité | Team@Once | Upwork | Toptal | Fiverr | Deel |
+|----------------|-----------|--------|--------|--------|------|
+| **Matching par IA** | ✅ NLP + matching intelligent | ❌ | ⚠️ Vérification manuelle | ❌ | ❌ |
+| **Gestion de projet intégrée** | ✅ Kanban, jalons, suivi du temps | ⚠️ Basique | ❌ | ❌ | ❌ |
+| **Paiements sous séquestre** | ✅ Basé sur les jalons | ✅ | ✅ | ✅ | ❌ |
+| **Collaboration vidéo** | ✅ Appels intégrés + partage d'écran | ❌ | ❌ | ❌ | ❌ |
+| **Évaluations de compétences** | ✅ Générées par IA + certificats | ⚠️ Tests basiques | ✅ Rigoureux | ⚠️ Basique | ❌ |
+| **Parcours d'apprentissage** | ✅ Cours + certifications | ❌ | ❌ | ❌ | ❌ |
+| **Chat en temps réel** | ✅ Canaux + partage de fichiers | ⚠️ Basique | ❌ | ⚠️ Basique | ❌ |
+| **Espaces de travail d'équipe** | ✅ Organisation multi-projets | ❌ | ❌ | ❌ | ❌ |
+| **Moteur de données** | ✅ Crawleur de découverte d'entreprises | ❌ | ❌ | ❌ | ❌ |
+| **Contrats intelligents** | ✅ Auto-générés + signature électronique | ⚠️ Basique | ❌ | ⚠️ Basique | ✅ |
+| **Accès API** | ✅ API REST complète | ⚠️ Partiel | ❌ | ❌ | ✅ |
+| **Auto-hébergé** | ✅ Docker Compose | ❌ | ❌ | ❌ | ❌ |
+| **Open Source** | ✅ AGPL 3.0 | ❌ | ❌ | ❌ | ❌ |
+| **Frais de plateforme** | 🟢 3-5% | 💰 10-20% | 💰 ~2x majoration | 💰 20% | 💰 Sur mesure |
+| **i18n** | ✅ 11 langues | ✅ | ✅ | ✅ | ✅ |
+
+## Fonctionnalités
+
+### Place de marché
+- **Profils d'entreprise** -- Présentez vos portfolios, compétences d'équipe et certifications
+- **Matching par IA** -- Matching intelligent entreprise-projet basé sur les compétences et l'historique
+- **Moteur de données** -- Crawling web et pipeline pour la découverte et l'enrichissement d'entreprises
+- **Paiements sous séquestre** -- Paiements sécurisés par jalons via Stripe
+
+### Apprentissage et Certification
+- **Gestion de cours** -- Créez et gérez des cours techniques avec modules et leçons
+- **Évaluations par IA** -- Quiz et évaluations de compétences générés par IA
+- **Certificats** -- Certificats de réussite vérifiables
+- **Parcours d'apprentissage** -- Parcours structurés de développement des compétences
+- **Accomplissements** -- Gamification avec badges et suivi de progression
+
+### Collaboration
+- **Gestion de projet** -- Suivez les projets avec jalons et livrables
+- **Forums de discussion** -- Discussions communautaires et partage de connaissances
+- **Notifications en temps réel** -- Mises à jour en direct via WebSocket
+- **Blog** -- Gestion de contenu pour articles et guides
+- **Groupes d'étude** -- Espaces d'apprentissage collaboratif
+
+### Plateforme
+- **Intégration IA** -- Génération et analyse de contenu propulsées par OpenAI
+- **Recherche** -- Recherche vectorielle Qdrant pour la découverte sémantique de contenu
+- **Multilingue** -- Support i18n
+- **Tableau de bord administrateur** -- Administration de la plateforme et analytiques
+- **SEO** -- Rendu côté serveur et optimisation des métadonnées
+
+## Stack Technique
+
+| Couche | Technologie |
+|--------|-------------|
+| **Backend** | NestJS 11, TypeScript, PostgreSQL (SQL brut), Redis, Qdrant, Socket.io |
+| **Frontend** | React 19, Vite, TypeScript, Tailwind CSS, Radix UI, Zustand |
+| **IA** | OpenAI (GPT-4o-mini, embeddings) |
+| **Paiements** | Stripe (séquestre, abonnements) |
+| **Recherche** | Qdrant (recherche vectorielle) |
+
+## Prérequis
+
+- **Node.js** >= 18
+- **Docker** (recommandé) ou PostgreSQL 15+, Redis et Qdrant installés localement
+
+## Démarrage Rapide
+
+### 1. Démarrer les services
+
+La manière la plus simple d'exécuter PostgreSQL, Redis et Qdrant est avec Docker :
+
+```bash
+git clone https://github.com/teamatonce/teamatonce.git
+cd teamatonce
+docker compose up -d
+```
+
+Cela démarre tous les services requis avec des identifiants qui correspondent à `.env.example` prêts à l'emploi.
+
+<details>
+<summary>Sans Docker (installation manuelle)</summary>
+
+Installez et démarrez PostgreSQL, Redis et Qdrant vous-même, puis mettez à jour `backend/.env` avec vos informations de connexion :
+
+```bash
+# PostgreSQL — créer la base de données de développement
+createdb -U postgres teamatonce_dev
+
+# Mettez à jour DATABASE_PASSWORD dans backend/.env pour correspondre à votre mot de passe PostgreSQL
+```
+
+</details>
+
+### 2. Backend
+
+```bash
+cd backend
+cp .env.example .env    # les identifiants correspondent déjà à docker-compose.yml
+npm install
+npm run migrate
+npm run start:dev
+```
+
+### 3. Frontend (nouveau terminal)
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+## Structure du Projet
+
+```
+teamatonce/
+├── backend/              # API NestJS (34 modules)
+│   ├── src/modules/      # auth, company, courses, assessments, ai, search,
+│   │                     # escrow, certificates, learning-paths, blog, ...
+│   └── migrations/       # Migrations PostgreSQL
+├── frontend/             # React + Vite + Tailwind
+│   └── src/
+└── .github/workflows/    # CI/CD
+```
+
+## Contributeurs
+
+Merci à toutes les personnes formidables qui ont contribué à Team@Once ! 🎉
+
+<a href="https://github.com/teamatonce/teamatonce/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=teamatonce/teamatonce&anon=1&max=100&columns=10" />
+</a>
+
+Vous voulez voir votre visage ici ? Consultez notre [Guide de Contribution](CONTRIBUTING.md) et commencez à contribuer dès aujourd'hui !
+
+## Activité du Projet
+
+<p align="center">
+  <img src="https://img.shields.io/github/stars/teamatonce/teamatonce?style=for-the-badge&logo=github&color=yellow" alt="Étoiles">
+  <img src="https://img.shields.io/github/forks/teamatonce/teamatonce?style=for-the-badge&logo=github&color=blue" alt="Forks">
+  <img src="https://img.shields.io/github/contributors/teamatonce/teamatonce?style=for-the-badge&logo=github&color=green" alt="Contributeurs">
+  <img src="https://img.shields.io/github/last-commit/teamatonce/teamatonce?style=for-the-badge&logo=github&color=orange" alt="Dernier Commit">
+</p>
+
+## Sécurité
+
+Veuillez signaler les vulnérabilités de sécurité de manière responsable. Consultez [SECURITY.md](SECURITY.md).
+
+## Licence
+
+Ce projet est sous licence [GNU Affero General Public License v3.0](LICENSE).
+
+Copyright 2025 Team@Once Contributors.

--- a/README_HI.md
+++ b/README_HI.md
@@ -1,19 +1,194 @@
 <p align="center">
-  <a href="https://teamatonce.com"><img src="frontend/public/assets/logo.png" alt="Team@Once" width="80"></a>
+  <a href="https://teamatonce.com">
+    <img src="frontend/public/assets/logo.png" alt="Team@Once" width="80">
+  </a>
   <h1 align="center">Team@Once</h1>
-  <p align="center"><strong>ओपन सोर्स AI-संचालित विकास आउटसोर्सिंग प्लेटफ़ॉर्म</strong></p>
+  <p align="center"><strong>ओपन-सोर्स AI-संचालित विकास आउटसोर्सिंग प्लेटफ़ॉर्म</strong></p>
+  <p align="center">बुद्धिमान स्वचालन, पारदर्शी प्रक्रियाओं और सहज सहयोग के माध्यम से सॉफ़्टवेयर विकास आउटसोर्सिंग में क्रांति।</p>
+</p>
+
+<p align="center">
+  <a href="https://github.com/teamatonce/teamatonce/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue.svg" alt="License"></a>
+  <a href="https://github.com/teamatonce/teamatonce/stargazers"><img src="https://img.shields.io/github/stars/teamatonce/teamatonce?style=social" alt="GitHub Stars"></a>
+  <a href="https://github.com/teamatonce/teamatonce/issues"><img src="https://img.shields.io/github/issues/teamatonce/teamatonce" alt="Issues"></a>
+</p>
+
+<p align="center">
+  <a href="https://teamatonce.com">वेबसाइट</a> |
+  <a href="#त्वरित-शुरुआत">त्वरित शुरुआत</a> |
+  <a href="#विशेषताएं">विशेषताएं</a> |
+  <a href="https://github.com/teamatonce/teamatonce/discussions">चर्चाएं</a> |
+  <a href="CONTRIBUTING.md">योगदान</a>
+</p>
+
+<p align="center">
+  <a href="./README.md">English</a> |
+  <a href="./README_JA.md">日本語</a> |
+  <a href="./README_ZH.md">中文</a> |
+  <a href="./README_KO.md">한국어</a> |
+  <a href="./README_ES.md">Español</a> |
+  <a href="./README_FR.md">Français</a> |
+  <a href="./README_DE.md">Deutsch</a> |
+  <a href="./README_PT-BR.md">Português</a> |
+  <a href="./README_AR.md">العربية</a> |
+  <a href="./README_HI.md">हिन्दी</a> |
+  <a href="./README_RU.md">Русский</a>
 </p>
 
 ---
 
-<p align="center"><a href="./README.md">English</a> | <a href="./README_JA.md">日本語</a> | <a href="./README_ZH.md">中文</a> | <a href="./README_KO.md">한국어</a> | <a href="./README_ES.md">Español</a> | <a href="./README_FR.md">Français</a> | <a href="./README_DE.md">Deutsch</a> | <a href="./README_PT-BR.md">Português</a> | <a href="./README_AR.md">العربية</a> | <a href="./README_HI.md">हिन्दी</a> | <a href="./README_RU.md">Русский</a></p>
-
 ## Team@Once क्या है?
 
-AI-संचालित ओपन सोर्स विकास आउटसोर्सिंग मार्केटप्लेस — बुद्धिमान टीम मैचिंग, एस्क्रो भुगतान, कौशल मूल्यांकन, और सीखने के मार्ग।
+Team@Once एक ओपन-सोर्स AI-संचालित विकास आउटसोर्सिंग मार्केटप्लेस है जो बुद्धिमान स्वचालन, AI-संचालित मूल्यांकन, एस्क्रो भुगतान और रियल-टाइम प्रोजेक्ट प्रबंधन के माध्यम से पारंपरिक जोखिमों को समाप्त करता है।
 
-अधिक जानकारी के लिए [अंग्रेजी README](./README.md) देखें।
+## Team@Once क्यों? (तुलना)
+
+| विशेषता | Team@Once | Upwork | Toptal | Fiverr | Deel |
+|---------|-----------|--------|--------|--------|------|
+| **AI-संचालित मैचिंग** | ✅ NLP + स्मार्ट मैचिंग | ❌ | ⚠️ मैन्युअल जांच | ❌ | ❌ |
+| **अंतर्निर्मित प्रोजेक्ट प्रबंधन** | ✅ कानबन, माइलस्टोन, समय ट्रैकिंग | ⚠️ बेसिक | ❌ | ❌ | ❌ |
+| **एस्क्रो भुगतान** | ✅ माइलस्टोन-आधारित | ✅ | ✅ | ✅ | ❌ |
+| **वीडियो सहयोग** | ✅ अंतर्निर्मित कॉल + स्क्रीन शेयर | ❌ | ❌ | ❌ | ❌ |
+| **कौशल मूल्यांकन** | ✅ AI-जनित + प्रमाणपत्र | ⚠️ बेसिक टेस्ट | ✅ कठोर | ⚠️ बेसिक | ❌ |
+| **सीखने के मार्ग** | ✅ पाठ्यक्रम + प्रमाणन | ❌ | ❌ | ❌ | ❌ |
+| **रियल-टाइम चैट** | ✅ चैनल + फ़ाइल शेयरिंग | ⚠️ बेसिक | ❌ | ⚠️ बेसिक | ❌ |
+| **टीम कार्यक्षेत्र** | ✅ मल्टी-प्रोजेक्ट संगठन | ❌ | ❌ | ❌ | ❌ |
+| **डेटा इंजन** | ✅ कंपनी खोज क्रॉलर | ❌ | ❌ | ❌ | ❌ |
+| **स्मार्ट अनुबंध** | ✅ स्वचालित-जनित + ई-हस्ताक्षर | ⚠️ बेसिक | ❌ | ⚠️ बेसिक | ✅ |
+| **API एक्सेस** | ✅ पूर्ण REST API | ⚠️ आंशिक | ❌ | ❌ | ✅ |
+| **सेल्फ-होस्टेड** | ✅ Docker Compose | ❌ | ❌ | ❌ | ❌ |
+| **ओपन सोर्स** | ✅ AGPL 3.0 | ❌ | ❌ | ❌ | ❌ |
+| **प्लेटफ़ॉर्म शुल्क** | 🟢 3-5% | 💰 10-20% | 💰 ~2x मार्कअप | 💰 20% | 💰 कस्टम |
+| **i18n** | ✅ 11 भाषाएं | ✅ | ✅ | ✅ | ✅ |
+
+## विशेषताएं
+
+### मार्केटप्लेस
+- **कंपनी प्रोफ़ाइल** -- पोर्टफ़ोलियो, टीम कौशल और प्रमाणन प्रदर्शित करें
+- **AI-संचालित मैचिंग** -- कौशल और ट्रैक रिकॉर्ड के आधार पर बुद्धिमान कंपनी-से-प्रोजेक्ट मैचिंग
+- **डेटा इंजन** -- कंपनी खोज और संवर्धन के लिए वेब क्रॉलिंग और पाइपलाइन
+- **एस्क्रो भुगतान** -- Stripe के माध्यम से सुरक्षित माइलस्टोन-आधारित भुगतान
+
+### सीखना और प्रमाणन
+- **पाठ्यक्रम प्रबंधन** -- मॉड्यूल और पाठों के साथ तकनीकी पाठ्यक्रम बनाएं और प्रबंधित करें
+- **AI मूल्यांकन** -- AI-जनित क्विज़ और कौशल मूल्यांकन
+- **प्रमाणपत्र** -- सत्यापन योग्य उपलब्धि प्रमाणपत्र
+- **सीखने के मार्ग** -- संरचित कौशल विकास मार्ग
+- **उपलब्धियां** -- बैज और प्रगति ट्रैकिंग के साथ गेमिफ़िकेशन
+
+### सहयोग
+- **प्रोजेक्ट प्रबंधन** -- माइलस्टोन और डिलिवरेबल्स के साथ प्रोजेक्ट ट्रैक करें
+- **चर्चा फ़ोरम** -- सामुदायिक चर्चा और ज्ञान साझाकरण
+- **रियल-टाइम सूचनाएं** -- WebSocket-संचालित लाइव अपडेट
+- **ब्लॉग** -- लेखों और गाइड के लिए कंटेंट प्रबंधन
+- **अध्ययन समूह** -- सहयोगी शिक्षण स्थान
+
+### प्लेटफ़ॉर्म
+- **AI एकीकरण** -- OpenAI-संचालित कंटेंट जनरेशन और विश्लेषण
+- **खोज** -- सिमेंटिक कंटेंट खोज के लिए Qdrant वेक्टर सर्च
+- **बहुभाषी** -- i18n समर्थन
+- **एडमिन डैशबोर्ड** -- प्लेटफ़ॉर्म प्रशासन और एनालिटिक्स
+- **SEO** -- सर्वर-साइड रेंडरिंग और मेटाडेटा ऑप्टिमाइज़ेशन
+
+## तकनीकी स्टैक
+
+| परत | प्रौद्योगिकी |
+|-------|------------|
+| **बैकएंड** | NestJS 11, TypeScript, PostgreSQL (raw SQL), Redis, Qdrant, Socket.io |
+| **फ़्रंटएंड** | React 19, Vite, TypeScript, Tailwind CSS, Radix UI, Zustand |
+| **AI** | OpenAI (GPT-4o-mini, embeddings) |
+| **भुगतान** | Stripe (एस्क्रो, सब्सक्रिप्शन) |
+| **खोज** | Qdrant (वेक्टर सर्च) |
+
+## पूर्वापेक्षाएं
+
+- **Node.js** >= 18
+- **Docker** (अनुशंसित) या PostgreSQL 15+, Redis, और Qdrant स्थानीय रूप से स्थापित
+
+## त्वरित शुरुआत
+
+### 1. सेवाएं शुरू करें
+
+PostgreSQL, Redis, और Qdrant चलाने का सबसे आसान तरीका Docker है:
+
+```bash
+git clone https://github.com/teamatonce/teamatonce.git
+cd teamatonce
+docker compose up -d
+```
+
+यह सभी आवश्यक सेवाओं को उन क्रेडेंशियल्स के साथ शुरू करता है जो `.env.example` से बिल्कुल मेल खाते हैं।
+
+<details>
+<summary>Docker के बिना (मैन्युअल सेटअप)</summary>
+
+PostgreSQL, Redis, और Qdrant स्वयं स्थापित करें और शुरू करें, फिर अपने कनेक्शन विवरण के साथ `backend/.env` अपडेट करें:
+
+```bash
+# PostgreSQL — विकास डेटाबेस बनाएं
+createdb -U postgres teamatonce_dev
+
+# backend/.env में DATABASE_PASSWORD को अपने PostgreSQL पासवर्ड से मिलाएं
+```
+
+</details>
+
+### 2. बैकएंड
+
+```bash
+cd backend
+cp .env.example .env    # क्रेडेंशियल्स पहले से docker-compose.yml से मेल खाते हैं
+npm install
+npm run migrate
+npm run start:dev
+```
+
+### 3. फ़्रंटएंड (नया टर्मिनल)
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+## प्रोजेक्ट संरचना
+
+```
+teamatonce/
+├── backend/              # NestJS API (34 मॉड्यूल)
+│   ├── src/modules/      # auth, company, courses, assessments, ai, search,
+│   │                     # escrow, certificates, learning-paths, blog, ...
+│   └── migrations/       # PostgreSQL माइग्रेशन
+├── frontend/             # React + Vite + Tailwind
+│   └── src/
+└── .github/workflows/    # CI/CD
+```
+
+## योगदानकर्ता
+
+Team@Once में योगदान देने वाले सभी अद्भुत लोगों का धन्यवाद! 🎉
+
+<a href="https://github.com/teamatonce/teamatonce/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=teamatonce/teamatonce&anon=1&max=100&columns=10" />
+</a>
+
+अपना चेहरा यहां देखना चाहते हैं? हमारी [योगदान गाइड](CONTRIBUTING.md) देखें और आज ही योगदान देना शुरू करें!
+
+## प्रोजेक्ट गतिविधि
+
+<p align="center">
+  <img src="https://img.shields.io/github/stars/teamatonce/teamatonce?style=for-the-badge&logo=github&color=yellow" alt="Stars">
+  <img src="https://img.shields.io/github/forks/teamatonce/teamatonce?style=for-the-badge&logo=github&color=blue" alt="Forks">
+  <img src="https://img.shields.io/github/contributors/teamatonce/teamatonce?style=for-the-badge&logo=github&color=green" alt="Contributors">
+  <img src="https://img.shields.io/github/last-commit/teamatonce/teamatonce?style=for-the-badge&logo=github&color=orange" alt="Last Commit">
+</p>
+
+## सुरक्षा
+
+कृपया सुरक्षा कमजोरियों की जिम्मेदारी से रिपोर्ट करें। [SECURITY.md](SECURITY.md) देखें।
 
 ## लाइसेंस
 
-[GNU AGPL 3.0](LICENSE)
+यह प्रोजेक्ट [GNU Affero General Public License v3.0](LICENSE) के तहत लाइसेंस प्राप्त है।
+
+Copyright 2025 Team@Once Contributors.

--- a/README_JA.md
+++ b/README_JA.md
@@ -3,20 +3,190 @@
     <img src="frontend/public/assets/logo.png" alt="Team@Once" width="80">
   </a>
   <h1 align="center">Team@Once</h1>
-  <p align="center"><strong>オープンソースAI駆動型開発アウトソーシングプラットフォーム</strong></p>
-  <p align="center">インテリジェントな自動化と透明なプロセスで、ソフトウェア開発アウトソーシングを革新。</p>
+  <p align="center">
+    <strong>オープンソースAI駆動型開発アウトソーシングプラットフォーム</strong>
+  </p>
+  <p align="center">
+    インテリジェントな自動化、透明なプロセス、シームレスなコラボレーションで、ソフトウェア開発アウトソーシングを革新。
+  </p>
 </p>
 
 <p align="center">
-  <a href="./README.md">English</a> | <a href="./README_JA.md">日本語</a> | <a href="./README_ZH.md">中文</a> | <a href="./README_KO.md">한국어</a> | <a href="./README_ES.md">Español</a> | <a href="./README_FR.md">Français</a> | <a href="./README_DE.md">Deutsch</a> | <a href="./README_PT-BR.md">Português</a> | <a href="./README_RU.md">Русский</a>
+  <a href="https://teamatonce.com">ウェブサイト</a> |
+  <a href="#クイックスタート">クイックスタート</a> |
+  <a href="#機能">機能</a> |
+  <a href="https://github.com/teamatonce/teamatonce/discussions">ディスカッション</a> |
+  <a href="CONTRIBUTING.md">コントリビューション</a>
+</p>
+
+<p align="center">
+  <a href="./README.md">English</a> |
+  <a href="./README_JA.md">日本語</a> |
+  <a href="./README_ZH.md">中文</a> |
+  <a href="./README_KO.md">한국어</a> |
+  <a href="./README_ES.md">Español</a> |
+  <a href="./README_FR.md">Français</a> |
+  <a href="./README_DE.md">Deutsch</a> |
+  <a href="./README_PT-BR.md">Português</a> |
+  <a href="./README_AR.md">العربية</a> |
+  <a href="./README_HI.md">हिन्दी</a> |
+  <a href="./README_RU.md">Русский</a>
 </p>
 
 ---
 
-<p align="center"><a href="./README.md">English</a> | <a href="./README_JA.md">日本語</a> | <a href="./README_ZH.md">中文</a> | <a href="./README_KO.md">한국어</a> | <a href="./README_ES.md">Español</a> | <a href="./README_FR.md">Français</a> | <a href="./README_DE.md">Deutsch</a> | <a href="./README_PT-BR.md">Português</a> | <a href="./README_AR.md">العربية</a> | <a href="./README_HI.md">हिन्दी</a> | <a href="./README_RU.md">Русский</a></p>
+## Team@Onceとは？
 
-[English README](./README.md)
+Team@Onceは、インテリジェントな自動化、AI駆動のアセスメント、エスクロー決済、リアルタイムプロジェクト管理を通じて、従来のリスクを排除するオープンソースAI駆動型開発アウトソーシングマーケットプレイスです。
 
-## License
+## なぜTeam@Onceなのか？（比較）
 
-[GNU AGPL 3.0](LICENSE)
+| 機能 | Team@Once | Upwork | Toptal | Fiverr | Deel |
+|------|-----------|--------|--------|--------|------|
+| **AIマッチング** | ✅ NLP + スマートマッチング | ❌ | ⚠️ 手動審査 | ❌ | ❌ |
+| **組み込みプロジェクト管理** | ✅ カンバン、マイルストーン、時間管理 | ⚠️ 基本的 | ❌ | ❌ | ❌ |
+| **エスクロー決済** | ✅ マイルストーンベース | ✅ | ✅ | ✅ | ❌ |
+| **ビデオコラボレーション** | ✅ 組み込み通話 + 画面共有 | ❌ | ❌ | ❌ | ❌ |
+| **スキルアセスメント** | ✅ AI生成 + 証明書 | ⚠️ 基本テスト | ✅ 厳格な審査 | ⚠️ 基本テスト | ❌ |
+| **学習パス** | ✅ コース + 認定資格 | ❌ | ❌ | ❌ | ❌ |
+| **リアルタイムチャット** | ✅ チャンネル + ファイル共有 | ⚠️ 基本的 | ❌ | ⚠️ 基本的 | ❌ |
+| **チームワークスペース** | ✅ マルチプロジェクト組織 | ❌ | ❌ | ❌ | ❌ |
+| **データエンジン** | ✅ 企業発見クローラー | ❌ | ❌ | ❌ | ❌ |
+| **スマートコントラクト** | ✅ 自動生成 + 電子署名 | ⚠️ 基本的 | ❌ | ⚠️ 基本的 | ✅ |
+| **APIアクセス** | ✅ フルREST API | ⚠️ 部分的 | ❌ | ❌ | ✅ |
+| **セルフホスト** | ✅ Docker Compose | ❌ | ❌ | ❌ | ❌ |
+| **オープンソース** | ✅ AGPL 3.0 | ❌ | ❌ | ❌ | ❌ |
+| **プラットフォーム手数料** | 🟢 3-5% | 💰 10-20% | 💰 約2倍のマークアップ | 💰 20% | 💰 カスタム |
+| **多言語対応** | ✅ 11言語 | ✅ | ✅ | ✅ | ✅ |
+
+## 機能
+
+### マーケットプレイス
+- **企業プロフィール** -- ポートフォリオ、チームスキル、認定資格のショーケース
+- **AIマッチング** -- スキルと実績に基づくインテリジェントな企業とプロジェクトのマッチング
+- **データエンジン** -- 企業発見とエンリッチメントのためのWebクローリングとパイプライン
+- **エスクロー決済** -- Stripeによる安全なマイルストーンベースの決済
+
+### 学習と認定
+- **コース管理** -- モジュールとレッスンで構成される技術コースの作成と管理
+- **AIアセスメント** -- AI生成のクイズとスキル評価
+- **証明書** -- 検証可能な達成証明書
+- **学習パス** -- 体系的なスキル開発ルート
+- **アチーブメント** -- バッジと進捗トラッキングによるゲーミフィケーション
+
+### コラボレーション
+- **プロジェクト管理** -- マイルストーンと成果物によるプロジェクト追跡
+- **ディスカッションフォーラム** -- コミュニティディスカッションと知識共有
+- **リアルタイム通知** -- WebSocket駆動のライブアップデート
+- **ブログ** -- 記事とガイドのコンテンツ管理
+- **スタディグループ** -- 協調学習スペース
+
+### プラットフォーム
+- **AI統合** -- OpenAI駆動のコンテンツ生成と分析
+- **検索** -- Qdrantベクトル検索によるセマンティックコンテンツ発見
+- **多言語対応** -- i18nサポート
+- **管理ダッシュボード** -- プラットフォーム管理と分析
+- **SEO** -- サーバーサイドレンダリングとメタデータ最適化
+
+## 技術スタック
+
+| レイヤー | 技術 |
+|---------|------|
+| **バックエンド** | NestJS 11, TypeScript, PostgreSQL (raw SQL), Redis, Qdrant, Socket.io |
+| **フロントエンド** | React 19, Vite, TypeScript, Tailwind CSS, Radix UI, Zustand |
+| **AI** | OpenAI (GPT-4o-mini, embeddings) |
+| **決済** | Stripe (エスクロー、サブスクリプション) |
+| **検索** | Qdrant (ベクトル検索) |
+
+## 前提条件
+
+- **Node.js** >= 18
+- **Docker**（推奨）、またはPostgreSQL 15+、Redis、Qdrantをローカルにインストール
+
+## クイックスタート
+
+### 1. サービスの起動
+
+PostgreSQL、Redis、Qdrantを実行する最も簡単な方法はDockerを使うことです：
+
+```bash
+git clone https://github.com/teamatonce/teamatonce.git
+cd teamatonce
+docker compose up -d
+```
+
+これにより、`.env.example`に一致する認証情報で必要なすべてのサービスが起動します。
+
+<details>
+<summary>Dockerなし（手動セットアップ）</summary>
+
+PostgreSQL、Redis、Qdrantを自分でインストールして起動し、`backend/.env`に接続情報を更新してください：
+
+```bash
+# PostgreSQL — 開発用データベースを作成
+createdb -U postgres teamatonce_dev
+
+# backend/.envのDATABASE_PASSWORDをPostgreSQLのパスワードに合わせて更新
+```
+
+</details>
+
+### 2. バックエンド
+
+```bash
+cd backend
+cp .env.example .env    # 認証情報はdocker-compose.ymlと一致済み
+npm install
+npm run migrate
+npm run start:dev
+```
+
+### 3. フロントエンド（新しいターミナルで）
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+## プロジェクト構成
+
+```
+teamatonce/
+├── backend/              # NestJS API（34モジュール）
+│   ├── src/modules/      # auth, company, courses, assessments, ai, search,
+│   │                     # escrow, certificates, learning-paths, blog, ...
+│   └── migrations/       # PostgreSQLマイグレーション
+├── frontend/             # React + Vite + Tailwind
+│   └── src/
+└── .github/workflows/    # CI/CD
+```
+
+## コントリビューター
+
+Team@Onceに貢献してくださったすべての素晴らしい方々に感謝します！ 🎉
+
+<a href="https://github.com/teamatonce/teamatonce/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=teamatonce/teamatonce&anon=1&max=100&columns=10" />
+</a>
+
+ここにあなたの顔を載せたいですか？[コントリビューションガイド](CONTRIBUTING.md)をチェックして、今日から貢献を始めましょう！
+
+## プロジェクトアクティビティ
+
+<p align="center">
+  <img src="https://img.shields.io/github/stars/teamatonce/teamatonce?style=for-the-badge&logo=github&color=yellow" alt="Stars">
+  <img src="https://img.shields.io/github/forks/teamatonce/teamatonce?style=for-the-badge&logo=github&color=blue" alt="Forks">
+  <img src="https://img.shields.io/github/contributors/teamatonce/teamatonce?style=for-the-badge&logo=github&color=green" alt="Contributors">
+  <img src="https://img.shields.io/github/last-commit/teamatonce/teamatonce?style=for-the-badge&logo=github&color=orange" alt="Last Commit">
+</p>
+
+## セキュリティ
+
+セキュリティの脆弱性は責任を持って報告してください。[SECURITY.md](SECURITY.md)をご覧ください。
+
+## ライセンス
+
+このプロジェクトは[GNU Affero General Public License v3.0](LICENSE)の下でライセンスされています。
+
+Copyright 2025 Team@Once Contributors.

--- a/README_KO.md
+++ b/README_KO.md
@@ -4,19 +4,191 @@
   </a>
   <h1 align="center">Team@Once</h1>
   <p align="center"><strong>오픈소스 AI 기반 개발 아웃소싱 플랫폼</strong></p>
-  <p align="center">지능형 자동화와 투명한 프로세스로 소프트웨어 개발 아웃소싱을 혁신합니다.</p>
+  <p align="center">지능형 자동화, 투명한 프로세스, 원활한 협업을 통해 소프트웨어 개발 아웃소싱을 혁신합니다.</p>
 </p>
 
 <p align="center">
-  <a href="./README.md">English</a> | <a href="./README_JA.md">日本語</a> | <a href="./README_ZH.md">中文</a> | <a href="./README_KO.md">한국어</a> | <a href="./README_ES.md">Español</a> | <a href="./README_FR.md">Français</a> | <a href="./README_DE.md">Deutsch</a> | <a href="./README_PT-BR.md">Português</a> | <a href="./README_RU.md">Русский</a>
+  <a href="https://github.com/teamatonce/teamatonce/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue.svg" alt="License"></a>
+  <a href="https://github.com/teamatonce/teamatonce/stargazers"><img src="https://img.shields.io/github/stars/teamatonce/teamatonce?style=social" alt="GitHub Stars"></a>
+  <a href="https://github.com/teamatonce/teamatonce/issues"><img src="https://img.shields.io/github/issues/teamatonce/teamatonce" alt="Issues"></a>
+</p>
+
+<p align="center">
+  <a href="https://teamatonce.com">웹사이트</a> |
+  <a href="#빠른-시작">빠른 시작</a> |
+  <a href="#기능">기능</a> |
+  <a href="https://github.com/teamatonce/teamatonce/discussions">토론</a> |
+  <a href="CONTRIBUTING.md">기여하기</a>
+</p>
+
+<p align="center">
+  <a href="./README.md">English</a> |
+  <a href="./README_JA.md">日本語</a> |
+  <a href="./README_ZH.md">中文</a> |
+  <a href="./README_KO.md">한국어</a> |
+  <a href="./README_ES.md">Español</a> |
+  <a href="./README_FR.md">Français</a> |
+  <a href="./README_DE.md">Deutsch</a> |
+  <a href="./README_PT-BR.md">Português</a> |
+  <a href="./README_AR.md">العربية</a> |
+  <a href="./README_HI.md">हिन्दी</a> |
+  <a href="./README_RU.md">Русский</a>
 </p>
 
 ---
 
-<p align="center"><a href="./README.md">English</a> | <a href="./README_JA.md">日本語</a> | <a href="./README_ZH.md">中文</a> | <a href="./README_KO.md">한국어</a> | <a href="./README_ES.md">Español</a> | <a href="./README_FR.md">Français</a> | <a href="./README_DE.md">Deutsch</a> | <a href="./README_PT-BR.md">Português</a> | <a href="./README_AR.md">العربية</a> | <a href="./README_HI.md">हिन्दी</a> | <a href="./README_RU.md">Русский</a></p>
+## Team@Once란?
 
-[English README](./README.md)
+Team@Once는 지능형 자동화, AI 기반 평가, 에스크로 결제, 실시간 프로젝트 관리를 통해 기존의 리스크를 제거하는 오픈소스 AI 기반 개발 아웃소싱 마켓플레이스입니다.
 
-## License
+## 왜 Team@Once인가? (비교)
 
-[GNU AGPL 3.0](LICENSE)
+| 기능 | Team@Once | Upwork | Toptal | Fiverr | Deel |
+|------|-----------|--------|--------|--------|------|
+| **AI 기반 매칭** | ✅ NLP + 스마트 매칭 | ❌ | ⚠️ 수동 심사 | ❌ | ❌ |
+| **내장 프로젝트 관리** | ✅ 칸반, 마일스톤, 시간 추적 | ⚠️ 기본 | ❌ | ❌ | ❌ |
+| **에스크로 결제** | ✅ 마일스톤 기반 | ✅ | ✅ | ✅ | ❌ |
+| **영상 협업** | ✅ 내장 통화 + 화면 공유 | ❌ | ❌ | ❌ | ❌ |
+| **스킬 평가** | ✅ AI 생성 + 인증서 | ⚠️ 기본 테스트 | ✅ 엄격한 심사 | ⚠️ 기본 | ❌ |
+| **학습 경로** | ✅ 강좌 + 자격증 | ❌ | ❌ | ❌ | ❌ |
+| **실시간 채팅** | ✅ 채널 + 파일 공유 | ⚠️ 기본 | ❌ | ⚠️ 기본 | ❌ |
+| **팀 워크스페이스** | ✅ 멀티 프로젝트 조직 | ❌ | ❌ | ❌ | ❌ |
+| **데이터 엔진** | ✅ 기업 발굴 크롤러 | ❌ | ❌ | ❌ | ❌ |
+| **스마트 계약** | ✅ 자동 생성 + 전자 서명 | ⚠️ 기본 | ❌ | ⚠️ 기본 | ✅ |
+| **API 접근** | ✅ 전체 REST API | ⚠️ 부분적 | ❌ | ❌ | ✅ |
+| **셀프 호스팅** | ✅ Docker Compose | ❌ | ❌ | ❌ | ❌ |
+| **오픈소스** | ✅ AGPL 3.0 | ❌ | ❌ | ❌ | ❌ |
+| **플랫폼 수수료** | 🟢 3-5% | 💰 10-20% | 💰 ~2배 마크업 | 💰 20% | 💰 맞춤형 |
+| **다국어 지원** | ✅ 11개 언어 | ✅ | ✅ | ✅ | ✅ |
+
+## 기능
+
+### 마켓플레이스
+- **기업 프로필** -- 포트폴리오, 팀 스킬, 자격증 전시
+- **AI 기반 매칭** -- 스킬과 실적 기반의 지능형 기업-프로젝트 매칭
+- **데이터 엔진** -- 기업 발굴 및 데이터 강화를 위한 웹 크롤링 파이프라인
+- **에스크로 결제** -- Stripe를 통한 안전한 마일스톤 기반 결제
+
+### 학습 및 자격증
+- **강좌 관리** -- 모듈과 레슨으로 기술 강좌 생성 및 관리
+- **AI 평가** -- AI가 생성하는 퀴즈 및 스킬 평가
+- **인증서** -- 검증 가능한 성취 인증서
+- **학습 경로** -- 체계적인 스킬 개발 경로
+- **업적** -- 배지와 진행 상황 추적을 통한 게이미피케이션
+
+### 협업
+- **프로젝트 관리** -- 마일스톤과 산출물로 프로젝트 추적
+- **토론 포럼** -- 커뮤니티 토론 및 지식 공유
+- **실시간 알림** -- WebSocket 기반 실시간 업데이트
+- **블로그** -- 아티클 및 가이드 콘텐츠 관리
+- **스터디 그룹** -- 협업 학습 공간
+
+### 플랫폼
+- **AI 통합** -- OpenAI 기반 콘텐츠 생성 및 분석
+- **검색** -- Qdrant 벡터 검색을 통한 시맨틱 콘텐츠 탐색
+- **다국어 지원** -- i18n 지원
+- **관리자 대시보드** -- 플랫폼 관리 및 분석
+- **SEO** -- 서버사이드 렌더링 및 메타데이터 최적화
+
+## 기술 스택
+
+| 레이어 | 기술 |
+|--------|------|
+| **백엔드** | NestJS 11, TypeScript, PostgreSQL (raw SQL), Redis, Qdrant, Socket.io |
+| **프론트엔드** | React 19, Vite, TypeScript, Tailwind CSS, Radix UI, Zustand |
+| **AI** | OpenAI (GPT-4o-mini, embeddings) |
+| **결제** | Stripe (에스크로, 구독) |
+| **검색** | Qdrant (벡터 검색) |
+
+## 사전 요구 사항
+
+- **Node.js** >= 18
+- **Docker** (권장) 또는 PostgreSQL 15+, Redis, Qdrant를 로컬에 설치
+
+## 빠른 시작
+
+### 1. 서비스 시작
+
+PostgreSQL, Redis, Qdrant를 실행하는 가장 쉬운 방법은 Docker를 사용하는 것입니다:
+
+```bash
+git clone https://github.com/teamatonce/teamatonce.git
+cd teamatonce
+docker compose up -d
+```
+
+이 명령어는 `.env.example`의 자격 증명과 일치하는 모든 필수 서비스를 즉시 시작합니다.
+
+<details>
+<summary>Docker 없이 (수동 설정)</summary>
+
+PostgreSQL, Redis, Qdrant를 직접 설치 및 시작한 후 `backend/.env`에 연결 정보를 업데이트하세요:
+
+```bash
+# PostgreSQL — 개발 데이터베이스 생성
+createdb -U postgres teamatonce_dev
+
+# backend/.env의 DATABASE_PASSWORD를 PostgreSQL 비밀번호에 맞게 업데이트
+```
+
+</details>
+
+### 2. 백엔드
+
+```bash
+cd backend
+cp .env.example .env    # 자격 증명이 이미 docker-compose.yml과 일치합니다
+npm install
+npm run migrate
+npm run start:dev
+```
+
+### 3. 프론트엔드 (새 터미널)
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+## 프로젝트 구조
+
+```
+teamatonce/
+├── backend/              # NestJS API (34개 모듈)
+│   ├── src/modules/      # auth, company, courses, assessments, ai, search,
+│   │                     # escrow, certificates, learning-paths, blog, ...
+│   └── migrations/       # PostgreSQL 마이그레이션
+├── frontend/             # React + Vite + Tailwind
+│   └── src/
+└── .github/workflows/    # CI/CD
+```
+
+## 기여자
+
+Team@Once에 기여해주신 모든 분들께 감사드립니다! 🎉
+
+<a href="https://github.com/teamatonce/teamatonce/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=teamatonce/teamatonce&anon=1&max=100&columns=10" />
+</a>
+
+여기에 이름을 올리고 싶으신가요? [기여 가이드](CONTRIBUTING.md)를 확인하고 지금 바로 기여를 시작하세요!
+
+## 프로젝트 활동
+
+<p align="center">
+  <img src="https://img.shields.io/github/stars/teamatonce/teamatonce?style=for-the-badge&logo=github&color=yellow" alt="Stars">
+  <img src="https://img.shields.io/github/forks/teamatonce/teamatonce?style=for-the-badge&logo=github&color=blue" alt="Forks">
+  <img src="https://img.shields.io/github/contributors/teamatonce/teamatonce?style=for-the-badge&logo=github&color=green" alt="Contributors">
+  <img src="https://img.shields.io/github/last-commit/teamatonce/teamatonce?style=for-the-badge&logo=github&color=orange" alt="Last Commit">
+</p>
+
+## 보안
+
+보안 취약점은 책임감 있게 보고해 주세요. [SECURITY.md](SECURITY.md)를 참조하세요.
+
+## 라이선스
+
+이 프로젝트는 [GNU Affero General Public License v3.0](LICENSE)에 따라 라이선스가 부여됩니다.
+
+Copyright 2025 Team@Once Contributors.

--- a/README_PT-BR.md
+++ b/README_PT-BR.md
@@ -3,20 +3,196 @@
     <img src="frontend/public/assets/logo.png" alt="Team@Once" width="80">
   </a>
   <h1 align="center">Team@Once</h1>
-  <p align="center"><strong>Plataforma de terceirizacao de desenvolvimento com IA</strong></p>
-  <p align="center">Revolucionando a terceirizacao de desenvolvimento de software.</p>
+  <p align="center">
+    <strong>Plataforma open-source de terceirização de desenvolvimento impulsionada por IA</strong>
+  </p>
+  <p align="center">
+    Revolucionando a terceirização de desenvolvimento de software através de automação inteligente, processos transparentes e colaboração fluida.
+  </p>
 </p>
 
 <p align="center">
-  <a href="./README.md">English</a> | <a href="./README_JA.md">日本語</a> | <a href="./README_ZH.md">中文</a> | <a href="./README_KO.md">한국어</a> | <a href="./README_ES.md">Español</a> | <a href="./README_FR.md">Français</a> | <a href="./README_DE.md">Deutsch</a> | <a href="./README_PT-BR.md">Português</a> | <a href="./README_RU.md">Русский</a>
+  <a href="https://github.com/teamatonce/teamatonce/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue.svg" alt="Licença"></a>
+  <a href="https://github.com/teamatonce/teamatonce/stargazers"><img src="https://img.shields.io/github/stars/teamatonce/teamatonce?style=social" alt="Estrelas no GitHub"></a>
+  <a href="https://github.com/teamatonce/teamatonce/issues"><img src="https://img.shields.io/github/issues/teamatonce/teamatonce" alt="Issues"></a>
+</p>
+
+<p align="center">
+  <a href="https://teamatonce.com">Website</a> |
+  <a href="#início-rápido">Início Rápido</a> |
+  <a href="#recursos">Recursos</a> |
+  <a href="https://github.com/teamatonce/teamatonce/discussions">Discussões</a> |
+  <a href="CONTRIBUTING.md">Contribuir</a>
+</p>
+
+<p align="center">
+  <a href="./README.md">English</a> |
+  <a href="./README_JA.md">日本語</a> |
+  <a href="./README_ZH.md">中文</a> |
+  <a href="./README_KO.md">한국어</a> |
+  <a href="./README_ES.md">Español</a> |
+  <a href="./README_FR.md">Français</a> |
+  <a href="./README_DE.md">Deutsch</a> |
+  <a href="./README_PT-BR.md">Português</a> |
+  <a href="./README_AR.md">العربية</a> |
+  <a href="./README_HI.md">हिन्दी</a> |
+  <a href="./README_RU.md">Русский</a>
 </p>
 
 ---
 
-<p align="center"><a href="./README.md">English</a> | <a href="./README_JA.md">日本語</a> | <a href="./README_ZH.md">中文</a> | <a href="./README_KO.md">한국어</a> | <a href="./README_ES.md">Español</a> | <a href="./README_FR.md">Français</a> | <a href="./README_DE.md">Deutsch</a> | <a href="./README_PT-BR.md">Português</a> | <a href="./README_AR.md">العربية</a> | <a href="./README_HI.md">हिन्दी</a> | <a href="./README_RU.md">Русский</a></p>
+## O que é o Team@Once?
 
-[English README](./README.md)
+Team@Once é um marketplace open-source de terceirização de desenvolvimento impulsionado por IA que elimina os riscos tradicionais através de automação inteligente, avaliações com IA, pagamentos em custódia e gerenciamento de projetos em tempo real.
 
-## License
+## Por que Team@Once? (Comparação)
 
-[GNU AGPL 3.0](LICENSE)
+| Recurso | Team@Once | Upwork | Toptal | Fiverr | Deel |
+|---------|-----------|--------|--------|--------|------|
+| **Matching com IA** | ✅ NLP + matching inteligente | ❌ | ⚠️ Triagem manual | ❌ | ❌ |
+| **Gerenciamento de Projetos Integrado** | ✅ Kanban, marcos, controle de tempo | ⚠️ Básico | ❌ | ❌ | ❌ |
+| **Pagamentos em Custódia** | ✅ Baseado em marcos | ✅ | ✅ | ✅ | ❌ |
+| **Colaboração por Vídeo** | ✅ Chamadas integradas + compartilhamento de tela | ❌ | ❌ | ❌ | ❌ |
+| **Avaliação de Habilidades** | ✅ Geradas por IA + certificados | ⚠️ Testes básicos | ✅ Rigoroso | ⚠️ Básico | ❌ |
+| **Trilhas de Aprendizado** | ✅ Cursos + certificações | ❌ | ❌ | ❌ | ❌ |
+| **Chat em Tempo Real** | ✅ Canais + compartilhamento de arquivos | ⚠️ Básico | ❌ | ⚠️ Básico | ❌ |
+| **Espaços de Trabalho em Equipe** | ✅ Organização multi-projeto | ❌ | ❌ | ❌ | ❌ |
+| **Motor de Dados** | ✅ Crawler de descoberta de empresas | ❌ | ❌ | ❌ | ❌ |
+| **Contratos Inteligentes** | ✅ Gerados automaticamente + assinatura eletrônica | ⚠️ Básico | ❌ | ⚠️ Básico | ✅ |
+| **Acesso à API** | ✅ API REST completa | ⚠️ Parcial | ❌ | ❌ | ✅ |
+| **Auto-hospedado** | ✅ Docker Compose | ❌ | ❌ | ❌ | ❌ |
+| **Open Source** | ✅ AGPL 3.0 | ❌ | ❌ | ❌ | ❌ |
+| **Taxa da Plataforma** | 🟢 3-5% | 💰 10-20% | 💰 ~2x markup | 💰 20% | 💰 Personalizado |
+| **i18n** | ✅ 11 idiomas | ✅ | ✅ | ✅ | ✅ |
+
+## Recursos
+
+### Mercado
+- **Perfis de Empresas** -- Vitrine de portfólios, habilidades da equipe e certificações
+- **Matching com IA** -- Correspondência inteligente entre empresas e projetos com base em habilidades e histórico
+- **Motor de Dados** -- Web crawling e pipeline para descoberta e enriquecimento de empresas
+- **Pagamentos em Custódia** -- Pagamentos seguros baseados em marcos via Stripe
+
+### Aprendizado e Certificação
+- **Gestão de Cursos** -- Crie e gerencie cursos técnicos com módulos e aulas
+- **Avaliações com IA** -- Quizzes e avaliações de habilidades gerados por IA
+- **Certificados** -- Certificados de conquista verificáveis
+- **Trilhas de Aprendizado** -- Rotas estruturadas de desenvolvimento de habilidades
+- **Conquistas** -- Gamificação com emblemas e acompanhamento de progresso
+
+### Colaboração
+- **Gerenciamento de Projetos** -- Acompanhe projetos com marcos e entregas
+- **Fóruns de Discussão** -- Discussões da comunidade e compartilhamento de conhecimento
+- **Notificações em Tempo Real** -- Atualizações ao vivo via WebSocket
+- **Blog** -- Gestão de conteúdo para artigos e guias
+- **Grupos de Estudo** -- Espaços de aprendizado colaborativo
+
+### Plataforma
+- **Integração com IA** -- Geração e análise de conteúdo alimentadas por OpenAI
+- **Busca** -- Busca vetorial Qdrant para descoberta semântica de conteúdo
+- **Multi-idiomas** -- Suporte a i18n
+- **Painel Administrativo** -- Administração e análises da plataforma
+- **SEO** -- Renderização server-side e otimização de metadados
+
+## Stack Tecnológico
+
+| Camada | Tecnologia |
+|--------|------------|
+| **Backend** | NestJS 11, TypeScript, PostgreSQL (SQL puro), Redis, Qdrant, Socket.io |
+| **Frontend** | React 19, Vite, TypeScript, Tailwind CSS, Radix UI, Zustand |
+| **IA** | OpenAI (GPT-4o-mini, embeddings) |
+| **Pagamentos** | Stripe (custódia, assinaturas) |
+| **Busca** | Qdrant (busca vetorial) |
+
+## Pré-requisitos
+
+- **Node.js** >= 18
+- **Docker** (recomendado) ou PostgreSQL 15+, Redis e Qdrant instalados localmente
+
+## Início Rápido
+
+### 1. Iniciar serviços
+
+A maneira mais fácil de executar PostgreSQL, Redis e Qdrant é com Docker:
+
+```bash
+git clone https://github.com/teamatonce/teamatonce.git
+cd teamatonce
+docker compose up -d
+```
+
+Isso inicia todos os serviços necessários com credenciais que correspondem ao `.env.example` prontas para uso.
+
+<details>
+<summary>Sem Docker (configuração manual)</summary>
+
+Instale e inicie PostgreSQL, Redis e Qdrant manualmente, depois atualize `backend/.env` com seus detalhes de conexão:
+
+```bash
+# PostgreSQL — criar o banco de dados de desenvolvimento
+createdb -U postgres teamatonce_dev
+
+# Atualize DATABASE_PASSWORD em backend/.env para corresponder à sua senha do PostgreSQL
+```
+
+</details>
+
+### 2. Backend
+
+```bash
+cd backend
+cp .env.example .env    # credenciais já correspondem ao docker-compose.yml
+npm install
+npm run migrate
+npm run start:dev
+```
+
+### 3. Frontend (novo terminal)
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+## Estrutura do Projeto
+
+```
+teamatonce/
+├── backend/              # API NestJS (34 módulos)
+│   ├── src/modules/      # auth, company, courses, assessments, ai, search,
+│   │                     # escrow, certificates, learning-paths, blog, ...
+│   └── migrations/       # Migrações PostgreSQL
+├── frontend/             # React + Vite + Tailwind
+│   └── src/
+└── .github/workflows/    # CI/CD
+```
+
+## Contribuidores
+
+Obrigado a todas as pessoas incríveis que contribuíram para o Team@Once! 🎉
+
+<a href="https://github.com/teamatonce/teamatonce/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=teamatonce/teamatonce&anon=1&max=100&columns=10" />
+</a>
+
+Quer ver seu rosto aqui? Confira nosso [Guia de Contribuição](CONTRIBUTING.md) e comece a contribuir hoje!
+
+## Atividade do Projeto
+
+<p align="center">
+  <img src="https://img.shields.io/github/stars/teamatonce/teamatonce?style=for-the-badge&logo=github&color=yellow" alt="Estrelas">
+  <img src="https://img.shields.io/github/forks/teamatonce/teamatonce?style=for-the-badge&logo=github&color=blue" alt="Forks">
+  <img src="https://img.shields.io/github/contributors/teamatonce/teamatonce?style=for-the-badge&logo=github&color=green" alt="Contribuidores">
+  <img src="https://img.shields.io/github/last-commit/teamatonce/teamatonce?style=for-the-badge&logo=github&color=orange" alt="Último Commit">
+</p>
+
+## Segurança
+
+Por favor, reporte vulnerabilidades de segurança de forma responsável. Consulte [SECURITY.md](SECURITY.md).
+
+## Licença
+
+Este projeto está licenciado sob a [GNU Affero General Public License v3.0](LICENSE).
+
+Copyright 2025 Team@Once Contributors.

--- a/README_RU.md
+++ b/README_RU.md
@@ -3,20 +3,192 @@
     <img src="frontend/public/assets/logo.png" alt="Team@Once" width="80">
   </a>
   <h1 align="center">Team@Once</h1>
-  <p align="center"><strong>Платформа аутсорсинга разработки на базе ИИ</strong></p>
-  <p align="center">Революция в аутсорсинге разработки программного обеспечения.</p>
+  <p align="center"><strong>Платформа аутсорсинга разработки с открытым исходным кодом на базе ИИ</strong></p>
+  <p align="center">Революция в аутсорсинге разработки ПО благодаря интеллектуальной автоматизации, прозрачным процессам и бесшовному сотрудничеству.</p>
 </p>
 
 <p align="center">
-  <a href="./README.md">English</a> | <a href="./README_JA.md">日本語</a> | <a href="./README_ZH.md">中文</a> | <a href="./README_KO.md">한국어</a> | <a href="./README_ES.md">Español</a> | <a href="./README_FR.md">Français</a> | <a href="./README_DE.md">Deutsch</a> | <a href="./README_PT-BR.md">Português</a> | <a href="./README_RU.md">Русский</a>
+  <a href="https://github.com/teamatonce/teamatonce/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue.svg" alt="License"></a>
+  <a href="https://github.com/teamatonce/teamatonce/stargazers"><img src="https://img.shields.io/github/stars/teamatonce/teamatonce?style=social" alt="GitHub Stars"></a>
+  <a href="https://github.com/teamatonce/teamatonce/issues"><img src="https://img.shields.io/github/issues/teamatonce/teamatonce" alt="Issues"></a>
+</p>
+
+<p align="center">
+  <a href="https://teamatonce.com">Сайт</a> |
+  <a href="#быстрый-старт">Быстрый старт</a> |
+  <a href="#возможности">Возможности</a> |
+  <a href="https://github.com/teamatonce/teamatonce/discussions">Обсуждения</a> |
+  <a href="CONTRIBUTING.md">Участие в проекте</a>
+</p>
+
+<p align="center">
+  <a href="./README.md">English</a> |
+  <a href="./README_JA.md">日本語</a> |
+  <a href="./README_ZH.md">中文</a> |
+  <a href="./README_KO.md">한국어</a> |
+  <a href="./README_ES.md">Español</a> |
+  <a href="./README_FR.md">Français</a> |
+  <a href="./README_DE.md">Deutsch</a> |
+  <a href="./README_PT-BR.md">Português</a> |
+  <a href="./README_AR.md">العربية</a> |
+  <a href="./README_HI.md">हिन्दी</a> |
+  <a href="./README_RU.md">Русский</a>
 </p>
 
 ---
 
-<p align="center"><a href="./README.md">English</a> | <a href="./README_JA.md">日本語</a> | <a href="./README_ZH.md">中文</a> | <a href="./README_KO.md">한국어</a> | <a href="./README_ES.md">Español</a> | <a href="./README_FR.md">Français</a> | <a href="./README_DE.md">Deutsch</a> | <a href="./README_PT-BR.md">Português</a> | <a href="./README_AR.md">العربية</a> | <a href="./README_HI.md">हिन्दी</a> | <a href="./README_RU.md">Русский</a></p>
+## Что такое Team@Once?
 
-[English README](./README.md)
+Team@Once — это платформа аутсорсинга разработки с открытым исходным кодом на базе ИИ, которая устраняет традиционные риски благодаря интеллектуальной автоматизации, оценке навыков с помощью ИИ, эскроу-платежам и управлению проектами в реальном времени.
 
-## License
+## Почему Team@Once? (Сравнение)
 
-[GNU AGPL 3.0](LICENSE)
+| Функция | Team@Once | Upwork | Toptal | Fiverr | Deel |
+|---------|-----------|--------|--------|--------|------|
+| **Подбор на базе ИИ** | ✅ NLP + умный подбор | ❌ | ⚠️ Ручная проверка | ❌ | ❌ |
+| **Встроенное управление проектами** | ✅ Kanban, вехи, учёт времени | ⚠️ Базовое | ❌ | ❌ | ❌ |
+| **Эскроу-платежи** | ✅ На основе вех | ✅ | ✅ | ✅ | ❌ |
+| **Видеосвязь** | ✅ Встроенные звонки + демонстрация экрана | ❌ | ❌ | ❌ | ❌ |
+| **Оценка навыков** | ✅ ИИ-генерация + сертификаты | ⚠️ Базовые тесты | ✅ Строгая проверка | ⚠️ Базовые | ❌ |
+| **Траектории обучения** | ✅ Курсы + сертификации | ❌ | ❌ | ❌ | ❌ |
+| **Чат в реальном времени** | ✅ Каналы + обмен файлами | ⚠️ Базовый | ❌ | ⚠️ Базовый | ❌ |
+| **Рабочие пространства команд** | ✅ Мультипроектная организация | ❌ | ❌ | ❌ | ❌ |
+| **Data Engine** | ✅ Краулер для поиска компаний | ❌ | ❌ | ❌ | ❌ |
+| **Умные контракты** | ✅ Автогенерация + электронная подпись | ⚠️ Базовые | ❌ | ⚠️ Базовые | ✅ |
+| **Доступ к API** | ✅ Полный REST API | ⚠️ Частичный | ❌ | ❌ | ✅ |
+| **Самостоятельное размещение** | ✅ Docker Compose | ❌ | ❌ | ❌ | ❌ |
+| **Открытый исходный код** | ✅ AGPL 3.0 | ❌ | ❌ | ❌ | ❌ |
+| **Комиссия платформы** | 🟢 3-5% | 💰 10-20% | 💰 ~2x наценка | 💰 20% | 💰 Индивидуально |
+| **Интернационализация** | ✅ 11 языков | ✅ | ✅ | ✅ | ✅ |
+
+## Возможности
+
+### Маркетплейс
+- **Профили компаний** — Демонстрация портфолио, навыков команды и сертификатов
+- **Подбор на базе ИИ** — Интеллектуальный подбор компании для проекта на основе навыков и послужного списка
+- **Data Engine** — Веб-краулинг и конвейер для поиска и обогащения данных о компаниях
+- **Эскроу-платежи** — Безопасные платежи на основе вех через Stripe
+
+### Обучение и сертификация
+- **Управление курсами** — Создание и управление техническими курсами с модулями и уроками
+- **ИИ-оценка** — Тесты и оценка навыков, сгенерированные ИИ
+- **Сертификаты** — Верифицируемые сертификаты достижений
+- **Траектории обучения** — Структурированные маршруты развития навыков
+- **Достижения** — Геймификация с бейджами и отслеживанием прогресса
+
+### Совместная работа
+- **Управление проектами** — Отслеживание проектов с вехами и результатами
+- **Дискуссионные форумы** — Обсуждения сообщества и обмен знаниями
+- **Уведомления в реальном времени** — Обновления в реальном времени на базе WebSocket
+- **Блог** — Управление контентом для статей и руководств
+- **Учебные группы** — Пространства для совместного обучения
+
+### Платформа
+- **Интеграция с ИИ** — Генерация и анализ контента на базе OpenAI
+- **Поиск** — Векторный поиск Qdrant для семантического обнаружения контента
+- **Мультиязычность** — Поддержка интернационализации (i18n)
+- **Панель администратора** — Администрирование платформы и аналитика
+- **SEO** — Серверный рендеринг и оптимизация метаданных
+
+## Технологический стек
+
+| Уровень | Технология |
+|---------|------------|
+| **Бэкенд** | NestJS 11, TypeScript, PostgreSQL (raw SQL), Redis, Qdrant, Socket.io |
+| **Фронтенд** | React 19, Vite, TypeScript, Tailwind CSS, Radix UI, Zustand |
+| **ИИ** | OpenAI (GPT-4o-mini, embeddings) |
+| **Платежи** | Stripe (эскроу, подписки) |
+| **Поиск** | Qdrant (векторный поиск) |
+
+## Требования
+
+- **Node.js** >= 18
+- **Docker** (рекомендуется) или PostgreSQL 15+, Redis и Qdrant, установленные локально
+
+## Быстрый старт
+
+### 1. Запуск сервисов
+
+Самый простой способ запустить PostgreSQL, Redis и Qdrant — использовать Docker:
+
+```bash
+git clone https://github.com/teamatonce/teamatonce.git
+cd teamatonce
+docker compose up -d
+```
+
+Это запустит все необходимые сервисы с учётными данными, которые совпадают с `.env.example` без дополнительной настройки.
+
+<details>
+<summary>Без Docker (ручная установка)</summary>
+
+Установите и запустите PostgreSQL, Redis и Qdrant самостоятельно, затем обновите `backend/.env` с вашими данными подключения:
+
+```bash
+# PostgreSQL — создание базы данных для разработки
+createdb -U postgres teamatonce_dev
+
+# Обновите DATABASE_PASSWORD в backend/.env, чтобы он соответствовал вашему паролю PostgreSQL
+```
+
+</details>
+
+### 2. Бэкенд
+
+```bash
+cd backend
+cp .env.example .env    # учётные данные уже совпадают с docker-compose.yml
+npm install
+npm run migrate
+npm run start:dev
+```
+
+### 3. Фронтенд (новый терминал)
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+## Структура проекта
+
+```
+teamatonce/
+├── backend/              # NestJS API (34 модуля)
+│   ├── src/modules/      # auth, company, courses, assessments, ai, search,
+│   │                     # escrow, certificates, learning-paths, blog, ...
+│   └── migrations/       # Миграции PostgreSQL
+├── frontend/             # React + Vite + Tailwind
+│   └── src/
+└── .github/workflows/    # CI/CD
+```
+
+## Участники
+
+Спасибо всем замечательным людям, которые внесли вклад в Team@Once!
+
+<a href="https://github.com/teamatonce/teamatonce/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=teamatonce/teamatonce&anon=1&max=100&columns=10" />
+</a>
+
+Хотите увидеть здесь своё имя? Ознакомьтесь с нашим [Руководством по участию](CONTRIBUTING.md) и начните вносить свой вклад уже сегодня!
+
+## Активность проекта
+
+<p align="center">
+  <img src="https://img.shields.io/github/stars/teamatonce/teamatonce?style=for-the-badge&logo=github&color=yellow" alt="Stars">
+  <img src="https://img.shields.io/github/forks/teamatonce/teamatonce?style=for-the-badge&logo=github&color=blue" alt="Forks">
+  <img src="https://img.shields.io/github/contributors/teamatonce/teamatonce?style=for-the-badge&logo=github&color=green" alt="Contributors">
+  <img src="https://img.shields.io/github/last-commit/teamatonce/teamatonce?style=for-the-badge&logo=github&color=orange" alt="Last Commit">
+</p>
+
+## Безопасность
+
+Пожалуйста, сообщайте об уязвимостях безопасности ответственно. См. [SECURITY.md](SECURITY.md).
+
+## Лицензия
+
+Этот проект лицензирован под [GNU Affero General Public License v3.0](LICENSE).
+
+Copyright 2025 Team@Once Contributors.

--- a/README_ZH.md
+++ b/README_ZH.md
@@ -4,19 +4,191 @@
   </a>
   <h1 align="center">Team@Once</h1>
   <p align="center"><strong>开源AI驱动的开发外包平台</strong></p>
-  <p align="center">通过智能自动化和透明流程，革新软件开发外包。</p>
+  <p align="center">通过智能自动化、透明流程和无缝协作，革新软件开发外包。</p>
 </p>
 
 <p align="center">
-  <a href="./README.md">English</a> | <a href="./README_JA.md">日本語</a> | <a href="./README_ZH.md">中文</a> | <a href="./README_KO.md">한국어</a> | <a href="./README_ES.md">Español</a> | <a href="./README_FR.md">Français</a> | <a href="./README_DE.md">Deutsch</a> | <a href="./README_PT-BR.md">Português</a> | <a href="./README_RU.md">Русский</a>
+  <a href="https://github.com/teamatonce/teamatonce/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue.svg" alt="License"></a>
+  <a href="https://github.com/teamatonce/teamatonce/stargazers"><img src="https://img.shields.io/github/stars/teamatonce/teamatonce?style=social" alt="GitHub Stars"></a>
+  <a href="https://github.com/teamatonce/teamatonce/issues"><img src="https://img.shields.io/github/issues/teamatonce/teamatonce" alt="Issues"></a>
+</p>
+
+<p align="center">
+  <a href="https://teamatonce.com">官网</a> |
+  <a href="#快速开始">快速开始</a> |
+  <a href="#功能特性">功能特性</a> |
+  <a href="https://github.com/teamatonce/teamatonce/discussions">讨论区</a> |
+  <a href="CONTRIBUTING.md">参与贡献</a>
+</p>
+
+<p align="center">
+  <a href="./README.md">English</a> |
+  <a href="./README_JA.md">日本語</a> |
+  <a href="./README_ZH.md">中文</a> |
+  <a href="./README_KO.md">한국어</a> |
+  <a href="./README_ES.md">Español</a> |
+  <a href="./README_FR.md">Français</a> |
+  <a href="./README_DE.md">Deutsch</a> |
+  <a href="./README_PT-BR.md">Português</a> |
+  <a href="./README_AR.md">العربية</a> |
+  <a href="./README_HI.md">हिन्दी</a> |
+  <a href="./README_RU.md">Русский</a>
 </p>
 
 ---
 
-<p align="center"><a href="./README.md">English</a> | <a href="./README_JA.md">日本語</a> | <a href="./README_ZH.md">中文</a> | <a href="./README_KO.md">한국어</a> | <a href="./README_ES.md">Español</a> | <a href="./README_FR.md">Français</a> | <a href="./README_DE.md">Deutsch</a> | <a href="./README_PT-BR.md">Português</a> | <a href="./README_AR.md">العربية</a> | <a href="./README_HI.md">हिन्दी</a> | <a href="./README_RU.md">Русский</a></p>
+## Team@Once 是什么？
 
-[English README](./README.md)
+Team@Once 是一个开源的 AI 驱动开发外包市场平台，通过智能自动化、AI 驱动的评估、托管支付和实时项目管理，消除传统外包风险。
 
-## License
+## 为什么选择 Team@Once？（对比）
 
-[GNU AGPL 3.0](LICENSE)
+| 功能 | Team@Once | Upwork | Toptal | Fiverr | Deel |
+|---------|-----------|--------|--------|--------|------|
+| **AI 智能匹配** | ✅ NLP + 智能匹配 | ❌ | ⚠️ 人工审核 | ❌ | ❌ |
+| **内置项目管理** | ✅ 看板、里程碑、时间追踪 | ⚠️ 基础功能 | ❌ | ❌ | ❌ |
+| **托管支付** | ✅ 基于里程碑 | ✅ | ✅ | ✅ | ❌ |
+| **视频协作** | ✅ 内置通话 + 屏幕共享 | ❌ | ❌ | ❌ | ❌ |
+| **技能评估** | ✅ AI 生成 + 证书 | ⚠️ 基础测试 | ✅ 严格筛选 | ⚠️ 基础功能 | ❌ |
+| **学习路径** | ✅ 课程 + 认证 | ❌ | ❌ | ❌ | ❌ |
+| **实时聊天** | ✅ 频道 + 文件共享 | ⚠️ 基础功能 | ❌ | ⚠️ 基础功能 | ❌ |
+| **团队工作区** | ✅ 多项目组织 | ❌ | ❌ | ❌ | ❌ |
+| **数据引擎** | ✅ 企业发现爬虫 | ❌ | ❌ | ❌ | ❌ |
+| **智能合同** | ✅ 自动生成 + 电子签名 | ⚠️ 基础功能 | ❌ | ⚠️ 基础功能 | ✅ |
+| **API 访问** | ✅ 完整 REST API | ⚠️ 部分支持 | ❌ | ❌ | ✅ |
+| **自托管** | ✅ Docker Compose | ❌ | ❌ | ❌ | ❌ |
+| **开源** | ✅ AGPL 3.0 | ❌ | ❌ | ❌ | ❌ |
+| **平台费用** | 🟢 3-5% | 💰 10-20% | 💰 约2倍加价 | 💰 20% | 💰 定制 |
+| **国际化** | ✅ 11 种语言 | ✅ | ✅ | ✅ | ✅ |
+
+## 功能特性
+
+### 市场平台
+- **企业档案** -- 展示作品集、团队技能和认证
+- **AI 智能匹配** -- 基于技能和业绩记录的智能企业-项目匹配
+- **数据引擎** -- 用于企业发现和信息丰富的网页爬取与数据管道
+- **托管支付** -- 通过 Stripe 实现安全的基于里程碑的支付
+
+### 学习与认证
+- **课程管理** -- 创建和管理包含模块与课时的技术课程
+- **AI 评估** -- AI 生成的测验和技能评估
+- **证书** -- 可验证的成就证书
+- **学习路径** -- 结构化的技能发展路线
+- **成就系统** -- 通过徽章和进度追踪实现游戏化
+
+### 协作
+- **项目管理** -- 通过里程碑和可交付成果追踪项目
+- **讨论论坛** -- 社区讨论和知识共享
+- **实时通知** -- 基于 WebSocket 的实时更新
+- **博客** -- 文章和指南的内容管理
+- **学习小组** -- 协作学习空间
+
+### 平台
+- **AI 集成** -- OpenAI 驱动的内容生成和分析
+- **搜索** -- Qdrant 向量搜索，实现语义化内容发现
+- **多语言** -- 国际化支持
+- **管理后台** -- 平台管理和数据分析
+- **SEO** -- 服务端渲染和元数据优化
+
+## 技术栈
+
+| 层级 | 技术 |
+|-------|------------|
+| **后端** | NestJS 11, TypeScript, PostgreSQL (原生 SQL), Redis, Qdrant, Socket.io |
+| **前端** | React 19, Vite, TypeScript, Tailwind CSS, Radix UI, Zustand |
+| **AI** | OpenAI (GPT-4o-mini, embeddings) |
+| **支付** | Stripe（托管、订阅） |
+| **搜索** | Qdrant（向量搜索） |
+
+## 前提条件
+
+- **Node.js** >= 18
+- **Docker**（推荐）或本地安装 PostgreSQL 15+、Redis 和 Qdrant
+
+## 快速开始
+
+### 1. 启动服务
+
+使用 Docker 运行 PostgreSQL、Redis 和 Qdrant 是最简单的方式：
+
+```bash
+git clone https://github.com/teamatonce/teamatonce.git
+cd teamatonce
+docker compose up -d
+```
+
+这将启动所有必需的服务，凭证与 `.env.example` 开箱即用地匹配。
+
+<details>
+<summary>不使用 Docker（手动安装）</summary>
+
+自行安装并启动 PostgreSQL、Redis 和 Qdrant，然后使用您的连接信息更新 `backend/.env`：
+
+```bash
+# PostgreSQL — 创建开发数据库
+createdb -U postgres teamatonce_dev
+
+# 将 backend/.env 中的 DATABASE_PASSWORD 更新为您的 PostgreSQL 密码
+```
+
+</details>
+
+### 2. 后端
+
+```bash
+cd backend
+cp .env.example .env    # 凭证已与 docker-compose.yml 匹配
+npm install
+npm run migrate
+npm run start:dev
+```
+
+### 3. 前端（新终端）
+
+```bash
+cd frontend
+npm install
+npm run dev
+```
+
+## 项目结构
+
+```
+teamatonce/
+├── backend/              # NestJS API（34 个模块）
+│   ├── src/modules/      # auth, company, courses, assessments, ai, search,
+│   │                     # escrow, certificates, learning-paths, blog, ...
+│   └── migrations/       # PostgreSQL 数据库迁移
+├── frontend/             # React + Vite + Tailwind
+│   └── src/
+└── .github/workflows/    # CI/CD
+```
+
+## 贡献者
+
+感谢所有为 Team@Once 做出贡献的优秀人们！🎉
+
+<a href="https://github.com/teamatonce/teamatonce/graphs/contributors">
+  <img src="https://contrib.rocks/image?repo=teamatonce/teamatonce&anon=1&max=100&columns=10" />
+</a>
+
+想在这里看到你的头像？查看我们的[贡献指南](CONTRIBUTING.md)，今天就开始参与贡献吧！
+
+## 项目活动
+
+<p align="center">
+  <img src="https://img.shields.io/github/stars/teamatonce/teamatonce?style=for-the-badge&logo=github&color=yellow" alt="Stars">
+  <img src="https://img.shields.io/github/forks/teamatonce/teamatonce?style=for-the-badge&logo=github&color=blue" alt="Forks">
+  <img src="https://img.shields.io/github/contributors/teamatonce/teamatonce?style=for-the-badge&logo=github&color=green" alt="Contributors">
+  <img src="https://img.shields.io/github/last-commit/teamatonce/teamatonce?style=for-the-badge&logo=github&color=orange" alt="Last Commit">
+</p>
+
+## 安全
+
+请以负责任的方式报告安全漏洞。详见 [SECURITY.md](SECURITY.md)。
+
+## 许可证
+
+本项目基于 [GNU Affero 通用公共许可证 v3.0](LICENSE) 授权。
+
+版权所有 2025 Team@Once 贡献者。


### PR DESCRIPTION
Previously these were stubs linking back to the English README. Now each contains the complete translation including all sections: features, comparison table, tech stack, quick start, project structure, and more.

Languages: JA, ZH, KO, ES, FR, DE, PT-BR, AR, HI, RU

