### PR TITLE
feat(storage): pluggable storage provider (local-fs/s3/r2/minio/b2/gcs/azure)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -91,3 +91,43 @@ OPENAI_MODEL=gpt-4o-mini
 QDRANT_HOST=localhost
 QDRANT_PORT=6333
 QDRANT_API_KEY=your_qdrant_api_key
+
+# =====================================================
+# FILE STORAGE
+# =====================================================
+# Pick a provider. local-fs needs zero setup and is the recommended
+# starting point. See backend/docs/providers/storage.md for the full
+# comparison and per-provider env vars.
+#
+# Valid values:
+#   local-fs | s3 | r2 | minio | b2 | gcs | azure | none
+
+STORAGE_PROVIDER=local-fs
+
+# --- local-fs (default, zero infra) ---
+LOCAL_FS_PATH=./data/uploads
+LOCAL_FS_PUBLIC_URL=/uploads
+LOCAL_FS_SIGNING_KEY=change_me_to_a_long_random_string
+
+# --- S3-compatible (s3 / r2 / minio / b2) ---
+STORAGE_BUCKET=teamatonce-dev
+STORAGE_REGION=auto
+STORAGE_ACCESS_KEY_ID=
+STORAGE_SECRET_ACCESS_KEY=
+STORAGE_ENDPOINT=
+STORAGE_PUBLIC_URL=
+STORAGE_FORCE_PATH_STYLE=false
+
+# --- Google Cloud Storage (gcs, optional dep) ---
+GCS_PROJECT_ID=
+GCS_KEY_FILE=
+
+# --- Azure Blob Storage (azure, optional dep) ---
+AZURE_STORAGE_CONNECTION_STRING=
+
+# Legacy R2_* env vars (kept for backwards compatibility)
+R2_ACCOUNT_ID=
+R2_ACCESS_KEY_ID=
+R2_SECRET_ACCESS_KEY=
+R2_BUCKET_NAME=
+R2_PUBLIC_URL=

--- a/backend/docs/providers/storage.md
+++ b/backend/docs/providers/storage.md
@@ -1,0 +1,168 @@
+# Storage providers
+
+Vasty Shop supports eight file storage backends plus a `none` default.
+Pick one by setting `STORAGE_PROVIDER` in your `.env`.
+
+```
+STORAGE_PROVIDER=local-fs   # zero-infra default
+```
+
+## Comparison
+
+| Provider | Free tier | Infra needed | Package | Signed URLs | Best for |
+|---|---|---|---|---|---|
+| **local-fs** *(recommended default for dev)* | ♾️ | none | built-in | HMAC-signed | getting started, small self-hosted |
+| **s3** | 5GB free tier for 12 mo | AWS account | `@aws-sdk/client-s3` | native | US/EU/global, scale |
+| **r2** *(current hardcoded impl)* | 10GB free forever | Cloudflare account | `@aws-sdk/client-s3` | native | cheap egress |
+| **minio** | ♾️ | self-host MinIO | `@aws-sdk/client-s3` | native | private cloud, homelab |
+| **b2** | 10GB free | Backblaze account | `@aws-sdk/client-s3` | native | cheapest egress of the big names |
+| **gcs** | 5GB free | GCP account | `@google-cloud/storage` *(optional)* | native | GCP deployments |
+| **azure** | 5GB free for 12 mo | Azure account | `@azure/storage-blob` *(optional)* | native | Azure deployments |
+| **none** | — | — | — | — | default — storage features disabled |
+
+## Which should I pick?
+
+- **"I just cloned the repo, I don't have any cloud accounts"** → `local-fs` (zero infra, writes under `./data/uploads`)
+- **Small self-hosted production** → `local-fs` or `minio` (both self-hosted, no vendor lock-in)
+- **Existing Cloudflare setup** → `r2` (cheapest egress, S3-compatible)
+- **Already on AWS** → `s3`
+- **Already on GCP** → `gcs`
+- **Already on Azure** → `azure`
+
+## Per-provider setup
+
+### local-fs (recommended default)
+
+No setup required. Uploads go to `./data/uploads/<bucket>/<key>` on the
+backend host. A companion static-serve route (wired up by the follow-up
+install PR) serves them at `LOCAL_FS_PUBLIC_URL` (default `/uploads`).
+
+```
+STORAGE_PROVIDER=local-fs
+LOCAL_FS_PATH=./data/uploads
+LOCAL_FS_PUBLIC_URL=/uploads
+LOCAL_FS_SIGNING_KEY=replace-with-a-long-random-string
+```
+
+**Signed URLs**: HMAC-SHA256 over `<bucket>/<key>:<expiresAt>`. The
+internal static-serve route validates the `?exp=` and `?sig=` query
+params before streaming the file.
+
+**Persistence warning**: files live on the backend container's
+filesystem. Mount `./data/uploads` to a named Docker volume in
+production so they survive container rebuilds.
+
+**Path traversal**: rejected at put/get/delete time. Any key containing
+`..` that resolves outside the bucket directory raises an error.
+
+### s3 (AWS)
+
+Create a bucket, an IAM user with `s3:PutObject` / `GetObject` /
+`DeleteObject` / `ListBucket` on it, copy the keys.
+
+```
+STORAGE_PROVIDER=s3
+STORAGE_BUCKET=my-vasty-bucket
+STORAGE_REGION=us-east-1
+STORAGE_ACCESS_KEY_ID=AKIA...
+STORAGE_SECRET_ACCESS_KEY=...
+STORAGE_PUBLIC_URL=https://cdn.example.com   # optional: CDN override
+```
+
+### r2 (Cloudflare)
+
+Grab an R2 access key from the Cloudflare dashboard. You have two
+equivalent ways to configure it:
+
+**Option A — new `STORAGE_*` layout (recommended):**
+```
+STORAGE_PROVIDER=r2
+STORAGE_ACCESS_KEY_ID=...
+STORAGE_SECRET_ACCESS_KEY=...
+STORAGE_ENDPOINT=https://<account>.r2.cloudflarestorage.com
+STORAGE_BUCKET=my-bucket
+STORAGE_PUBLIC_URL=https://cdn.example.com
+```
+
+**Option B — legacy `R2_*` layout (backwards compatible):**
+```
+R2_ACCOUNT_ID=...
+R2_ACCESS_KEY_ID=...
+R2_SECRET_ACCESS_KEY=...
+R2_PUBLIC_URL=https://cdn.example.com
+```
+
+If you leave `STORAGE_PROVIDER` unset but the `R2_*` vars exist, the
+factory auto-infers `r2` to keep existing `.env` files working. A
+deprecation warning is logged — plan to rename.
+
+### minio (self-hosted)
+
+Run MinIO in Docker (via the provided `--profile minio` compose profile
+once install PR #24 lands, or any `minio/minio` image). Default admin
+creds on a fresh dev install: `minioadmin` / `minioadmin`.
+
+```
+STORAGE_PROVIDER=minio
+STORAGE_ENDPOINT=http://localhost:9000
+STORAGE_ACCESS_KEY_ID=minioadmin
+STORAGE_SECRET_ACCESS_KEY=minioadmin
+STORAGE_BUCKET=vasty-dev
+STORAGE_FORCE_PATH_STYLE=true        # required for localhost MinIO
+```
+
+### b2 (Backblaze)
+
+Create an application key with access to your bucket.
+
+```
+STORAGE_PROVIDER=b2
+STORAGE_REGION=us-west-002
+STORAGE_ENDPOINT=https://s3.us-west-002.backblazeb2.com
+STORAGE_ACCESS_KEY_ID=...
+STORAGE_SECRET_ACCESS_KEY=...
+STORAGE_BUCKET=my-bucket
+```
+
+### gcs (Google Cloud Storage)
+
+`@google-cloud/storage` is in **optionalDependencies**. When you run
+`npm install` with `STORAGE_PROVIDER=gcs`, npm installs it
+automatically. If you pick a different provider, it's never downloaded.
+
+```
+STORAGE_PROVIDER=gcs
+GCS_PROJECT_ID=your-project
+GCS_KEY_FILE=/path/to/service-account.json    # or rely on ADC
+STORAGE_BUCKET=your-bucket
+```
+
+### azure (Azure Blob Storage)
+
+`@azure/storage-blob` is in **optionalDependencies**.
+
+```
+STORAGE_PROVIDER=azure
+AZURE_STORAGE_CONNECTION_STRING=DefaultEndpointsProtocol=https;AccountName=...
+STORAGE_BUCKET=my-container
+```
+
+> ⚠️ The current Azure provider returns the public URL from
+> `getSignedUrl` instead of a real SAS token. For private containers,
+> implement `generateBlobSASQueryParameters` as a follow-up.
+
+### none (default when no provider is set)
+
+Every method throws `StorageProviderNotConfiguredError`. The startup
+log prints exactly which env var to set to enable storage.
+
+## Adding a new provider
+
+1. Implement `StorageProvider` in
+   `backend/src/modules/storage/providers/<name>.provider.ts`
+2. Add a case to `createStorageProvider()` in `providers/index.ts`
+3. Document env vars in this file and in `.env.example`
+4. If the provider needs an SDK, declare it in `optionalDependencies`
+   in `backend/package.json` and `require()` it inside a `loadSdk()`
+   method — never at the top of the file. See `gcs.provider.ts` for
+   the pattern.

--- a/backend/package.json
+++ b/backend/package.json
@@ -80,6 +80,10 @@
     "stripe": "^22.0.1",
     "uuid": "^11.1.0"
   },
+  "optionalDependencies": {
+    "@google-cloud/storage": "^7.11.0",
+    "@azure/storage-blob": "^12.17.0"
+  },
   "devDependencies": {
     "@nestjs/cli": "^11.0.14",
     "@nestjs/schematics": "^11.0.7",

--- a/backend/scripts/smoke-test-storage-providers.ts
+++ b/backend/scripts/smoke-test-storage-providers.ts
@@ -1,0 +1,242 @@
+/**
+ * Smoke test for the multi-provider storage factory.
+ *
+ * Exercises the factory + each provider against the real filesystem (for
+ * local-fs) and against mocked availability checks (for the cloud providers
+ * that need real credentials). Does NOT hit any remote service.
+ *
+ * Run with: npx ts-node scripts/smoke-test-storage-providers.ts
+ */
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { ConfigService } from '@nestjs/config';
+import {
+  createStorageProvider,
+  StorageProviderNotConfiguredError,
+} from '../src/modules/storage/providers';
+
+function fakeConfig(env: Record<string, string>): ConfigService {
+  return {
+    get: <T>(key: string, def?: T) => (env[key] as any) ?? def,
+  } as unknown as ConfigService;
+}
+
+async function expectThrow(
+  label: string,
+  fn: () => Promise<unknown>,
+  matcher: (e: Error) => boolean,
+): Promise<boolean> {
+  try {
+    await fn();
+    console.log(`  ❌ ${label}: expected throw, got success`);
+    return false;
+  } catch (e) {
+    if (matcher(e as Error)) {
+      console.log(`  ✅ ${label}: threw as expected`);
+      return true;
+    }
+    console.log(`  ❌ ${label}: wrong error: ${(e as Error).message}`);
+    return false;
+  }
+}
+
+async function main(): Promise<void> {
+  let pass = 0;
+  let fail = 0;
+  const ok = (b: boolean) => (b ? pass++ : fail++);
+  console.log('=== Storage provider factory smoke test ===\n');
+
+  // 1. none (no env at all, no legacy R2)
+  console.log('1. no STORAGE_PROVIDER, no legacy R2 → none');
+  {
+    const p = createStorageProvider(fakeConfig({}));
+    ok(p.name === 'none');
+    console.log(`  ✅ factory returned: ${p.name}`);
+    ok(p.isAvailable() === false);
+    console.log(`  ✅ isAvailable()=false`);
+    ok(
+      await expectThrow(
+        'put fails loudly',
+        () => p.put('bucket', 'key', Buffer.from('x')),
+        (e) => e instanceof StorageProviderNotConfiguredError,
+      ),
+    );
+  }
+
+  // 2. legacy R2 env vars → infer r2
+  console.log('\n2. legacy R2_* vars set (no STORAGE_PROVIDER) → r2');
+  {
+    const p = createStorageProvider(
+      fakeConfig({
+        R2_ACCOUNT_ID: 'abc123',
+        R2_ACCESS_KEY_ID: 'key',
+        R2_SECRET_ACCESS_KEY: 'secret',
+      }),
+    );
+    ok(p.name === 'r2');
+    console.log(`  ✅ inferred: ${p.name}`);
+    ok(p.isAvailable() === true);
+    console.log(`  ✅ isAvailable()=true`);
+  }
+
+  // 3. local-fs with a temp dir — full happy path
+  console.log('\n3. local-fs (real filesystem happy path)');
+  {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'vasty-storage-'));
+    try {
+      const p = createStorageProvider(
+        fakeConfig({
+          STORAGE_PROVIDER: 'local-fs',
+          LOCAL_FS_PATH: tmp,
+          LOCAL_FS_PUBLIC_URL: '/uploads',
+        }),
+      );
+      ok(p.name === 'local-fs');
+      ok(p.isAvailable() === true);
+      console.log(`  ✅ factory + availability`);
+
+      const body = Buffer.from('hello world', 'utf-8');
+      const put = await p.put('products', 'images/abc.jpg', body, {
+        contentType: 'image/jpeg',
+      });
+      ok(put.size === body.length);
+      ok(put.url === '/uploads/products/images/abc.jpg');
+      console.log(`  ✅ put → ${put.url}`);
+
+      const exists = await p.exists('products', 'images/abc.jpg');
+      ok(exists === true);
+      console.log(`  ✅ exists=true`);
+
+      const got = await p.get('products', 'images/abc.jpg');
+      ok(got.toString('utf-8') === 'hello world');
+      console.log(`  ✅ round-trip read`);
+
+      const listed = await p.list('products', 'images');
+      ok(listed.length === 1 && listed[0].key.endsWith('abc.jpg'));
+      console.log(`  ✅ list returned ${listed.length} object`);
+
+      const signed = await p.getSignedUrl(
+        'products',
+        'images/abc.jpg',
+        60,
+      );
+      ok(/\?exp=\d+&sig=[a-f0-9]+$/.test(signed));
+      console.log(`  ✅ signed URL: ${signed.slice(0, 60)}...`);
+
+      await p.delete('products', 'images/abc.jpg');
+      const stillExists = await p.exists('products', 'images/abc.jpg');
+      ok(stillExists === false);
+      console.log(`  ✅ delete worked`);
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  }
+
+  // 4. local-fs rejects path traversal
+  console.log('\n4. local-fs rejects path traversal');
+  {
+    const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'vasty-storage-'));
+    try {
+      const p = createStorageProvider(
+        fakeConfig({ STORAGE_PROVIDER: 'local-fs', LOCAL_FS_PATH: tmp }),
+      );
+      ok(
+        await expectThrow(
+          'put with ../../ rejected',
+          () => p.put('b', '../../etc/passwd', Buffer.from('x')),
+          (e) => /path traversal/.test(e.message),
+        ),
+      );
+    } finally {
+      fs.rmSync(tmp, { recursive: true, force: true });
+    }
+  }
+
+  // 5. s3 without creds → unavailable
+  console.log('\n5. STORAGE_PROVIDER=s3 without creds → unavailable');
+  {
+    const p = createStorageProvider(fakeConfig({ STORAGE_PROVIDER: 's3' }));
+    ok(p.name === 's3');
+    ok(p.isAvailable() === false);
+    console.log(`  ✅ factory + unavailable`);
+    ok(
+      await expectThrow(
+        'put throws NotConfigured',
+        () => p.put('b', 'k', Buffer.from('x')),
+        (e) => e instanceof StorageProviderNotConfiguredError,
+      ),
+    );
+  }
+
+  // 6. r2 with STORAGE_* set
+  console.log('\n6. STORAGE_PROVIDER=r2 with STORAGE_* vars → available');
+  {
+    const p = createStorageProvider(
+      fakeConfig({
+        STORAGE_PROVIDER: 'r2',
+        STORAGE_ACCESS_KEY_ID: 'k',
+        STORAGE_SECRET_ACCESS_KEY: 's',
+        STORAGE_ENDPOINT: 'https://account.r2.cloudflarestorage.com',
+      }),
+    );
+    ok(p.name === 'r2');
+    ok(p.isAvailable() === true);
+    console.log(`  ✅ r2 configured via STORAGE_*`);
+  }
+
+  // 7. minio without endpoint → unavailable (endpoint is required)
+  console.log('\n7. STORAGE_PROVIDER=minio without endpoint → unavailable');
+  {
+    const p = createStorageProvider(
+      fakeConfig({
+        STORAGE_PROVIDER: 'minio',
+        STORAGE_ACCESS_KEY_ID: 'k',
+        STORAGE_SECRET_ACCESS_KEY: 's',
+      }),
+    );
+    ok(p.name === 'minio');
+    ok(p.isAvailable() === false);
+    console.log(`  ✅ minio requires STORAGE_ENDPOINT`);
+  }
+
+  // 8. unknown → fall back to none with warning
+  console.log('\n8. STORAGE_PROVIDER=foobar → none (fallback)');
+  {
+    const p = createStorageProvider(fakeConfig({ STORAGE_PROVIDER: 'foobar' }));
+    ok(p.name === 'none');
+    console.log(`  ✅ unknown fell back to: ${p.name}`);
+  }
+
+  // 9. gcs / azure instantiate without SDK installed (they lazy-load at call time)
+  console.log('\n9. gcs instantiates with project id (SDK lazy-loaded)');
+  {
+    const p = createStorageProvider(
+      fakeConfig({
+        STORAGE_PROVIDER: 'gcs',
+        GCS_PROJECT_ID: 'my-project',
+      }),
+    );
+    ok(p.name === 'gcs');
+    ok(p.isAvailable() === true);
+    console.log(`  ✅ gcs available=true (SDK not yet loaded)`);
+  }
+
+  console.log('\n10. azure without connection string → unavailable');
+  {
+    const p = createStorageProvider(
+      fakeConfig({ STORAGE_PROVIDER: 'azure' }),
+    );
+    ok(p.name === 'azure');
+    ok(p.isAvailable() === false);
+    console.log(`  ✅ azure requires connection string`);
+  }
+
+  console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+  process.exit(fail > 0 ? 1 : 0);
+}
+
+main().catch((e) => {
+  console.error('Smoke test crashed:', e);
+  process.exit(1);
+});

--- a/backend/src/modules/storage/providers/azure.provider.ts
+++ b/backend/src/modules/storage/providers/azure.provider.ts
@@ -1,0 +1,157 @@
+/**
+ * Azure Blob Storage provider.
+ *
+ *   STORAGE_PROVIDER=azure
+ *   AZURE_STORAGE_CONNECTION_STRING=...
+ *   STORAGE_BUCKET=my-container      (Azure calls buckets "containers")
+ *
+ * The `@azure/storage-blob` package is an OPTIONAL dependency — lazy-loaded
+ * inside loadSdk() only when the provider is selected, and declared in
+ * optionalDependencies in package.json.
+ */
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  ListedObject,
+  PutOptions,
+  PutResult,
+  StorageProvider,
+  StorageProviderNotConfiguredError,
+} from './storage-provider.interface';
+
+export class AzureProvider implements StorageProvider {
+  readonly name = 'azure' as const;
+  private readonly logger = new Logger('AzureProvider');
+
+  private readonly connectionString: string;
+  private readonly publicUrl?: string;
+
+  private sdkLoaded = false;
+  private client: any;
+
+  constructor(config: ConfigService) {
+    this.connectionString = config.get<string>(
+      'AZURE_STORAGE_CONNECTION_STRING',
+      '',
+    );
+    this.publicUrl = config.get<string>('STORAGE_PUBLIC_URL');
+
+    if (this.isAvailable()) {
+      this.logger.log('Azure Blob configured');
+    } else {
+      this.logger.warn(
+        'Azure provider selected but AZURE_STORAGE_CONNECTION_STRING missing',
+      );
+    }
+  }
+
+  isAvailable(): boolean {
+    return !!this.connectionString;
+  }
+
+  private loadSdk() {
+    if (this.sdkLoaded) return;
+    if (!this.isAvailable()) {
+      throw new StorageProviderNotConfiguredError('azure', [
+        'AZURE_STORAGE_CONNECTION_STRING',
+      ]);
+    }
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const sdk = require('@azure/storage-blob');
+      this.client = sdk.BlobServiceClient.fromConnectionString(
+        this.connectionString,
+      );
+      this.sdkLoaded = true;
+      this.logger.log('@azure/storage-blob loaded');
+    } catch (e: any) {
+      throw new Error(
+        `Azure provider selected but "@azure/storage-blob" is not installed. ` +
+          `Run: npm install @azure/storage-blob    Original: ${e.message}`,
+      );
+    }
+  }
+
+  async put(
+    bucket: string,
+    key: string,
+    body: Buffer,
+    options?: PutOptions,
+  ): Promise<PutResult> {
+    this.loadSdk();
+    const containerClient = this.client.getContainerClient(bucket);
+    await containerClient.createIfNotExists();
+    const blockBlobClient = containerClient.getBlockBlobClient(key);
+    await blockBlobClient.uploadData(body, {
+      blobHTTPHeaders: {
+        blobContentType: options?.contentType ?? 'application/octet-stream',
+        blobCacheControl: options?.cacheControl,
+      },
+      metadata: options?.metadata,
+    });
+    return {
+      path: key,
+      url: this.getPublicUrl(bucket, key),
+      size: body.length,
+    };
+  }
+
+  async get(bucket: string, key: string): Promise<Buffer> {
+    this.loadSdk();
+    const blobClient = this.client.getContainerClient(bucket).getBlobClient(key);
+    return await blobClient.downloadToBuffer();
+  }
+
+  async delete(bucket: string, key: string): Promise<void> {
+    this.loadSdk();
+    await this.client
+      .getContainerClient(bucket)
+      .getBlobClient(key)
+      .deleteIfExists();
+  }
+
+  async exists(bucket: string, key: string): Promise<boolean> {
+    this.loadSdk();
+    return await this.client
+      .getContainerClient(bucket)
+      .getBlobClient(key)
+      .exists();
+  }
+
+  async list(bucket: string, prefix?: string): Promise<ListedObject[]> {
+    this.loadSdk();
+    const out: ListedObject[] = [];
+    const containerClient = this.client.getContainerClient(bucket);
+    for await (const blob of containerClient.listBlobsFlat({ prefix })) {
+      out.push({
+        key: blob.name,
+        size: Number(blob.properties.contentLength) || 0,
+        lastModified: blob.properties.lastModified ?? new Date(),
+      });
+    }
+    return out;
+  }
+
+  getPublicUrl(bucket: string, key: string): string {
+    if (this.publicUrl) {
+      return `${this.publicUrl.replace(/\/+$/, '')}/${key.replace(/^\/+/, '')}`;
+    }
+    // Best-effort synth from the connection string's account name.
+    const accountMatch = /AccountName=([^;]+)/.exec(this.connectionString);
+    const account = accountMatch?.[1] ?? 'unknown';
+    return `https://${account}.blob.core.windows.net/${bucket}/${key}`;
+  }
+
+  async getSignedUrl(
+    bucket: string,
+    key: string,
+    _expiresInSeconds: number,
+  ): Promise<string> {
+    // Generating SAS tokens requires the shared key credential, which
+    // the connection string gives us. For now we return the public URL —
+    // callers that need real SAS can implement `generateBlobSASQueryParameters`
+    // as a follow-up.
+    this.loadSdk();
+    return this.getPublicUrl(bucket, key);
+  }
+}

--- a/backend/src/modules/storage/providers/gcs.provider.ts
+++ b/backend/src/modules/storage/providers/gcs.provider.ts
@@ -1,0 +1,150 @@
+/**
+ * Google Cloud Storage provider.
+ *
+ *   STORAGE_PROVIDER=gcs
+ *   GCS_PROJECT_ID=your-project
+ *   GCS_KEY_FILE=/path/to/service-account.json    (OR rely on ADC)
+ *   STORAGE_BUCKET=your-bucket
+ *
+ * The `@google-cloud/storage` package is an OPTIONAL dependency — it's
+ * lazy-loaded inside loadSdk() only when the provider is actually selected,
+ * and declared in optionalDependencies in package.json. Users who pick a
+ * different provider never install it.
+ *
+ * If you select gcs but haven't run `npm install @google-cloud/storage`,
+ * the first method call will throw a clear "package not installed" error
+ * pointing at the install command.
+ */
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  ListedObject,
+  PutOptions,
+  PutResult,
+  StorageProvider,
+  StorageProviderNotConfiguredError,
+} from './storage-provider.interface';
+
+export class GcsProvider implements StorageProvider {
+  readonly name = 'gcs' as const;
+  private readonly logger = new Logger('GcsProvider');
+
+  private readonly projectId: string;
+  private readonly keyFile?: string;
+  private readonly publicUrl?: string;
+
+  private sdkLoaded = false;
+  private client: any;
+  private storageClass: any;
+
+  constructor(config: ConfigService) {
+    this.projectId = config.get<string>('GCS_PROJECT_ID', '');
+    this.keyFile = config.get<string>('GCS_KEY_FILE');
+    this.publicUrl = config.get<string>('STORAGE_PUBLIC_URL');
+
+    if (this.isAvailable()) {
+      this.logger.log(`GCS configured (project=${this.projectId})`);
+    } else {
+      this.logger.warn('GCS selected but GCS_PROJECT_ID missing');
+    }
+  }
+
+  isAvailable(): boolean {
+    // keyFile is optional because GCS can use Application Default
+    // Credentials (ADC) when running on GCP, so only projectId is
+    // strictly required.
+    return !!this.projectId;
+  }
+
+  private loadSdk() {
+    if (this.sdkLoaded) return;
+    if (!this.isAvailable()) {
+      throw new StorageProviderNotConfiguredError('gcs', ['GCS_PROJECT_ID']);
+    }
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const sdk = require('@google-cloud/storage');
+      this.storageClass = sdk.Storage;
+      this.client = new sdk.Storage({
+        projectId: this.projectId,
+        keyFilename: this.keyFile,
+      });
+      this.sdkLoaded = true;
+      this.logger.log('@google-cloud/storage loaded');
+    } catch (e: any) {
+      throw new Error(
+        `GCS provider selected but "@google-cloud/storage" is not installed. ` +
+          `Run: npm install @google-cloud/storage    Original: ${e.message}`,
+      );
+    }
+  }
+
+  async put(
+    bucket: string,
+    key: string,
+    body: Buffer,
+    options?: PutOptions,
+  ): Promise<PutResult> {
+    this.loadSdk();
+    const file = this.client.bucket(bucket).file(key);
+    await file.save(body, {
+      contentType: options?.contentType,
+      metadata: options?.metadata
+        ? { metadata: options.metadata, cacheControl: options.cacheControl }
+        : undefined,
+      public: options?.acl === 'public',
+    });
+    return {
+      path: key,
+      url: this.getPublicUrl(bucket, key),
+      size: body.length,
+    };
+  }
+
+  async get(bucket: string, key: string): Promise<Buffer> {
+    this.loadSdk();
+    const [contents] = await this.client.bucket(bucket).file(key).download();
+    return contents as Buffer;
+  }
+
+  async delete(bucket: string, key: string): Promise<void> {
+    this.loadSdk();
+    await this.client.bucket(bucket).file(key).delete({ ignoreNotFound: true });
+  }
+
+  async exists(bucket: string, key: string): Promise<boolean> {
+    this.loadSdk();
+    const [exists] = await this.client.bucket(bucket).file(key).exists();
+    return exists;
+  }
+
+  async list(bucket: string, prefix?: string): Promise<ListedObject[]> {
+    this.loadSdk();
+    const [files] = await this.client.bucket(bucket).getFiles({ prefix });
+    return files.map((f: any) => ({
+      key: f.name,
+      size: Number(f.metadata.size) || 0,
+      lastModified: new Date(f.metadata.updated || Date.now()),
+    }));
+  }
+
+  getPublicUrl(bucket: string, key: string): string {
+    if (this.publicUrl) {
+      return `${this.publicUrl.replace(/\/+$/, '')}/${key.replace(/^\/+/, '')}`;
+    }
+    return `https://storage.googleapis.com/${bucket}/${key}`;
+  }
+
+  async getSignedUrl(
+    bucket: string,
+    key: string,
+    expiresInSeconds: number,
+  ): Promise<string> {
+    this.loadSdk();
+    const [url] = await this.client.bucket(bucket).file(key).getSignedUrl({
+      action: 'read',
+      expires: Date.now() + expiresInSeconds * 1000,
+    });
+    return url;
+  }
+}

--- a/backend/src/modules/storage/providers/index.ts
+++ b/backend/src/modules/storage/providers/index.ts
@@ -1,0 +1,114 @@
+/**
+ * Storage provider factory.
+ *
+ * Reads STORAGE_PROVIDER from config and returns the matching provider.
+ * Also provides a legacy shim: if STORAGE_PROVIDER is unset but the old
+ * R2_* env vars are present, we default to 'r2' so existing vasty-shop
+ * .env files keep working without the operator having to touch anything.
+ *
+ * Add a new provider by:
+ *   1. Implementing StorageProvider in <name>.provider.ts
+ *   2. Adding a case to createStorageProvider() below
+ *   3. Documenting env vars in docs/providers/storage.md
+ */
+import { ConfigService } from '@nestjs/config';
+import { Logger } from '@nestjs/common';
+import { StorageProvider } from './storage-provider.interface';
+import { LocalFsProvider } from './local-fs.provider';
+import { S3Provider } from './s3.provider';
+import { GcsProvider } from './gcs.provider';
+import { AzureProvider } from './azure.provider';
+import { NoneStorageProvider } from './none.provider';
+
+const log = new Logger('StorageProviderFactory');
+
+export function createStorageProvider(config: ConfigService): StorageProvider {
+  let choice = (
+    config.get<string>('STORAGE_PROVIDER') || ''
+  )
+    .toLowerCase()
+    .trim();
+
+  // Legacy shim: if no STORAGE_PROVIDER but R2 env vars exist, infer r2.
+  if (!choice) {
+    const hasLegacyR2 =
+      !!config.get<string>('R2_ACCOUNT_ID') &&
+      !!config.get<string>('R2_ACCESS_KEY_ID') &&
+      !!config.get<string>('R2_SECRET_ACCESS_KEY');
+    if (hasLegacyR2) {
+      log.log(
+        'STORAGE_PROVIDER unset but legacy R2_* env vars detected — using "r2" for backwards compatibility. Consider renaming to STORAGE_*.',
+      );
+      choice = 'r2';
+    } else {
+      choice = 'none';
+    }
+  }
+
+  switch (choice) {
+    case 'local-fs':
+    case 'local':
+    case 'fs':
+    case 'filesystem': {
+      const p = new LocalFsProvider(config);
+      log.log(`Selected storage provider: local-fs (available=${p.isAvailable()})`);
+      return p;
+    }
+    case 's3':
+    case 'aws':
+    case 'aws-s3': {
+      const p = new S3Provider(config, 's3');
+      log.log(`Selected storage provider: s3 (available=${p.isAvailable()})`);
+      return p;
+    }
+    case 'r2':
+    case 'cloudflare':
+    case 'cloudflare-r2': {
+      const p = new S3Provider(config, 'r2');
+      log.log(`Selected storage provider: r2 (available=${p.isAvailable()})`);
+      return p;
+    }
+    case 'minio': {
+      const p = new S3Provider(config, 'minio');
+      log.log(`Selected storage provider: minio (available=${p.isAvailable()})`);
+      return p;
+    }
+    case 'b2':
+    case 'backblaze':
+    case 'backblaze-b2': {
+      const p = new S3Provider(config, 'b2');
+      log.log(`Selected storage provider: b2 (available=${p.isAvailable()})`);
+      return p;
+    }
+    case 'gcs':
+    case 'google':
+    case 'google-cloud':
+    case 'google-cloud-storage': {
+      const p = new GcsProvider(config);
+      log.log(`Selected storage provider: gcs (available=${p.isAvailable()})`);
+      return p;
+    }
+    case 'azure':
+    case 'azure-blob':
+    case 'azure-storage': {
+      const p = new AzureProvider(config);
+      log.log(`Selected storage provider: azure (available=${p.isAvailable()})`);
+      return p;
+    }
+    case 'none':
+    case '':
+      return new NoneStorageProvider();
+    default:
+      log.warn(
+        `Unknown STORAGE_PROVIDER="${choice}". Falling back to "none". Valid values: local-fs, s3, r2, minio, b2, gcs, azure, none.`,
+      );
+      return new NoneStorageProvider();
+  }
+}
+
+export * from './storage-provider.interface';
+export { LocalFsProvider } from './local-fs.provider';
+export { S3Provider } from './s3.provider';
+export { GcsProvider } from './gcs.provider';
+export { AzureProvider } from './azure.provider';
+export { NoneStorageProvider } from './none.provider';

--- a/backend/src/modules/storage/providers/local-fs.provider.ts
+++ b/backend/src/modules/storage/providers/local-fs.provider.ts
@@ -1,0 +1,232 @@
+/**
+ * Local filesystem storage provider.
+ *
+ * THIS IS THE EASIEST OPTION FOR ANYONE SETTING UP VASTY-SHOP TODAY:
+ *
+ *   STORAGE_PROVIDER=local-fs
+ *
+ * That's it. With zero other config, uploaded files are written under
+ * ./data/uploads (or $LOCAL_FS_PATH), organized by bucket, and served via
+ * an internal static route. No S3 credentials, no bucket creation, no
+ * cloud signup. Perfect for dev, small self-hosted deployments, and
+ * contributors who just cloned the repo 2 minutes ago.
+ *
+ * Env vars:
+ *   LOCAL_FS_PATH        - Base directory (default ./data/uploads)
+ *   LOCAL_FS_PUBLIC_URL  - URL prefix the frontend uses to fetch files.
+ *                          Defaults to "/uploads". The backend should
+ *                          serve LOCAL_FS_PATH at this URL via a static
+ *                          route.
+ *   LOCAL_FS_SIGNING_KEY - Secret for HMAC-signing short-lived URLs.
+ *                          Auto-generated if not set (per-process; change
+ *                          means signed URLs from old processes become
+ *                          invalid).
+ *
+ * Signed URLs use HMAC-SHA256 over "bucket/key:expiresAt" and add
+ * `?exp=<timestamp>&sig=<signature>` to the URL. An internal controller
+ * should validate these before serving private files.
+ */
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as fs from 'fs';
+import * as path from 'path';
+import * as crypto from 'crypto';
+import {
+  ListedObject,
+  PutOptions,
+  PutResult,
+  StorageProvider,
+} from './storage-provider.interface';
+
+export class LocalFsProvider implements StorageProvider {
+  readonly name = 'local-fs' as const;
+  private readonly logger = new Logger('LocalFsProvider');
+
+  private readonly basePath: string;
+  private readonly publicUrlPrefix: string;
+  private readonly signingKey: string;
+
+  constructor(config: ConfigService) {
+    this.basePath = path.resolve(
+      config.get<string>('LOCAL_FS_PATH', './data/uploads'),
+    );
+    this.publicUrlPrefix = config
+      .get<string>('LOCAL_FS_PUBLIC_URL', '/uploads')
+      .replace(/\/+$/, '');
+    this.signingKey =
+      config.get<string>('LOCAL_FS_SIGNING_KEY') ??
+      crypto.randomBytes(32).toString('hex');
+
+    // Ensure the base directory exists.
+    try {
+      fs.mkdirSync(this.basePath, { recursive: true });
+      this.logger.log(
+        `LocalFs provider: ${this.basePath} served at ${this.publicUrlPrefix}`,
+      );
+    } catch (e: any) {
+      this.logger.warn(
+        `LocalFs provider: failed to create base path ${this.basePath}: ${e.message}`,
+      );
+    }
+  }
+
+  isAvailable(): boolean {
+    // LocalFs is always available — writing is just fs.writeFile. If the
+    // base path is unwritable, the first put() will throw with a real
+    // error anyway.
+    try {
+      fs.accessSync(this.basePath, fs.constants.W_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Resolve a bucket + key to an absolute filesystem path inside basePath.
+   * Rejects any key that tries to escape via '..'.
+   */
+  private resolvePath(bucket: string, key: string): string {
+    const safeBucket = bucket.replace(/[^a-zA-Z0-9_-]/g, '_');
+    const joined = path.resolve(this.basePath, safeBucket, key);
+    const prefix = path.resolve(this.basePath, safeBucket);
+    if (!joined.startsWith(prefix + path.sep) && joined !== prefix) {
+      throw new Error(`Rejected path traversal in storage key: ${key}`);
+    }
+    return joined;
+  }
+
+  async put(
+    bucket: string,
+    key: string,
+    body: Buffer,
+    options?: PutOptions,
+  ): Promise<PutResult> {
+    const fullPath = this.resolvePath(bucket, key);
+    fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+    fs.writeFileSync(fullPath, body);
+
+    // Store contentType + metadata alongside the file as JSON sidecar
+    // so get() can serve it with the right headers.
+    if (options?.contentType || options?.metadata) {
+      fs.writeFileSync(
+        fullPath + '.meta.json',
+        JSON.stringify(
+          {
+            contentType: options?.contentType ?? 'application/octet-stream',
+            metadata: options?.metadata ?? {},
+            cacheControl: options?.cacheControl,
+            acl: options?.acl ?? 'public',
+          },
+          null,
+          2,
+        ),
+      );
+    }
+
+    return {
+      path: key,
+      url: this.getPublicUrl(bucket, key),
+      size: body.length,
+    };
+  }
+
+  async get(bucket: string, key: string): Promise<Buffer> {
+    return fs.readFileSync(this.resolvePath(bucket, key));
+  }
+
+  async delete(bucket: string, key: string): Promise<void> {
+    const fullPath = this.resolvePath(bucket, key);
+    try {
+      fs.unlinkSync(fullPath);
+    } catch (e: any) {
+      if (e.code !== 'ENOENT') throw e;
+    }
+    // Clean up sidecar if it exists.
+    try {
+      fs.unlinkSync(fullPath + '.meta.json');
+    } catch {
+      /* ignore */
+    }
+  }
+
+  async exists(bucket: string, key: string): Promise<boolean> {
+    try {
+      fs.accessSync(this.resolvePath(bucket, key));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async list(bucket: string, prefix?: string): Promise<ListedObject[]> {
+    const rootDir = this.resolvePath(bucket, prefix ?? '');
+    const out: ListedObject[] = [];
+    const walk = (dir: string, rel: string) => {
+      if (!fs.existsSync(dir)) return;
+      for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+        if (entry.name.endsWith('.meta.json')) continue;
+        const abs = path.join(dir, entry.name);
+        const key = rel ? `${rel}/${entry.name}` : entry.name;
+        if (entry.isDirectory()) {
+          walk(abs, key);
+        } else {
+          const stat = fs.statSync(abs);
+          out.push({
+            key: (prefix ? `${prefix}/${key}` : key).replace(/^\/+/, ''),
+            size: stat.size,
+            lastModified: stat.mtime,
+          });
+        }
+      }
+    };
+    walk(rootDir, '');
+    return out;
+  }
+
+  getPublicUrl(bucket: string, key: string): string {
+    const safeBucket = bucket.replace(/[^a-zA-Z0-9_-]/g, '_');
+    return `${this.publicUrlPrefix}/${safeBucket}/${key.replace(/^\/+/, '')}`;
+  }
+
+  async getSignedUrl(
+    bucket: string,
+    key: string,
+    expiresInSeconds: number,
+  ): Promise<string> {
+    const expiresAt = Math.floor(Date.now() / 1000) + expiresInSeconds;
+    const payload = `${bucket}/${key}:${expiresAt}`;
+    const sig = crypto
+      .createHmac('sha256', this.signingKey)
+      .update(payload)
+      .digest('hex');
+    const base = this.getPublicUrl(bucket, key);
+    return `${base}?exp=${expiresAt}&sig=${sig}`;
+  }
+
+  /**
+   * Verify a signed URL. Exposed for the static-serve controller that
+   * validates incoming ?exp + ?sig query params before reading the file.
+   */
+  verifySignature(
+    bucket: string,
+    key: string,
+    expiresAt: number,
+    sig: string,
+  ): boolean {
+    if (Math.floor(Date.now() / 1000) > expiresAt) return false;
+    const expected = crypto
+      .createHmac('sha256', this.signingKey)
+      .update(`${bucket}/${key}:${expiresAt}`)
+      .digest('hex');
+    // Constant-time compare
+    try {
+      return crypto.timingSafeEqual(
+        Buffer.from(expected),
+        Buffer.from(sig),
+      );
+    } catch {
+      return false;
+    }
+  }
+}

--- a/backend/src/modules/storage/providers/none.provider.ts
+++ b/backend/src/modules/storage/providers/none.provider.ts
@@ -1,0 +1,71 @@
+/**
+ * "None" storage provider — file storage is disabled.
+ *
+ * The default if STORAGE_PROVIDER is unset and no legacy R2_* env vars
+ * are detected. Every method throws StorageProviderNotConfiguredError so
+ * calling code fails loudly rather than silently no-opping.
+ *
+ * Unlike the previous StorageService stub which created an undefined
+ * S3Client and crashed at runtime with cryptic errors, this provider
+ * logs a clear startup message telling the operator which env var to set.
+ */
+import { Logger } from '@nestjs/common';
+import {
+  ListedObject,
+  PutOptions,
+  PutResult,
+  StorageProvider,
+  StorageProviderNotConfiguredError,
+} from './storage-provider.interface';
+
+export class NoneStorageProvider implements StorageProvider {
+  readonly name = 'none' as const;
+  private readonly logger = new Logger('NoneStorageProvider');
+
+  constructor() {
+    this.logger.log(
+      'File storage is DISABLED (STORAGE_PROVIDER not set). To enable, set STORAGE_PROVIDER to one of: local-fs, s3, r2, minio, b2, gcs, azure. See docs/providers/storage.md.',
+    );
+  }
+
+  isAvailable(): boolean {
+    return false;
+  }
+
+  private fail(op: string): never {
+    throw new StorageProviderNotConfiguredError('none', [
+      `STORAGE_PROVIDER (currently unset) - cannot ${op}`,
+    ]);
+  }
+
+  async put(
+    _bucket: string,
+    _key: string,
+    _body: Buffer,
+    _options?: PutOptions,
+  ): Promise<PutResult> {
+    return this.fail('put');
+  }
+  async get(_bucket: string, _key: string): Promise<Buffer> {
+    return this.fail('get');
+  }
+  async delete(_bucket: string, _key: string): Promise<void> {
+    return this.fail('delete');
+  }
+  async exists(_bucket: string, _key: string): Promise<boolean> {
+    return false;
+  }
+  async list(_bucket: string, _prefix?: string): Promise<ListedObject[]> {
+    return [];
+  }
+  getPublicUrl(_bucket: string, _key: string): string {
+    return '';
+  }
+  async getSignedUrl(
+    _bucket: string,
+    _key: string,
+    _expiresInSeconds: number,
+  ): Promise<string> {
+    return this.fail('getSignedUrl');
+  }
+}

--- a/backend/src/modules/storage/providers/s3.provider.ts
+++ b/backend/src/modules/storage/providers/s3.provider.ts
@@ -1,0 +1,233 @@
+/**
+ * S3-compatible storage provider.
+ *
+ * Handles AWS S3 and every S3-compatible service (Cloudflare R2, MinIO,
+ * Backblaze B2) via the same @aws-sdk/client-s3 codepath. The "flavor"
+ * just changes the endpoint URL.
+ *
+ *   STORAGE_PROVIDER=s3     -> AWS S3 (no endpoint override)
+ *   STORAGE_PROVIDER=r2     -> Cloudflare R2 (endpoint: https://<account>.r2.cloudflarestorage.com)
+ *   STORAGE_PROVIDER=minio  -> requires STORAGE_ENDPOINT (e.g. http://localhost:9000)
+ *   STORAGE_PROVIDER=b2     -> Backblaze B2 (endpoint: https://s3.<region>.backblazeb2.com)
+ *
+ * Required env vars:
+ *   STORAGE_ACCESS_KEY_ID
+ *   STORAGE_SECRET_ACCESS_KEY
+ *   STORAGE_BUCKET           - the default bucket (individual put/get calls
+ *                              still take a bucket, but this is the one the
+ *                              app uses when callers don't specify)
+ *
+ * Optional env vars:
+ *   STORAGE_REGION           - default 'auto' (works for R2), 'us-east-1' for AWS
+ *   STORAGE_ENDPOINT         - override endpoint (required for MinIO, optional
+ *                              for R2 if R2_ACCOUNT_ID is set instead)
+ *   STORAGE_PUBLIC_URL       - CDN / public URL prefix for getPublicUrl()
+ *   STORAGE_FORCE_PATH_STYLE - 'true' for MinIO (virtual-host style doesn't
+ *                              work with localhost); default false
+ *
+ * Legacy env var shim:
+ *   If R2_ACCOUNT_ID + R2_ACCESS_KEY_ID + R2_SECRET_ACCESS_KEY are set
+ *   (the pre-adapter vasty-shop layout), this provider reads them when
+ *   STORAGE_PROVIDER=r2 and the STORAGE_* equivalents are unset. That way
+ *   existing .env files keep working during the transition.
+ */
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  S3Client,
+  PutObjectCommand,
+  GetObjectCommand,
+  DeleteObjectCommand,
+  HeadObjectCommand,
+  ListObjectsV2Command,
+} from '@aws-sdk/client-s3';
+import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import {
+  ListedObject,
+  PutOptions,
+  PutResult,
+  StorageProvider,
+  StorageProviderNotConfiguredError,
+} from './storage-provider.interface';
+
+export type S3Flavor = 's3' | 'r2' | 'minio' | 'b2';
+
+export class S3Provider implements StorageProvider {
+  readonly name: S3Flavor;
+  private readonly logger: Logger;
+
+  private readonly accessKeyId: string;
+  private readonly secretAccessKey: string;
+  private readonly region: string;
+  private readonly endpoint?: string;
+  private readonly publicUrl?: string;
+  private readonly forcePathStyle: boolean;
+
+  private client?: S3Client;
+
+  constructor(config: ConfigService, flavor: S3Flavor) {
+    this.name = flavor;
+    this.logger = new Logger(`S3Provider(${flavor})`);
+
+    // Pull STORAGE_* with legacy R2_* fallback for flavor=r2 only.
+    const getS = <T = string>(key: string, def?: T) =>
+      config.get<T>(key, def as T);
+
+    this.accessKeyId =
+      getS<string>('STORAGE_ACCESS_KEY_ID', '') ||
+      (flavor === 'r2' ? getS<string>('R2_ACCESS_KEY_ID', '') : '');
+    this.secretAccessKey =
+      getS<string>('STORAGE_SECRET_ACCESS_KEY', '') ||
+      (flavor === 'r2' ? getS<string>('R2_SECRET_ACCESS_KEY', '') : '');
+    this.region = getS<string>('STORAGE_REGION', 'auto');
+    this.publicUrl =
+      getS<string>('STORAGE_PUBLIC_URL') ||
+      (flavor === 'r2' ? getS<string>('R2_PUBLIC_URL') : undefined) ||
+      undefined;
+    this.forcePathStyle =
+      String(getS<string>('STORAGE_FORCE_PATH_STYLE', 'false')).toLowerCase() ===
+      'true';
+
+    // Endpoint resolution per-flavor:
+    let endpoint = getS<string>('STORAGE_ENDPOINT') || undefined;
+    if (!endpoint && flavor === 'r2') {
+      const accountId =
+        getS<string>('R2_ACCOUNT_ID') || getS<string>('STORAGE_ACCOUNT_ID');
+      if (accountId) {
+        endpoint = `https://${accountId}.r2.cloudflarestorage.com`;
+      }
+    }
+    this.endpoint = endpoint;
+
+    if (this.isAvailable()) {
+      this.logger.log(
+        `${flavor} configured (endpoint=${this.endpoint ?? '[aws default]'})`,
+      );
+    } else {
+      this.logger.warn(
+        `${flavor} selected but credentials missing (STORAGE_ACCESS_KEY_ID / STORAGE_SECRET_ACCESS_KEY)`,
+      );
+    }
+  }
+
+  isAvailable(): boolean {
+    if (!this.accessKeyId || !this.secretAccessKey) return false;
+    if (this.name === 'minio' && !this.endpoint) return false;
+    return true;
+  }
+
+  private getClient(): S3Client {
+    if (this.client) return this.client;
+    if (!this.isAvailable()) {
+      throw new StorageProviderNotConfiguredError(this.name, this.missingVars());
+    }
+    this.client = new S3Client({
+      region: this.region,
+      endpoint: this.endpoint,
+      forcePathStyle:
+        this.forcePathStyle || this.name === 'minio' ? true : undefined,
+      credentials: {
+        accessKeyId: this.accessKeyId,
+        secretAccessKey: this.secretAccessKey,
+      },
+    });
+    return this.client;
+  }
+
+  private missingVars(): string[] {
+    const out: string[] = [];
+    if (!this.accessKeyId) out.push('STORAGE_ACCESS_KEY_ID');
+    if (!this.secretAccessKey) out.push('STORAGE_SECRET_ACCESS_KEY');
+    if (this.name === 'minio' && !this.endpoint) out.push('STORAGE_ENDPOINT');
+    return out;
+  }
+
+  async put(
+    bucket: string,
+    key: string,
+    body: Buffer,
+    options?: PutOptions,
+  ): Promise<PutResult> {
+    await this.getClient().send(
+      new PutObjectCommand({
+        Bucket: bucket,
+        Key: key,
+        Body: body,
+        ContentType: options?.contentType ?? 'application/octet-stream',
+        Metadata: options?.metadata,
+        CacheControl: options?.cacheControl,
+        ACL: options?.acl === 'public' ? 'public-read' : undefined,
+      }),
+    );
+    return {
+      path: key,
+      url: this.getPublicUrl(bucket, key),
+      size: body.length,
+    };
+  }
+
+  async get(bucket: string, key: string): Promise<Buffer> {
+    const res = await this.getClient().send(
+      new GetObjectCommand({ Bucket: bucket, Key: key }),
+    );
+    const stream = res.Body as any;
+    const chunks: Buffer[] = [];
+    for await (const chunk of stream) chunks.push(Buffer.from(chunk));
+    return Buffer.concat(chunks);
+  }
+
+  async delete(bucket: string, key: string): Promise<void> {
+    await this.getClient().send(
+      new DeleteObjectCommand({ Bucket: bucket, Key: key }),
+    );
+  }
+
+  async exists(bucket: string, key: string): Promise<boolean> {
+    try {
+      await this.getClient().send(
+        new HeadObjectCommand({ Bucket: bucket, Key: key }),
+      );
+      return true;
+    } catch (e: any) {
+      if (e.name === 'NotFound' || e.$metadata?.httpStatusCode === 404) {
+        return false;
+      }
+      throw e;
+    }
+  }
+
+  async list(bucket: string, prefix?: string): Promise<ListedObject[]> {
+    const res = await this.getClient().send(
+      new ListObjectsV2Command({ Bucket: bucket, Prefix: prefix }),
+    );
+    return (res.Contents || []).map((o) => ({
+      key: o.Key || '',
+      size: o.Size || 0,
+      lastModified: o.LastModified || new Date(),
+    }));
+  }
+
+  getPublicUrl(bucket: string, key: string): string {
+    if (this.publicUrl) {
+      return `${this.publicUrl.replace(/\/+$/, '')}/${key.replace(/^\/+/, '')}`;
+    }
+    // Fallback: synthesize a URL from the endpoint. Not all S3-compatible
+    // backends expose objects publicly by default, so this is best-effort.
+    if (this.endpoint) {
+      return `${this.endpoint.replace(/\/+$/, '')}/${bucket}/${key}`;
+    }
+    // AWS S3 virtual-hosted style
+    return `https://${bucket}.s3.${this.region}.amazonaws.com/${key}`;
+  }
+
+  async getSignedUrl(
+    bucket: string,
+    key: string,
+    expiresInSeconds: number,
+  ): Promise<string> {
+    const command = new GetObjectCommand({ Bucket: bucket, Key: key });
+    return getSignedUrl(this.getClient(), command, {
+      expiresIn: expiresInSeconds,
+    });
+  }
+}

--- a/backend/src/modules/storage/providers/storage-provider.interface.ts
+++ b/backend/src/modules/storage/providers/storage-provider.interface.ts
@@ -1,0 +1,129 @@
+/**
+ * Common interface that every storage provider implements.
+ *
+ * Pick a provider by setting STORAGE_PROVIDER in your .env to one of:
+ *
+ *   local-fs - Local filesystem. Writes under ./data/uploads, serves via an
+ *              internal static route. Zero infra, zero signup, zero config.
+ *              The default and recommended starting point for dev.
+ *
+ *   s3       - AWS S3. Requires STORAGE_ACCESS_KEY_ID + STORAGE_SECRET_ACCESS_KEY
+ *              + STORAGE_BUCKET (+ STORAGE_REGION).
+ *
+ *   r2       - Cloudflare R2. Same as s3 but with R2's endpoint autowired
+ *              from STORAGE_ENDPOINT or R2_ACCOUNT_ID.
+ *
+ *   minio    - MinIO self-hosted S3-compatible. Same as s3 but with
+ *              STORAGE_ENDPOINT pointing at your MinIO server.
+ *
+ *   b2       - Backblaze B2 S3-compatible. Same as s3 but with the B2
+ *              endpoint.
+ *
+ *   gcs      - Google Cloud Storage. Requires @google-cloud/storage
+ *              (optional dependency, lazy-loaded).
+ *
+ *   azure    - Azure Blob Storage. Requires @azure/storage-blob (optional
+ *              dependency, lazy-loaded).
+ *
+ *   none     - Storage disabled. Every method throws loud errors.
+ *              The default if STORAGE_PROVIDER is unset AND no legacy
+ *              R2_* env vars are detected.
+ *
+ * Adding a new provider: implement this interface, register it in
+ * providers/index.ts, document the env vars in docs/providers/storage.md.
+ */
+
+export interface PutOptions {
+  /** MIME type. Default 'application/octet-stream'. */
+  contentType?: string;
+  /** Arbitrary user metadata attached to the object. */
+  metadata?: Record<string, string>;
+  /** Cache-Control header. */
+  cacheControl?: string;
+  /** 'public' | 'private' access control (provider-dependent). */
+  acl?: 'public' | 'private';
+}
+
+export interface PutResult {
+  /** The path the file was written to (bucket-relative key). */
+  path: string;
+  /** A URL the user can open — public CDN URL or signed URL if private. */
+  url: string;
+  /** Size in bytes (when known). */
+  size?: number;
+  /** Provider-specific ETag or version id. */
+  etag?: string;
+}
+
+export interface ListedObject {
+  key: string;
+  size: number;
+  lastModified: Date;
+}
+
+/**
+ * Common interface implemented by every storage provider.
+ * Methods a provider can't support should throw a clear
+ * StorageProviderNotSupportedError — never silently no-op.
+ */
+export interface StorageProvider {
+  /** Stable provider name for logging / clients. */
+  readonly name:
+    | 'local-fs'
+    | 's3'
+    | 'r2'
+    | 'minio'
+    | 'b2'
+    | 'gcs'
+    | 'azure'
+    | 'none';
+
+  /** True if the provider has the credentials it needs to function. */
+  isAvailable(): boolean;
+
+  /** Write a file. */
+  put(bucket: string, key: string, body: Buffer, options?: PutOptions): Promise<PutResult>;
+
+  /** Read a file as a Buffer. */
+  get(bucket: string, key: string): Promise<Buffer>;
+
+  /** Delete a file. */
+  delete(bucket: string, key: string): Promise<void>;
+
+  /** Check if an object exists. Must not throw on missing — return false. */
+  exists(bucket: string, key: string): Promise<boolean>;
+
+  /** List objects in a bucket, optionally under a prefix. */
+  list(bucket: string, prefix?: string): Promise<ListedObject[]>;
+
+  /** Get a permanent public URL (CDN / public bucket). */
+  getPublicUrl(bucket: string, key: string): string;
+
+  /** Get a short-lived signed URL that grants read access without auth. */
+  getSignedUrl(bucket: string, key: string, expiresInSeconds: number): Promise<string>;
+}
+
+/**
+ * Thrown when a provider is asked to do something it can't support on the
+ * current backend (e.g. permanent public URLs on a private bucket with no CDN).
+ */
+export class StorageProviderNotSupportedError extends Error {
+  constructor(provider: string, operation: string) {
+    super(
+      `Operation "${operation}" is not supported by the "${provider}" storage provider. See docs/providers/storage.md for provider capabilities.`,
+    );
+    this.name = 'StorageProviderNotSupportedError';
+  }
+}
+
+/**
+ * Thrown when a provider is selected but its credentials are missing.
+ */
+export class StorageProviderNotConfiguredError extends Error {
+  constructor(provider: string, missingVars: string[]) {
+    super(
+      `Storage provider "${provider}" is selected but the following env vars are missing: ${missingVars.join(', ')}. See docs/providers/storage.md.`,
+    );
+    this.name = 'StorageProviderNotConfiguredError';
+  }
+}

--- a/backend/src/modules/storage/storage.service.ts
+++ b/backend/src/modules/storage/storage.service.ts
@@ -1,44 +1,54 @@
+/**
+ * StorageService — the app's storage façade.
+ *
+ * Exposes the same public methods vasty-shop has always had
+ * (uploadFile / downloadFile / deleteFile / getPublicUrl / createSignedUrl /
+ * listFiles) so existing call sites don't need to change, and internally
+ * dispatches every call to whichever provider the operator has selected
+ * via `STORAGE_PROVIDER` in .env.
+ *
+ * See `./providers/` and `docs/providers/storage.md` for the full list
+ * of backends (local-fs, s3, r2, minio, b2, gcs, azure, none) and their
+ * env vars.
+ */
 import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
 import { ConfigService } from '@nestjs/config';
-import {
-  S3Client,
-  PutObjectCommand,
-  GetObjectCommand,
-  DeleteObjectCommand,
-  ListObjectsV2Command,
-} from '@aws-sdk/client-s3';
-import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
+import { createStorageProvider, StorageProvider } from './providers';
 
 @Injectable()
 export class StorageService implements OnModuleInit {
   private readonly logger = new Logger(StorageService.name);
-  private s3Client: S3Client;
-  private publicUrl: string;
+  private provider!: StorageProvider;
 
-  constructor(private configService: ConfigService) {}
+  constructor(private readonly configService: ConfigService) {}
 
   onModuleInit() {
-    const accountId = this.configService.get('R2_ACCOUNT_ID');
-    const accessKeyId = this.configService.get('R2_ACCESS_KEY_ID');
-    const secretAccessKey = this.configService.get('R2_SECRET_ACCESS_KEY');
-
-    if (!accountId || !accessKeyId || !secretAccessKey) {
-      this.logger.warn('R2/S3 storage credentials not configured. File operations will fail.');
-      return;
-    }
-
-    this.s3Client = new S3Client({
-      region: 'auto',
-      endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
-      credentials: {
-        accessKeyId,
-        secretAccessKey,
-      },
-    });
-
-    this.publicUrl = this.configService.get('R2_PUBLIC_URL', '');
-    this.logger.log('Storage service (R2/S3) initialized');
+    this.provider = createStorageProvider(this.configService);
+    this.logger.log(
+      `Storage provider initialized: ${this.provider.name} (available=${this.provider.isAvailable()})`,
+    );
   }
+
+  /**
+   * Direct access to the underlying provider for advanced callers. Prefer
+   * the higher-level methods below.
+   */
+  getProvider(): StorageProvider {
+    return this.provider;
+  }
+
+  getProviderName(): string {
+    return this.provider?.name ?? 'none';
+  }
+
+  isAvailable(): boolean {
+    return !!this.provider && this.provider.isAvailable();
+  }
+
+  // =====================================================================
+  // Public API — preserved from the pre-adapter StorageService so existing
+  // call sites keep working without changes.
+  // =====================================================================
 
   async uploadFile(
     bucket: string,
@@ -46,76 +56,38 @@ export class StorageService implements OnModuleInit {
     path: string,
     options?: { contentType?: string; metadata?: Record<string, string> },
   ): Promise<{ path: string; url: string }> {
-    const command = new PutObjectCommand({
-      Bucket: bucket,
-      Key: path,
-      Body: fileBuffer,
-      ContentType: options?.contentType || 'application/octet-stream',
-      Metadata: options?.metadata,
+    const result = await this.provider.put(bucket, path, fileBuffer, {
+      contentType: options?.contentType,
+      metadata: options?.metadata,
+      acl: 'public',
     });
-
-    await this.s3Client.send(command);
-
-    return {
-      path,
-      url: this.getPublicUrl(bucket, path),
-    };
+    return { path: result.path, url: result.url };
   }
 
   async downloadFile(bucket: string, path: string): Promise<Buffer> {
-    const command = new GetObjectCommand({
-      Bucket: bucket,
-      Key: path,
-    });
-
-    const response = await this.s3Client.send(command);
-    const stream = response.Body as any;
-
-    // Convert stream to buffer
-    const chunks: Buffer[] = [];
-    for await (const chunk of stream) {
-      chunks.push(Buffer.from(chunk));
-    }
-    return Buffer.concat(chunks);
+    return this.provider.get(bucket, path);
   }
 
   async deleteFile(bucket: string, path: string): Promise<void> {
-    const command = new DeleteObjectCommand({
-      Bucket: bucket,
-      Key: path,
-    });
-
-    await this.s3Client.send(command);
+    return this.provider.delete(bucket, path);
   }
 
   getPublicUrl(bucket: string, path: string): string {
-    if (this.publicUrl) {
-      return `${this.publicUrl}/${path}`;
-    }
-    return `/${bucket}/${path}`;
+    return this.provider.getPublicUrl(bucket, path);
   }
 
-  async createSignedUrl(bucket: string, path: string, expiresIn: number = 3600): Promise<string> {
-    const command = new GetObjectCommand({
-      Bucket: bucket,
-      Key: path,
-    });
-
-    return getSignedUrl(this.s3Client, command, { expiresIn });
+  async createSignedUrl(
+    bucket: string,
+    path: string,
+    expiresIn: number = 3600,
+  ): Promise<string> {
+    return this.provider.getSignedUrl(bucket, path, expiresIn);
   }
 
-  async listFiles(bucket: string, prefix?: string): Promise<{ key: string; size: number; lastModified: Date }[]> {
-    const command = new ListObjectsV2Command({
-      Bucket: bucket,
-      Prefix: prefix,
-    });
-
-    const response = await this.s3Client.send(command);
-
-    return (response.Contents || []).map((obj) => ({
-      key: obj.Key || '',
-      size: obj.Size || 0,
-      lastModified: obj.LastModified || new Date(),
-    }));
+  async listFiles(
+    bucket: string,
+    prefix?: string,
+  ): Promise<{ key: string; size: number; lastModified: Date }[]> {
+    return this.provider.list(bucket, prefix);
   }
 }


### PR DESCRIPTION
## Summary

Closes #28. Direct port of vasty-shop PR #26 — Team@Once now has the same pluggable storage provider adapter, so self-hosters default to **local-fs** (zero infra, writes under `./data/uploads`) and can graduate to any S3-compatible backend, GCS, or Azure Blob by changing one env var.

Both repos shared the exact same R2-hardcoded `StorageService`, so the port is a pure copy of the provider files and façade rewrite from vasty #26.

## What's in it

7 provider implementations + factory + preserved façade. Same design as vasty #26:

- `local-fs` *(default)* — HMAC-signed URLs, path traversal rejection, auto-creates base dir
- `s3` / `r2` / `minio` / `b2` — share one `@aws-sdk/client-s3` codepath
- `gcs` — `@google-cloud/storage` lazy-loaded from `optionalDependencies`
- `azure` — `@azure/storage-blob` lazy-loaded from `optionalDependencies`
- `none` — disabled stub, throws loudly

**`StorageService` façade preserved**: `uploadFile`/`downloadFile`/`deleteFile`/`getPublicUrl`/`createSignedUrl`/`listFiles` — existing callers compile unchanged.

**Legacy `R2_*` shim**: if `STORAGE_PROVIDER` is unset but `R2_ACCOUNT_ID` + `R2_ACCESS_KEY_ID` + `R2_SECRET_ACCESS_KEY` are set, factory auto-selects `r2` with a deprecation warning.

## Note on `.env.example`

Team@Once previously had **no storage env vars documented at all** in `.env.example` — even though `StorageService` was silently reading `R2_*`. This PR adds the missing `FILE STORAGE` section defaulting to `local-fs`.

## Verification status (honest)

| Provider | Status |
|---|---|
| **local-fs** | **smoke-tested end-to-end** — put/exists/get/list/sign/delete round-trip against real filesystem |
| **path traversal** | **smoke-tested** — `../../etc/passwd` rejected |
| **r2 legacy shim** | **smoke-tested** — `R2_*` vars correctly infer `r2` |
| **none** | **smoke-tested** — throws as expected |
| **s3** / **minio** / **b2** | written, tsc clean, **NOT tested** against real backends |
| **gcs** / **azure** | written, tsc clean, **NOT tested** (need creds) |

- `npx tsc --noEmit`: **0 errors**
- Smoke test: **27/27 assertions pass**

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx ts-node scripts/smoke-test-storage-providers.ts` 27/27 pass
- [ ] Manual: upload a file via the API with `STORAGE_PROVIDER=local-fs`, verify `./data/uploads/...` contains it
- [ ] Manual: boot with existing `R2_*` env vars, verify deprecation log + successful upload to R2

## Related

- vasty-shop PR #26 — the identical adapter on the sibling repo
- Tracking issue #38 (pluggable providers meta)

🤖 Generated with [Claude Code](https://claude.com/claude-code)