### PR TITLE
feat(email): unified email module with pluggable provider (smtp/resend/sendgrid/postmark/ses/mailgun)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -91,3 +91,41 @@ OPENAI_MODEL=gpt-4o-mini
 QDRANT_HOST=localhost
 QDRANT_PORT=6333
 QDRANT_API_KEY=your_qdrant_api_key
+
+# =====================================================
+# EMAIL
+# =====================================================
+# Pick a provider. See backend/docs/providers/email.md for the full
+# comparison and per-provider env vars.
+#
+# Valid values: smtp | resend | sendgrid | postmark | ses | mailgun | none
+
+EMAIL_PROVIDER=smtp
+EMAIL_FROM=Team@Once <noreply@teamatonce.com>
+EMAIL_REPLY_TO=
+
+# --- SMTP (default, works with Gmail/Mailtrap/Postfix/etc) ---
+SMTP_HOST=smtp.gmail.com
+SMTP_PORT=587
+SMTP_SECURE=false
+SMTP_USER=
+SMTP_PASSWORD=
+
+# --- Resend (https://resend.com) ---
+RESEND_API_KEY=
+
+# --- SendGrid (https://sendgrid.com) ---
+SENDGRID_API_KEY=
+
+# --- Postmark (https://postmarkapp.com) ---
+POSTMARK_SERVER_TOKEN=
+
+# --- AWS SES (optional dep @aws-sdk/client-ses) ---
+SES_REGION=us-east-1
+SES_ACCESS_KEY_ID=
+SES_SECRET_ACCESS_KEY=
+
+# --- Mailgun (https://www.mailgun.com) ---
+MAILGUN_API_KEY=
+MAILGUN_DOMAIN=
+MAILGUN_REGION=us

--- a/backend/docs/providers/email.md
+++ b/backend/docs/providers/email.md
@@ -1,0 +1,160 @@
+# Email providers
+
+Vasty Shop supports six email backends plus a `none` default. Pick one by
+setting `EMAIL_PROVIDER` in your `.env`.
+
+```
+EMAIL_PROVIDER=smtp   # zero vendor lock-in default
+```
+
+## Comparison
+
+| Provider | Free tier | Transport | Attachments | Best for |
+|---|---|---|---|---|
+| **smtp** *(default)* | depends on your server | nodemailer | ✅ | zero lock-in, dev with Mailtrap, Gmail app passwords |
+| **resend** | 3,000 / month | REST | ✅ | modern API, best DX |
+| **sendgrid** | 100 / day | REST | ✅ | enterprise standard |
+| **postmark** | 100 / month | REST | ✅ | top-tier transactional deliverability |
+| **ses** | 62k / month (from EC2) | AWS SDK *(optional dep)* | ❌ *(yet)* | cheapest at scale |
+| **mailgun** | 100 / day × 30 days | REST | ✅ | solid EU/global |
+| **none** | — | — | — | default — email features disabled |
+
+## Which should I pick?
+
+- **"I just want it to work locally"** → `smtp` with [Mailtrap](https://mailtrap.io) (free sandbox)
+- **New production setup in 2 minutes** → `resend` (the cleanest DX)
+- **Already on AWS, at scale** → `ses`
+- **Europe-first deployment** → `mailgun` with `MAILGUN_REGION=eu` or `resend`
+- **Max deliverability for transactional** → `postmark`
+- **Existing SendGrid contract** → `sendgrid`
+
+## Per-provider setup
+
+### smtp (default)
+
+Works with any SMTP server.
+
+```
+EMAIL_PROVIDER=smtp
+SMTP_HOST=smtp.yourprovider.com
+SMTP_PORT=587
+SMTP_USER=your-user
+SMTP_PASSWORD=your-pass
+SMTP_SECURE=false          # true for port 465 implicit TLS
+EMAIL_FROM=Vasty Shop <noreply@yourdomain.com>
+EMAIL_REPLY_TO=support@yourdomain.com
+```
+
+**Dev tip**: run Mailtrap (or the `maildev` compose profile once
+install PR #24 lands) to inspect outgoing mail in a local web UI
+without actually sending anything.
+
+### resend
+
+Sign up at <https://resend.com>, verify a sending domain, copy the API key
+from the dashboard.
+
+```
+EMAIL_PROVIDER=resend
+RESEND_API_KEY=re_...
+EMAIL_FROM=Vasty Shop <noreply@yourdomain.com>
+```
+
+Pure REST — no SDK dep on the server. 3,000 free emails/month + 100/day
+with the free tier.
+
+### sendgrid
+
+Sign up at <https://sendgrid.com>, create an API key with "Mail Send"
+permission, verify a sender identity.
+
+```
+EMAIL_PROVIDER=sendgrid
+SENDGRID_API_KEY=SG.xxxxx
+EMAIL_FROM=Vasty Shop <noreply@yourdomain.com>
+```
+
+### postmark
+
+Sign up at <https://postmarkapp.com>, create a Server, grab the Server API
+Token.
+
+```
+EMAIL_PROVIDER=postmark
+POSTMARK_SERVER_TOKEN=...
+EMAIL_FROM=Vasty Shop <noreply@yourdomain.com>
+```
+
+### ses
+
+`@aws-sdk/client-ses` is in **optionalDependencies**. When you run
+`npm install` with `EMAIL_PROVIDER=ses`, npm installs it automatically.
+Users who pick a different provider never download it.
+
+```
+EMAIL_PROVIDER=ses
+SES_REGION=us-east-1
+SES_ACCESS_KEY_ID=AKIA...
+SES_SECRET_ACCESS_KEY=...
+EMAIL_FROM=Vasty Shop <noreply@yourdomain.com>
+```
+
+**Limitation**: attachments aren't supported yet. The current provider
+uses `SendEmailCommand`, which doesn't take attachments — attachment
+support needs a `SendRawEmailCommand` MIME-building migration. Use
+`smtp` or another provider for emails that need attachments, or file
+a follow-up PR.
+
+### mailgun
+
+Sign up at <https://www.mailgun.com>, add and verify a domain.
+
+```
+EMAIL_PROVIDER=mailgun
+MAILGUN_API_KEY=key-...
+MAILGUN_DOMAIN=mail.yourdomain.com
+MAILGUN_REGION=us            # or 'eu' for EU data residency
+EMAIL_FROM=Vasty Shop <noreply@mail.yourdomain.com>
+```
+
+### none (default if unset)
+
+Every method throws `EmailProviderNotConfiguredError`. The startup log
+prints which env var to set.
+
+## Migrating from the legacy SMTP helper
+
+`backend/src/modules/database/email-helpers.ts` predates this adapter —
+it's a direct nodemailer wrapper exposed via
+`DatabaseService.sendEmail()`. It still works and isn't deprecated
+**yet**, but new callers should inject `EmailService` instead:
+
+```ts
+import { EmailService } from '@/modules/email/email.service';
+
+class MyService {
+  constructor(private readonly email: EmailService) {}
+
+  async notify() {
+    await this.email.send({
+      to: 'user@example.com',
+      subject: 'Hello',
+      html: '<p>Hi!</p>',
+    });
+  }
+}
+```
+
+A follow-up PR will migrate `DatabaseService.sendEmail()` to delegate to
+`EmailService` and then delete `email-helpers.ts`.
+
+## Adding a new provider
+
+1. Implement `EmailProvider` in
+   `backend/src/modules/email/providers/<name>.provider.ts`
+2. Add a case to `createEmailProvider()` in `providers/index.ts`
+3. Document env vars in this file and in `.env.example`
+4. If the provider needs an SDK, declare it in `optionalDependencies`
+   in `backend/package.json` and `require()` it inside a `loadSdk()`
+   method — never at the top of the file. See `ses.provider.ts` for
+   the pattern.

--- a/backend/package.json
+++ b/backend/package.json
@@ -80,6 +80,9 @@
     "stripe": "^22.0.1",
     "uuid": "^11.1.0"
   },
+  "optionalDependencies": {
+    "@aws-sdk/client-ses": "^3.600.0"
+  },
   "devDependencies": {
     "@nestjs/cli": "^11.0.14",
     "@nestjs/schematics": "^11.0.7",

--- a/backend/scripts/smoke-test-email-providers.ts
+++ b/backend/scripts/smoke-test-email-providers.ts
@@ -1,0 +1,349 @@
+/**
+ * Smoke test for the multi-provider email factory.
+ *
+ * Exercises the factory and each provider WITHOUT making real network
+ * calls to anyone's inbox. Intercepts `fetch` for the REST-based
+ * providers (resend/sendgrid/postmark/mailgun) and a mock SMTP
+ * transporter for nodemailer.
+ *
+ * Run with: npx ts-node scripts/smoke-test-email-providers.ts
+ */
+import { ConfigService } from '@nestjs/config';
+import {
+  createEmailProvider,
+  EmailProviderNotConfiguredError,
+} from '../src/modules/email/providers';
+
+function fakeConfig(env: Record<string, string>): ConfigService {
+  return {
+    get: <T>(key: string, def?: T) => (env[key] as any) ?? def,
+  } as unknown as ConfigService;
+}
+
+// Capture every outbound fetch so we can assert what the providers send
+// to each REST API without actually hitting the network.
+type FetchCall = {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: string | null;
+};
+const fetchCalls: FetchCall[] = [];
+const realFetch = global.fetch;
+function installMockFetch(status = 200, body: any = {}) {
+  global.fetch = (async (url: any, init: any = {}) => {
+    const headers: Record<string, string> = {};
+    if (init.headers) {
+      for (const [k, v] of Object.entries(init.headers)) {
+        headers[k] = String(v);
+      }
+    }
+    fetchCalls.push({
+      url: String(url),
+      method: init.method ?? 'GET',
+      headers,
+      body: typeof init.body === 'string' ? init.body : null,
+    });
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'x-message-id': 'mock-message-id-abc123' },
+    });
+  }) as any;
+}
+function restoreFetch() {
+  global.fetch = realFetch;
+}
+
+async function expectThrow(
+  label: string,
+  fn: () => Promise<unknown>,
+  matcher: (e: Error) => boolean,
+): Promise<boolean> {
+  try {
+    await fn();
+    console.log(`  ❌ ${label}: expected throw, got success`);
+    return false;
+  } catch (e) {
+    if (matcher(e as Error)) {
+      console.log(`  ✅ ${label}: threw as expected`);
+      return true;
+    }
+    console.log(`  ❌ ${label}: wrong error: ${(e as Error).message}`);
+    return false;
+  }
+}
+
+async function main(): Promise<void> {
+  let pass = 0;
+  let fail = 0;
+  const ok = (b: boolean) => (b ? pass++ : fail++);
+  console.log('=== Email provider factory smoke test ===\n');
+
+  // 1. none (no env at all)
+  console.log('1. no EMAIL_PROVIDER → none');
+  {
+    const p = createEmailProvider(fakeConfig({}));
+    ok(p.name === 'none');
+    console.log(`  ✅ factory returned: ${p.name}`);
+    ok(p.isAvailable() === false);
+    console.log(`  ✅ isAvailable()=false`);
+    ok(
+      await expectThrow(
+        'send fails loudly',
+        () =>
+          p.send({
+            to: 'test@example.com',
+            subject: 'x',
+            text: 'x',
+          }),
+        (e) => e instanceof EmailProviderNotConfiguredError,
+      ),
+    );
+  }
+
+  // 2. smtp without host → unavailable
+  console.log('\n2. EMAIL_PROVIDER=smtp without SMTP_HOST → unavailable');
+  {
+    const p = createEmailProvider(fakeConfig({ EMAIL_PROVIDER: 'smtp' }));
+    ok(p.name === 'smtp');
+    console.log(`  ✅ factory returned: ${p.name}`);
+    ok(p.isAvailable() === false);
+    console.log(`  ✅ isAvailable()=false`);
+    ok(
+      await expectThrow(
+        'send throws NotConfigured',
+        () => p.send({ to: 'a@b.com', subject: 'x', text: 'x' }),
+        (e) => e instanceof EmailProviderNotConfiguredError,
+      ),
+    );
+  }
+
+  // 3. resend with API key + mocked fetch → happy path
+  console.log('\n3. EMAIL_PROVIDER=resend (mocked network)');
+  {
+    installMockFetch(200, { id: 'resend-msg-xyz' });
+    try {
+      const p = createEmailProvider(
+        fakeConfig({
+          EMAIL_PROVIDER: 'resend',
+          RESEND_API_KEY: 're_testkey123',
+          EMAIL_FROM: 'Test <test@example.com>',
+        }),
+      );
+      ok(p.name === 'resend');
+      ok(p.isAvailable() === true);
+      console.log(`  ✅ factory + availability`);
+
+      const result = await p.send({
+        to: 'alice@example.com',
+        subject: 'hello',
+        html: '<p>hi</p>',
+      });
+      ok(result.provider === 'resend');
+      ok(result.messageId === 'resend-msg-xyz');
+      ok(result.accepted === true);
+      console.log(`  ✅ send returned: messageId=${result.messageId}`);
+
+      const call = fetchCalls[fetchCalls.length - 1];
+      ok(call.url === 'https://api.resend.com/emails');
+      ok(call.method === 'POST');
+      ok(call.headers['Authorization'] === 'Bearer re_testkey123');
+      console.log(`  ✅ POST to correct URL with auth header`);
+
+      const payload = JSON.parse(call.body!);
+      ok(payload.to[0] === 'alice@example.com');
+      ok(payload.subject === 'hello');
+      ok(payload.html === '<p>hi</p>');
+      ok(payload.from === 'Test <test@example.com>');
+      console.log(`  ✅ payload shape correct`);
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
+  // 4. sendgrid with API key + mocked fetch
+  console.log('\n4. EMAIL_PROVIDER=sendgrid (mocked network)');
+  {
+    installMockFetch(202, {});
+    try {
+      const p = createEmailProvider(
+        fakeConfig({
+          EMAIL_PROVIDER: 'sendgrid',
+          SENDGRID_API_KEY: 'SG.testkey',
+          EMAIL_FROM: 'Shop <noreply@shop.io>',
+        }),
+      );
+      ok(p.name === 'sendgrid');
+      ok(p.isAvailable() === true);
+      console.log(`  ✅ factory + availability`);
+
+      const result = await p.send({
+        to: 'user@test.com',
+        subject: 'Order confirmed',
+        text: 'Your order is on its way',
+      });
+      ok(result.provider === 'sendgrid');
+      ok(result.accepted === true);
+      console.log(`  ✅ send returned: messageId=${result.messageId}`);
+
+      const call = fetchCalls[fetchCalls.length - 1];
+      ok(call.url === 'https://api.sendgrid.com/v3/mail/send');
+      ok(call.headers['Authorization'] === 'Bearer SG.testkey');
+      console.log(`  ✅ POST to correct URL with auth`);
+
+      const payload = JSON.parse(call.body!);
+      ok(payload.from.email === 'noreply@shop.io');
+      ok(payload.from.name === 'Shop');
+      ok(payload.personalizations[0].to[0].email === 'user@test.com');
+      ok(payload.personalizations[0].subject === 'Order confirmed');
+      console.log(`  ✅ payload shape correct (parsed From + personalizations)`);
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
+  // 5. postmark
+  console.log('\n5. EMAIL_PROVIDER=postmark (mocked network)');
+  {
+    installMockFetch(200, { MessageID: 'pm-msg-456', ErrorCode: 0 });
+    try {
+      const p = createEmailProvider(
+        fakeConfig({
+          EMAIL_PROVIDER: 'postmark',
+          POSTMARK_SERVER_TOKEN: 'pm-token-123',
+          EMAIL_FROM: 'noreply@shop.io',
+        }),
+      );
+      ok(p.name === 'postmark');
+      ok(p.isAvailable() === true);
+
+      const result = await p.send({
+        to: 'b@c.com',
+        subject: 'Receipt',
+        html: '<p>receipt</p>',
+      });
+      ok(result.messageId === 'pm-msg-456');
+      ok(result.accepted === true);
+      console.log(`  ✅ postmark send → ${result.messageId}`);
+
+      const call = fetchCalls[fetchCalls.length - 1];
+      ok(call.headers['X-Postmark-Server-Token'] === 'pm-token-123');
+      const payload = JSON.parse(call.body!);
+      ok(payload.Subject === 'Receipt');
+      ok(payload.To === 'b@c.com');
+      console.log(`  ✅ auth header + payload correct`);
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
+  // 6. mailgun
+  console.log('\n6. EMAIL_PROVIDER=mailgun (mocked network)');
+  {
+    installMockFetch(200, { id: 'mg-id-789' });
+    try {
+      const p = createEmailProvider(
+        fakeConfig({
+          EMAIL_PROVIDER: 'mailgun',
+          MAILGUN_API_KEY: 'key-abc',
+          MAILGUN_DOMAIN: 'mg.shop.io',
+          EMAIL_FROM: 'noreply@mg.shop.io',
+        }),
+      );
+      ok(p.name === 'mailgun');
+      ok(p.isAvailable() === true);
+
+      const result = await p.send({
+        to: 'x@y.com',
+        subject: 'Hello',
+        text: 'hi',
+      });
+      ok(result.messageId === 'mg-id-789');
+      console.log(`  ✅ mailgun send → ${result.messageId}`);
+
+      const call = fetchCalls[fetchCalls.length - 1];
+      ok(call.url === 'https://api.mailgun.net/v3/mg.shop.io/messages');
+      ok(call.headers['Authorization']?.startsWith('Basic '));
+      console.log(`  ✅ POST to correct URL with basic auth`);
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
+  // 7. mailgun EU region
+  console.log('\n7. EMAIL_PROVIDER=mailgun with MAILGUN_REGION=eu');
+  {
+    installMockFetch(200, { id: 'mg-eu' });
+    try {
+      const p = createEmailProvider(
+        fakeConfig({
+          EMAIL_PROVIDER: 'mailgun',
+          MAILGUN_API_KEY: 'key-abc',
+          MAILGUN_DOMAIN: 'mg.shop.io',
+          MAILGUN_REGION: 'eu',
+        }),
+      );
+      await p.send({ to: 'a@b.com', subject: 's', text: 't' });
+      const call = fetchCalls[fetchCalls.length - 1];
+      ok(call.url === 'https://api.eu.mailgun.net/v3/mg.shop.io/messages');
+      console.log(`  ✅ EU region routes to correct host`);
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
+  // 8. ses without creds
+  console.log('\n8. EMAIL_PROVIDER=ses without creds → unavailable');
+  {
+    const p = createEmailProvider(fakeConfig({ EMAIL_PROVIDER: 'ses' }));
+    ok(p.name === 'ses');
+    ok(p.isAvailable() === false);
+    console.log(`  ✅ ses requires credentials`);
+  }
+
+  // 9. unknown
+  console.log('\n9. EMAIL_PROVIDER=foobar → none (fallback)');
+  {
+    const p = createEmailProvider(
+      fakeConfig({ EMAIL_PROVIDER: 'foobar' }),
+    );
+    ok(p.name === 'none');
+    console.log(`  ✅ unknown fell back to: ${p.name}`);
+  }
+
+  // 10. resend missing from address → still uses EMAIL_FROM default
+  console.log('\n10. resend with no EMAIL_FROM → uses default');
+  {
+    installMockFetch(200, { id: 'r' });
+    try {
+      const p = createEmailProvider(
+        fakeConfig({
+          EMAIL_PROVIDER: 'resend',
+          RESEND_API_KEY: 'k',
+        }),
+      );
+      await p.send({ to: 'a@b.com', subject: 's', text: 't' });
+      const payload = JSON.parse(
+        fetchCalls[fetchCalls.length - 1].body!,
+      );
+      ok(payload.from === 'noreply@example.com');
+      console.log(`  ✅ default from applied`);
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
+  console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+  process.exit(fail > 0 ? 1 : 0);
+}
+
+main().catch((e) => {
+  console.error('Smoke test crashed:', e);
+  process.exit(1);
+});

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -27,6 +27,7 @@ import { SearchModule } from './modules/search/search.module';
 import { AchievementsModule } from './modules/achievements/achievements.module';
 import { DatabaseModule } from './modules/database/database.module';
 import { StorageModule } from './modules/storage/storage.module';
+import { EmailModule } from './modules/email/email.module';
 import { AdminModule } from './modules/admin/admin.module';
 import { InstructorsModule } from './modules/instructors/instructors.module';
 import { EscrowModule } from './modules/escrow/escrow.module';
@@ -85,6 +86,7 @@ import { QueueModule } from './modules/queue/queue.module';
     AchievementsModule,
     DatabaseModule,
     StorageModule,
+    EmailModule,
     AdminModule,
     InstructorsModule,
     EscrowModule,

--- a/backend/src/modules/email/email.module.ts
+++ b/backend/src/modules/email/email.module.ts
@@ -1,0 +1,20 @@
+import { Module } from '@nestjs/common';
+import { EmailService } from './email.service';
+
+/**
+ * Email module — exposes the pluggable EmailService for all transactional
+ * email needs (auth verification, order confirmations, shipping updates,
+ * etc.).
+ *
+ * Pick a provider by setting EMAIL_PROVIDER in your .env. See
+ * `docs/providers/email.md` for the full list.
+ *
+ * This module deliberately has no controllers — email is an outbound
+ * concern. A future `/admin/email/test` endpoint can land in a follow-up
+ * when the admin Integrations page needs it.
+ */
+@Module({
+  providers: [EmailService],
+  exports: [EmailService],
+})
+export class EmailModule {}

--- a/backend/src/modules/email/email.service.ts
+++ b/backend/src/modules/email/email.service.ts
@@ -1,0 +1,72 @@
+/**
+ * EmailService — the app's transactional email façade.
+ *
+ * Every module that needs to send email (auth verification, password
+ * reset, order confirmation, shipment tracking, vendor notifications,
+ * refund updates, etc.) should inject EmailService and call `send()`.
+ *
+ * Internally this dispatches to whichever provider the operator has
+ * selected via EMAIL_PROVIDER in .env. See `./providers/` and
+ * `docs/providers/email.md` for the full list (smtp, resend, sendgrid,
+ * postmark, ses, mailgun, none).
+ *
+ * Backwards compatibility: `backend/src/modules/database/email-helpers.ts`
+ * continues to exist and is still used by `DatabaseService.sendEmail()`.
+ * Once all call sites migrate to EmailService, the old helper can be
+ * deleted in a follow-up PR.
+ */
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  createEmailProvider,
+  EmailProvider,
+  SendEmailInput,
+  SendEmailResult,
+} from './providers';
+
+@Injectable()
+export class EmailService implements OnModuleInit {
+  private readonly logger = new Logger(EmailService.name);
+  private provider!: EmailProvider;
+
+  constructor(private readonly config: ConfigService) {}
+
+  onModuleInit() {
+    this.provider = createEmailProvider(this.config);
+    this.logger.log(
+      `Email provider initialized: ${this.provider.name} (available=${this.provider.isAvailable()})`,
+    );
+  }
+
+  getProviderName(): string {
+    return this.provider?.name ?? 'none';
+  }
+
+  isAvailable(): boolean {
+    return !!this.provider && this.provider.isAvailable();
+  }
+
+  /** Send a single transactional email. */
+  async send(input: SendEmailInput): Promise<SendEmailResult> {
+    this.logger.log(
+      `send subject="${input.subject}" to=${Array.isArray(input.to) ? input.to.join(',') : input.to} via=${this.provider.name}`,
+    );
+    return this.provider.send(input);
+  }
+
+  /** Send many emails. Providers with a native batch API override this. */
+  async sendBulk(inputs: SendEmailInput[]): Promise<SendEmailResult[]> {
+    this.logger.log(
+      `sendBulk count=${inputs.length} via=${this.provider.name}`,
+    );
+    return this.provider.sendBulk(inputs);
+  }
+
+  /**
+   * Direct access to the underlying provider for advanced call sites.
+   * Prefer the higher-level methods above.
+   */
+  getProvider(): EmailProvider {
+    return this.provider;
+  }
+}

--- a/backend/src/modules/email/providers/email-provider.interface.ts
+++ b/backend/src/modules/email/providers/email-provider.interface.ts
@@ -1,0 +1,123 @@
+/**
+ * Common interface that every email provider implements.
+ *
+ * Pick a provider by setting EMAIL_PROVIDER in your .env to one of:
+ *
+ *   smtp      - Any SMTP server via nodemailer (Gmail app passwords,
+ *               Mailtrap, Postfix, Resend SMTP, SendGrid SMTP, etc.).
+ *               The default. Zero vendor lock-in.
+ *
+ *   resend    - Resend REST API. Modern, generous free tier.
+ *
+ *   sendgrid  - SendGrid REST API. Enterprise standard.
+ *
+ *   postmark  - Postmark REST API. Strong deliverability for transactional.
+ *
+ *   ses       - AWS SES via @aws-sdk/client-ses (optional dependency,
+ *               lazy-loaded). Cheapest at scale.
+ *
+ *   mailgun   - Mailgun REST API. Solid EU / global option.
+ *
+ *   none      - Email disabled. Every method throws loudly.
+ *               The default if EMAIL_PROVIDER is unset.
+ *
+ * Adding a new provider: implement this interface, register it in
+ * providers/index.ts, document the env vars in docs/providers/email.md.
+ */
+
+export interface EmailAttachment {
+  /** Filename shown in the email client. */
+  filename: string;
+  /** Raw content bytes. */
+  content: Buffer;
+  /** MIME type, e.g. 'application/pdf'. */
+  contentType?: string;
+}
+
+export interface SendEmailInput {
+  /** Recipient(s). Provider will fan out if multiple. */
+  to: string | string[];
+  /** Subject line. */
+  subject: string;
+  /** HTML body. At least one of html/text must be provided. */
+  html?: string;
+  /** Plain text body. */
+  text?: string;
+  /** From address override. Defaults to EMAIL_FROM env var. */
+  from?: string;
+  /** Reply-To header override. */
+  replyTo?: string;
+  /** CC recipients. */
+  cc?: string | string[];
+  /** BCC recipients. */
+  bcc?: string | string[];
+  /** File attachments. */
+  attachments?: EmailAttachment[];
+  /** Custom headers (provider-dependent). */
+  headers?: Record<string, string>;
+  /** Arbitrary tags / metadata (provider-dependent). */
+  tags?: Record<string, string>;
+}
+
+export interface SendEmailResult {
+  /** Provider-specific message id (for tracking / idempotency). */
+  messageId: string;
+  /** The provider that handled the send. */
+  provider: string;
+  /** True if the provider accepted the message. */
+  accepted: boolean;
+}
+
+/**
+ * Common interface implemented by every email provider. Methods a provider
+ * can't support should throw EmailProviderNotSupportedError — never
+ * silently no-op.
+ */
+export interface EmailProvider {
+  /** Stable provider name for logging / clients. */
+  readonly name:
+    | 'smtp'
+    | 'resend'
+    | 'sendgrid'
+    | 'postmark'
+    | 'ses'
+    | 'mailgun'
+    | 'none';
+
+  /** True if the provider has the credentials it needs to function. */
+  isAvailable(): boolean;
+
+  /** Send a single email. */
+  send(input: SendEmailInput): Promise<SendEmailResult>;
+
+  /**
+   * Send many emails in one batch. Default implementation just loops
+   * `send()`; providers with a real batch API (Resend, SendGrid) override.
+   */
+  sendBulk(inputs: SendEmailInput[]): Promise<SendEmailResult[]>;
+}
+
+/**
+ * Thrown when a provider is asked to do something it doesn't support
+ * (e.g. templated sends on a provider without templates).
+ */
+export class EmailProviderNotSupportedError extends Error {
+  constructor(provider: string, operation: string) {
+    super(
+      `Operation "${operation}" is not supported by the "${provider}" email provider. See docs/providers/email.md for provider capabilities.`,
+    );
+    this.name = 'EmailProviderNotSupportedError';
+  }
+}
+
+/**
+ * Thrown when a provider is selected but its credentials are missing.
+ */
+export class EmailProviderNotConfiguredError extends Error {
+  constructor(provider: string, missingVars: string[]) {
+    super(
+      `Email provider "${provider}" is selected but the following env vars are missing: ${missingVars.join(', ')}. See docs/providers/email.md.`,
+    );
+    this.name = 'EmailProviderNotConfiguredError';
+  }
+}

--- a/backend/src/modules/email/providers/index.ts
+++ b/backend/src/modules/email/providers/index.ts
@@ -1,0 +1,89 @@
+/**
+ * Email provider factory.
+ *
+ * Reads EMAIL_PROVIDER from config and returns the matching provider.
+ * Unknown values fall back to 'none' with a warning listing the valid
+ * choices.
+ *
+ * Add a new provider by:
+ *   1. Implementing EmailProvider in <name>.provider.ts
+ *   2. Adding a case to createEmailProvider() below
+ *   3. Documenting env vars in docs/providers/email.md
+ */
+import { ConfigService } from '@nestjs/config';
+import { Logger } from '@nestjs/common';
+import { EmailProvider } from './email-provider.interface';
+import { SmtpProvider } from './smtp.provider';
+import { ResendProvider } from './resend.provider';
+import { SendgridProvider } from './sendgrid.provider';
+import { PostmarkProvider } from './postmark.provider';
+import { MailgunProvider } from './mailgun.provider';
+import { SesProvider } from './ses.provider';
+import { NoneEmailProvider } from './none.provider';
+
+const log = new Logger('EmailProviderFactory');
+
+export function createEmailProvider(config: ConfigService): EmailProvider {
+  const choice = (config.get<string>('EMAIL_PROVIDER') || 'none')
+    .toLowerCase()
+    .trim();
+
+  switch (choice) {
+    case 'smtp':
+    case 'nodemailer': {
+      const p = new SmtpProvider(config);
+      log.log(`Selected email provider: smtp (available=${p.isAvailable()})`);
+      return p;
+    }
+    case 'resend': {
+      const p = new ResendProvider(config);
+      log.log(`Selected email provider: resend (available=${p.isAvailable()})`);
+      return p;
+    }
+    case 'sendgrid': {
+      const p = new SendgridProvider(config);
+      log.log(
+        `Selected email provider: sendgrid (available=${p.isAvailable()})`,
+      );
+      return p;
+    }
+    case 'postmark': {
+      const p = new PostmarkProvider(config);
+      log.log(
+        `Selected email provider: postmark (available=${p.isAvailable()})`,
+      );
+      return p;
+    }
+    case 'mailgun': {
+      const p = new MailgunProvider(config);
+      log.log(
+        `Selected email provider: mailgun (available=${p.isAvailable()})`,
+      );
+      return p;
+    }
+    case 'ses':
+    case 'aws-ses':
+    case 'aws': {
+      const p = new SesProvider(config);
+      log.log(`Selected email provider: ses (available=${p.isAvailable()})`);
+      return p;
+    }
+    case 'none':
+    case '':
+      return new NoneEmailProvider();
+    default:
+      log.warn(
+        `Unknown EMAIL_PROVIDER="${choice}". Falling back to "none". Valid values: smtp, resend, sendgrid, postmark, mailgun, ses, none.`,
+      );
+      return new NoneEmailProvider();
+  }
+}
+
+export * from './email-provider.interface';
+export { SmtpProvider } from './smtp.provider';
+export { ResendProvider } from './resend.provider';
+export { SendgridProvider } from './sendgrid.provider';
+export { PostmarkProvider } from './postmark.provider';
+export { MailgunProvider } from './mailgun.provider';
+export { SesProvider } from './ses.provider';
+export { NoneEmailProvider } from './none.provider';

--- a/backend/src/modules/email/providers/mailgun.provider.ts
+++ b/backend/src/modules/email/providers/mailgun.provider.ts
@@ -1,0 +1,154 @@
+/**
+ * Mailgun email provider.
+ *
+ *   EMAIL_PROVIDER=mailgun
+ *   MAILGUN_API_KEY=key-...
+ *   MAILGUN_DOMAIN=mail.yourdomain.com
+ *   EMAIL_FROM="Vasty Shop <noreply@mail.yourdomain.com>"
+ *
+ * Optional env vars:
+ *   MAILGUN_REGION=us   (or 'eu' for the EU region)
+ *
+ * Pure REST via fetch. Sign up at https://www.mailgun.com and add a
+ * domain. Free tier includes 100 emails/day for 30 days.
+ */
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  EmailProvider,
+  EmailProviderNotConfiguredError,
+  SendEmailInput,
+  SendEmailResult,
+} from './email-provider.interface';
+
+export class MailgunProvider implements EmailProvider {
+  readonly name = 'mailgun' as const;
+  private readonly logger = new Logger('MailgunProvider');
+
+  private readonly apiKey: string;
+  private readonly domain: string;
+  private readonly region: 'us' | 'eu';
+  private readonly from: string;
+  private readonly replyTo?: string;
+
+  constructor(config: ConfigService) {
+    this.apiKey = config.get<string>('MAILGUN_API_KEY', '');
+    this.domain = config.get<string>('MAILGUN_DOMAIN', '');
+    const rawRegion = config.get<string>('MAILGUN_REGION', 'us').toLowerCase();
+    this.region = rawRegion === 'eu' ? 'eu' : 'us';
+    this.from = config.get<string>('EMAIL_FROM', 'noreply@example.com');
+    this.replyTo = config.get<string>('EMAIL_REPLY_TO');
+
+    if (this.isAvailable()) {
+      this.logger.log(
+        `Mailgun provider configured (domain=${this.domain}, region=${this.region})`,
+      );
+    } else {
+      this.logger.warn(
+        'Mailgun provider selected but MAILGUN_API_KEY or MAILGUN_DOMAIN missing',
+      );
+    }
+  }
+
+  isAvailable(): boolean {
+    return !!(this.apiKey && this.domain);
+  }
+
+  private baseUrl(): string {
+    return this.region === 'eu'
+      ? `https://api.eu.mailgun.net/v3/${this.domain}`
+      : `https://api.mailgun.net/v3/${this.domain}`;
+  }
+
+  async send(input: SendEmailInput): Promise<SendEmailResult> {
+    if (!this.isAvailable()) {
+      throw new EmailProviderNotConfiguredError(
+        'mailgun',
+        this.missingVars(),
+      );
+    }
+
+    // Mailgun /messages expects application/x-www-form-urlencoded for
+    // simple sends (or multipart/form-data for attachments). Use
+    // multipart so attachment support is uniform.
+    const form = new FormData();
+    form.append('from', input.from ?? this.from);
+    (Array.isArray(input.to) ? input.to : [input.to]).forEach((t) =>
+      form.append('to', t),
+    );
+    if (input.cc) {
+      (Array.isArray(input.cc) ? input.cc : [input.cc]).forEach((c) =>
+        form.append('cc', c),
+      );
+    }
+    if (input.bcc) {
+      (Array.isArray(input.bcc) ? input.bcc : [input.bcc]).forEach((b) =>
+        form.append('bcc', b),
+      );
+    }
+    form.append('subject', input.subject);
+    if (input.text) form.append('text', input.text);
+    if (input.html) form.append('html', input.html);
+    if (input.replyTo ?? this.replyTo) {
+      form.append('h:Reply-To', input.replyTo ?? this.replyTo ?? '');
+    }
+    if (input.headers) {
+      for (const [k, v] of Object.entries(input.headers)) {
+        form.append(`h:${k}`, v);
+      }
+    }
+    if (input.tags) {
+      for (const [k, v] of Object.entries(input.tags)) {
+        form.append(`v:${k}`, v);
+      }
+    }
+    if (input.attachments) {
+      for (const a of input.attachments) {
+        form.append(
+          'attachment',
+          // Convert Buffer → Uint8Array → Blob for undici-compatible FormData.
+          new Blob([new Uint8Array(a.content)], {
+            type: a.contentType ?? 'application/octet-stream',
+          }),
+          a.filename,
+        );
+      }
+    }
+
+    const res = await fetch(`${this.baseUrl()}/messages`, {
+      method: 'POST',
+      headers: {
+        Authorization:
+          'Basic ' + Buffer.from(`api:${this.apiKey}`).toString('base64'),
+      },
+      body: form,
+    });
+
+    const body = (await res.json()) as { id?: string };
+    if (!res.ok) {
+      throw new Error(
+        `Mailgun API failed: ${res.status} ${JSON.stringify(body)}`,
+      );
+    }
+    return {
+      messageId: body.id ?? `mailgun-${Date.now()}`,
+      provider: 'mailgun',
+      accepted: true,
+    };
+  }
+
+  async sendBulk(inputs: SendEmailInput[]): Promise<SendEmailResult[]> {
+    const results: SendEmailResult[] = [];
+    for (const input of inputs) {
+      results.push(await this.send(input));
+    }
+    return results;
+  }
+
+  private missingVars(): string[] {
+    const out: string[] = [];
+    if (!this.apiKey) out.push('MAILGUN_API_KEY');
+    if (!this.domain) out.push('MAILGUN_DOMAIN');
+    return out;
+  }
+}

--- a/backend/src/modules/email/providers/none.provider.ts
+++ b/backend/src/modules/email/providers/none.provider.ts
@@ -1,0 +1,44 @@
+/**
+ * "None" email provider — email is disabled.
+ *
+ * The default if EMAIL_PROVIDER is unset. Every method throws
+ * EmailProviderNotConfiguredError so calling code fails loudly rather
+ * than silently no-opping. The startup log prints a clear message
+ * telling the operator which env var to set to enable email.
+ */
+import { Logger } from '@nestjs/common';
+import {
+  EmailProvider,
+  EmailProviderNotConfiguredError,
+  SendEmailInput,
+  SendEmailResult,
+} from './email-provider.interface';
+
+export class NoneEmailProvider implements EmailProvider {
+  readonly name = 'none' as const;
+  private readonly logger = new Logger('NoneEmailProvider');
+
+  constructor() {
+    this.logger.log(
+      'Email is DISABLED (EMAIL_PROVIDER not set). To enable, set EMAIL_PROVIDER to one of: smtp, resend, sendgrid, postmark, ses, mailgun. See docs/providers/email.md.',
+    );
+  }
+
+  isAvailable(): boolean {
+    return false;
+  }
+
+  private fail(op: string): never {
+    throw new EmailProviderNotConfiguredError('none', [
+      `EMAIL_PROVIDER (currently unset) - cannot ${op}`,
+    ]);
+  }
+
+  async send(_input: SendEmailInput): Promise<SendEmailResult> {
+    return this.fail('send');
+  }
+
+  async sendBulk(_inputs: SendEmailInput[]): Promise<SendEmailResult[]> {
+    return this.fail('sendBulk');
+  }
+}

--- a/backend/src/modules/email/providers/postmark.provider.ts
+++ b/backend/src/modules/email/providers/postmark.provider.ts
@@ -1,0 +1,120 @@
+/**
+ * Postmark email provider.
+ *
+ *   EMAIL_PROVIDER=postmark
+ *   POSTMARK_SERVER_TOKEN=...
+ *   EMAIL_FROM="Vasty Shop <noreply@yourdomain.com>"
+ *
+ * Pure REST via fetch. Postmark is known for top-tier deliverability on
+ * transactional email. 100-emails/month free tier.
+ *
+ * Sign up at https://postmarkapp.com, create a Server, copy its Server API Token.
+ */
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  EmailProvider,
+  EmailProviderNotConfiguredError,
+  SendEmailInput,
+  SendEmailResult,
+} from './email-provider.interface';
+
+const POSTMARK_API_BASE = 'https://api.postmarkapp.com';
+
+export class PostmarkProvider implements EmailProvider {
+  readonly name = 'postmark' as const;
+  private readonly logger = new Logger('PostmarkProvider');
+
+  private readonly serverToken: string;
+  private readonly from: string;
+  private readonly replyTo?: string;
+
+  constructor(config: ConfigService) {
+    this.serverToken = config.get<string>('POSTMARK_SERVER_TOKEN', '');
+    this.from = config.get<string>('EMAIL_FROM', 'noreply@example.com');
+    this.replyTo = config.get<string>('EMAIL_REPLY_TO');
+
+    if (this.isAvailable()) {
+      this.logger.log('Postmark provider configured');
+    } else {
+      this.logger.warn(
+        'Postmark provider selected but POSTMARK_SERVER_TOKEN missing',
+      );
+    }
+  }
+
+  isAvailable(): boolean {
+    return !!this.serverToken;
+  }
+
+  async send(input: SendEmailInput): Promise<SendEmailResult> {
+    if (!this.isAvailable()) {
+      throw new EmailProviderNotConfiguredError('postmark', [
+        'POSTMARK_SERVER_TOKEN',
+      ]);
+    }
+
+    const payload: any = {
+      From: input.from ?? this.from,
+      To: Array.isArray(input.to) ? input.to.join(', ') : input.to,
+      Cc: input.cc
+        ? Array.isArray(input.cc)
+          ? input.cc.join(', ')
+          : input.cc
+        : undefined,
+      Bcc: input.bcc
+        ? Array.isArray(input.bcc)
+          ? input.bcc.join(', ')
+          : input.bcc
+        : undefined,
+      ReplyTo: input.replyTo ?? this.replyTo,
+      Subject: input.subject,
+      HtmlBody: input.html,
+      TextBody: input.text,
+      Headers: input.headers
+        ? Object.entries(input.headers).map(([Name, Value]) => ({ Name, Value }))
+        : undefined,
+      Metadata: input.tags,
+      Attachments: input.attachments?.map((a) => ({
+        Name: a.filename,
+        Content: a.content.toString('base64'),
+        ContentType: a.contentType ?? 'application/octet-stream',
+      })),
+    };
+
+    const res = await fetch(`${POSTMARK_API_BASE}/email`, {
+      method: 'POST',
+      headers: {
+        'X-Postmark-Server-Token': this.serverToken,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    const body = (await res.json()) as {
+      MessageID?: string;
+      ErrorCode?: number;
+    };
+    if (!res.ok) {
+      throw new Error(
+        `Postmark API failed: ${res.status} ${JSON.stringify(body)}`,
+      );
+    }
+    return {
+      messageId: body.MessageID ?? `postmark-${Date.now()}`,
+      provider: 'postmark',
+      accepted: body.ErrorCode === 0,
+    };
+  }
+
+  async sendBulk(inputs: SendEmailInput[]): Promise<SendEmailResult[]> {
+    // Postmark has a /email/batch endpoint. For simplicity, we loop —
+    // Postmark's rate limits are generous and the REST round-trips are fast.
+    const results: SendEmailResult[] = [];
+    for (const input of inputs) {
+      results.push(await this.send(input));
+    }
+    return results;
+  }
+}

--- a/backend/src/modules/email/providers/resend.provider.ts
+++ b/backend/src/modules/email/providers/resend.provider.ts
@@ -1,0 +1,104 @@
+/**
+ * Resend email provider.
+ *
+ *   EMAIL_PROVIDER=resend
+ *   RESEND_API_KEY=re_...
+ *   EMAIL_FROM="Vasty Shop <noreply@yourdomain.com>"
+ *
+ * Pure REST via fetch — no SDK dep needed on the server. Resend has a
+ * generous free tier (3,000 emails/month) and a clean modern API.
+ *
+ * Sign up at https://resend.com and verify a sending domain.
+ */
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  EmailProvider,
+  EmailProviderNotConfiguredError,
+  SendEmailInput,
+  SendEmailResult,
+} from './email-provider.interface';
+
+const RESEND_API_BASE = 'https://api.resend.com';
+
+export class ResendProvider implements EmailProvider {
+  readonly name = 'resend' as const;
+  private readonly logger = new Logger('ResendProvider');
+
+  private readonly apiKey: string;
+  private readonly from: string;
+  private readonly replyTo?: string;
+
+  constructor(config: ConfigService) {
+    this.apiKey = config.get<string>('RESEND_API_KEY', '');
+    this.from = config.get<string>('EMAIL_FROM', 'noreply@example.com');
+    this.replyTo = config.get<string>('EMAIL_REPLY_TO');
+
+    if (this.isAvailable()) {
+      this.logger.log('Resend provider configured');
+    } else {
+      this.logger.warn('Resend provider selected but RESEND_API_KEY missing');
+    }
+  }
+
+  isAvailable(): boolean {
+    return !!this.apiKey;
+  }
+
+  private async resendApi(path: string, body: any): Promise<any> {
+    if (!this.isAvailable()) {
+      throw new EmailProviderNotConfiguredError('resend', ['RESEND_API_KEY']);
+    }
+    const res = await fetch(`${RESEND_API_BASE}${path}`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Resend API ${path} failed: ${res.status} ${text}`);
+    }
+    return res.json();
+  }
+
+  async send(input: SendEmailInput): Promise<SendEmailResult> {
+    const payload: any = {
+      from: input.from ?? this.from,
+      to: Array.isArray(input.to) ? input.to : [input.to],
+      subject: input.subject,
+      html: input.html,
+      text: input.text,
+      reply_to: input.replyTo ?? this.replyTo,
+      cc: input.cc,
+      bcc: input.bcc,
+      headers: input.headers,
+      tags: input.tags
+        ? Object.entries(input.tags).map(([name, value]) => ({ name, value }))
+        : undefined,
+      attachments: input.attachments?.map((a) => ({
+        filename: a.filename,
+        content: a.content.toString('base64'),
+      })),
+    };
+    const res = await this.resendApi('/emails', payload);
+    return {
+      messageId: res.id,
+      provider: 'resend',
+      accepted: true,
+    };
+  }
+
+  async sendBulk(inputs: SendEmailInput[]): Promise<SendEmailResult[]> {
+    // Resend has a /emails/batch endpoint (max 100 per call). For
+    // simplicity, just fan out individual sends — the REST calls are
+    // independently rate-limited and fast enough.
+    const results: SendEmailResult[] = [];
+    for (const input of inputs) {
+      results.push(await this.send(input));
+    }
+    return results;
+  }
+}

--- a/backend/src/modules/email/providers/sendgrid.provider.ts
+++ b/backend/src/modules/email/providers/sendgrid.provider.ts
@@ -1,0 +1,137 @@
+/**
+ * SendGrid email provider.
+ *
+ *   EMAIL_PROVIDER=sendgrid
+ *   SENDGRID_API_KEY=SG....
+ *   EMAIL_FROM="Vasty Shop <noreply@yourdomain.com>"
+ *
+ * Pure REST via fetch — no SDK dep needed. SendGrid is the enterprise
+ * standard for transactional email, with solid deliverability and a
+ * 100-emails/day free tier.
+ *
+ * Sign up at https://sendgrid.com and verify a sender identity.
+ */
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  EmailProvider,
+  EmailProviderNotConfiguredError,
+  SendEmailInput,
+  SendEmailResult,
+} from './email-provider.interface';
+
+const SENDGRID_API_BASE = 'https://api.sendgrid.com/v3';
+
+export class SendgridProvider implements EmailProvider {
+  readonly name = 'sendgrid' as const;
+  private readonly logger = new Logger('SendgridProvider');
+
+  private readonly apiKey: string;
+  private readonly from: string;
+  private readonly replyTo?: string;
+
+  constructor(config: ConfigService) {
+    this.apiKey = config.get<string>('SENDGRID_API_KEY', '');
+    this.from = config.get<string>('EMAIL_FROM', 'noreply@example.com');
+    this.replyTo = config.get<string>('EMAIL_REPLY_TO');
+
+    if (this.isAvailable()) {
+      this.logger.log('SendGrid provider configured');
+    } else {
+      this.logger.warn(
+        'SendGrid provider selected but SENDGRID_API_KEY missing',
+      );
+    }
+  }
+
+  isAvailable(): boolean {
+    return !!this.apiKey;
+  }
+
+  /**
+   * Parse a From-like string of either "Name <addr@host>" or plain
+   * "addr@host" into SendGrid's { email, name } object.
+   */
+  private parseAddress(addr: string): { email: string; name?: string } {
+    const m = /^\s*(.+?)\s*<(.+?)>\s*$/.exec(addr);
+    if (m) return { name: m[1], email: m[2] };
+    return { email: addr.trim() };
+  }
+
+  async send(input: SendEmailInput): Promise<SendEmailResult> {
+    if (!this.isAvailable()) {
+      throw new EmailProviderNotConfiguredError('sendgrid', [
+        'SENDGRID_API_KEY',
+      ]);
+    }
+
+    const toList = Array.isArray(input.to) ? input.to : [input.to];
+    const contents: any[] = [];
+    if (input.text) contents.push({ type: 'text/plain', value: input.text });
+    if (input.html) contents.push({ type: 'text/html', value: input.html });
+
+    const payload: any = {
+      personalizations: [
+        {
+          to: toList.map((t) => this.parseAddress(t)),
+          cc: input.cc
+            ? (Array.isArray(input.cc) ? input.cc : [input.cc]).map((a) =>
+                this.parseAddress(a),
+              )
+            : undefined,
+          bcc: input.bcc
+            ? (Array.isArray(input.bcc) ? input.bcc : [input.bcc]).map((a) =>
+                this.parseAddress(a),
+              )
+            : undefined,
+          subject: input.subject,
+        },
+      ],
+      from: this.parseAddress(input.from ?? this.from),
+      reply_to: input.replyTo
+        ? this.parseAddress(input.replyTo)
+        : this.replyTo
+          ? this.parseAddress(this.replyTo)
+          : undefined,
+      content: contents,
+      headers: input.headers,
+      custom_args: input.tags,
+      attachments: input.attachments?.map((a) => ({
+        filename: a.filename,
+        content: a.content.toString('base64'),
+        type: a.contentType,
+        disposition: 'attachment',
+      })),
+    };
+
+    const res = await fetch(`${SENDGRID_API_BASE}/mail/send`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(payload),
+    });
+
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`SendGrid API failed: ${res.status} ${text}`);
+    }
+
+    // SendGrid returns 202 Accepted with an X-Message-Id header.
+    const messageId = res.headers.get('x-message-id') ?? `sendgrid-${Date.now()}`;
+    return {
+      messageId,
+      provider: 'sendgrid',
+      accepted: true,
+    };
+  }
+
+  async sendBulk(inputs: SendEmailInput[]): Promise<SendEmailResult[]> {
+    const results: SendEmailResult[] = [];
+    for (const input of inputs) {
+      results.push(await this.send(input));
+    }
+    return results;
+  }
+}

--- a/backend/src/modules/email/providers/ses.provider.ts
+++ b/backend/src/modules/email/providers/ses.provider.ts
@@ -1,0 +1,158 @@
+/**
+ * AWS SES email provider.
+ *
+ *   EMAIL_PROVIDER=ses
+ *   SES_REGION=us-east-1
+ *   SES_ACCESS_KEY_ID=AKIA...
+ *   SES_SECRET_ACCESS_KEY=...
+ *   EMAIL_FROM="Vasty Shop <noreply@yourdomain.com>"
+ *
+ * The `@aws-sdk/client-ses` package is an OPTIONAL dependency — lazy-loaded
+ * inside loadSdk() only when the provider is selected. Listed in
+ * optionalDependencies in package.json. Users who pick a different
+ * provider never install it.
+ *
+ * Cheapest email at scale (~$0.10 per 1000 emails). Verify the sending
+ * domain in the SES console before sending.
+ */
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  EmailProvider,
+  EmailProviderNotConfiguredError,
+  SendEmailInput,
+  SendEmailResult,
+} from './email-provider.interface';
+
+export class SesProvider implements EmailProvider {
+  readonly name = 'ses' as const;
+  private readonly logger = new Logger('SesProvider');
+
+  private readonly region: string;
+  private readonly accessKeyId: string;
+  private readonly secretAccessKey: string;
+  private readonly from: string;
+  private readonly replyTo?: string;
+
+  private sdkLoaded = false;
+  private client: any;
+  private sendCommandClass: any;
+
+  constructor(config: ConfigService) {
+    this.region = config.get<string>('SES_REGION', 'us-east-1');
+    this.accessKeyId = config.get<string>('SES_ACCESS_KEY_ID', '');
+    this.secretAccessKey = config.get<string>('SES_SECRET_ACCESS_KEY', '');
+    this.from = config.get<string>('EMAIL_FROM', 'noreply@example.com');
+    this.replyTo = config.get<string>('EMAIL_REPLY_TO');
+
+    if (this.isAvailable()) {
+      this.logger.log(`SES provider configured (region=${this.region})`);
+    } else {
+      this.logger.warn(
+        'SES provider selected but SES_ACCESS_KEY_ID / SES_SECRET_ACCESS_KEY missing',
+      );
+    }
+  }
+
+  isAvailable(): boolean {
+    return !!(this.accessKeyId && this.secretAccessKey);
+  }
+
+  private loadSdk() {
+    if (this.sdkLoaded) return;
+    if (!this.isAvailable()) {
+      throw new EmailProviderNotConfiguredError('ses', this.missingVars());
+    }
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const sdk = require('@aws-sdk/client-ses');
+      this.client = new sdk.SESClient({
+        region: this.region,
+        credentials: {
+          accessKeyId: this.accessKeyId,
+          secretAccessKey: this.secretAccessKey,
+        },
+      });
+      this.sendCommandClass = sdk.SendEmailCommand;
+      this.sdkLoaded = true;
+      this.logger.log('@aws-sdk/client-ses loaded');
+    } catch (e: any) {
+      throw new Error(
+        `SES provider selected but "@aws-sdk/client-ses" is not installed. ` +
+          `Run: npm install @aws-sdk/client-ses    Original: ${e.message}`,
+      );
+    }
+  }
+
+  private missingVars(): string[] {
+    const out: string[] = [];
+    if (!this.accessKeyId) out.push('SES_ACCESS_KEY_ID');
+    if (!this.secretAccessKey) out.push('SES_SECRET_ACCESS_KEY');
+    return out;
+  }
+
+  async send(input: SendEmailInput): Promise<SendEmailResult> {
+    this.loadSdk();
+
+    const toAddresses = Array.isArray(input.to) ? input.to : [input.to];
+    const ccAddresses = input.cc
+      ? Array.isArray(input.cc)
+        ? input.cc
+        : [input.cc]
+      : undefined;
+    const bccAddresses = input.bcc
+      ? Array.isArray(input.bcc)
+        ? input.bcc
+        : [input.bcc]
+      : undefined;
+
+    // SES SendEmailCommand doesn't natively support attachments —
+    // attachments require SendRawEmailCommand (MIME-built). For this
+    // first iteration, reject attachments loudly so the caller knows.
+    if (input.attachments && input.attachments.length > 0) {
+      throw new Error(
+        'SES provider does not yet support attachments — needs SendRawEmailCommand migration. Use SMTP or another provider for emails with attachments.',
+      );
+    }
+
+    const command = new this.sendCommandClass({
+      Source: input.from ?? this.from,
+      Destination: {
+        ToAddresses: toAddresses,
+        CcAddresses: ccAddresses,
+        BccAddresses: bccAddresses,
+      },
+      ReplyToAddresses: input.replyTo
+        ? [input.replyTo]
+        : this.replyTo
+          ? [this.replyTo]
+          : undefined,
+      Message: {
+        Subject: { Data: input.subject, Charset: 'UTF-8' },
+        Body: {
+          Html: input.html
+            ? { Data: input.html, Charset: 'UTF-8' }
+            : undefined,
+          Text: input.text
+            ? { Data: input.text, Charset: 'UTF-8' }
+            : undefined,
+        },
+      },
+    });
+
+    const res = await this.client.send(command);
+    return {
+      messageId: res.MessageId,
+      provider: 'ses',
+      accepted: true,
+    };
+  }
+
+  async sendBulk(inputs: SendEmailInput[]): Promise<SendEmailResult[]> {
+    const results: SendEmailResult[] = [];
+    for (const input of inputs) {
+      results.push(await this.send(input));
+    }
+    return results;
+  }
+}

--- a/backend/src/modules/email/providers/smtp.provider.ts
+++ b/backend/src/modules/email/providers/smtp.provider.ts
@@ -1,0 +1,116 @@
+/**
+ * SMTP email provider (via nodemailer).
+ *
+ * Works with any SMTP server: Gmail app passwords, Mailtrap for dev,
+ * Postfix, Resend's SMTP bridge, SendGrid SMTP, self-hosted, etc. Zero
+ * vendor lock-in.
+ *
+ * Required env vars:
+ *   SMTP_HOST       e.g. smtp.gmail.com, smtp.resend.com, mailtrap.io
+ *   SMTP_PORT       587 (STARTTLS) or 465 (implicit TLS) or 25
+ *   EMAIL_FROM      default From address, e.g. "Vasty Shop <noreply@...>"
+ *
+ * Optional env vars:
+ *   SMTP_USER       username / API key user (leave blank for anon relays)
+ *   SMTP_PASSWORD   password / API key
+ *   SMTP_SECURE     "true" for port 465 implicit TLS; defaults to false
+ *   EMAIL_REPLY_TO  default Reply-To header
+ *
+ * Nodemailer is in `dependencies` (already used by database/email-helpers.ts)
+ * so this provider does NOT need lazy loading.
+ */
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as nodemailer from 'nodemailer';
+import {
+  EmailProvider,
+  EmailProviderNotConfiguredError,
+  SendEmailInput,
+  SendEmailResult,
+} from './email-provider.interface';
+
+export class SmtpProvider implements EmailProvider {
+  readonly name = 'smtp' as const;
+  private readonly logger = new Logger('SmtpProvider');
+
+  private readonly host: string;
+  private readonly port: number;
+  private readonly user: string;
+  private readonly password: string;
+  private readonly secure: boolean;
+  private readonly from: string;
+  private readonly replyTo?: string;
+
+  private transporter?: nodemailer.Transporter;
+
+  constructor(config: ConfigService) {
+    this.host = config.get<string>('SMTP_HOST', '');
+    this.port = parseInt(config.get<string>('SMTP_PORT', '587'), 10);
+    this.user = config.get<string>('SMTP_USER', '');
+    this.password = config.get<string>('SMTP_PASSWORD', '');
+    this.secure =
+      String(config.get<string>('SMTP_SECURE', 'false')).toLowerCase() ===
+      'true';
+    this.from = config.get<string>('EMAIL_FROM', 'noreply@example.com');
+    this.replyTo = config.get<string>('EMAIL_REPLY_TO');
+
+    if (this.isAvailable()) {
+      this.logger.log(`SMTP provider configured: ${this.host}:${this.port}`);
+    } else {
+      this.logger.warn('SMTP provider selected but SMTP_HOST missing');
+    }
+  }
+
+  isAvailable(): boolean {
+    return !!this.host;
+  }
+
+  private getTransport(): nodemailer.Transporter {
+    if (this.transporter) return this.transporter;
+    if (!this.isAvailable()) {
+      throw new EmailProviderNotConfiguredError('smtp', ['SMTP_HOST']);
+    }
+    this.transporter = nodemailer.createTransport({
+      host: this.host,
+      port: this.port,
+      secure: this.secure,
+      auth: this.user
+        ? { user: this.user, pass: this.password }
+        : undefined,
+    });
+    return this.transporter;
+  }
+
+  async send(input: SendEmailInput): Promise<SendEmailResult> {
+    const info = await this.getTransport().sendMail({
+      from: input.from ?? this.from,
+      to: input.to,
+      cc: input.cc,
+      bcc: input.bcc,
+      replyTo: input.replyTo ?? this.replyTo,
+      subject: input.subject,
+      html: input.html,
+      text: input.text,
+      headers: input.headers,
+      attachments: input.attachments?.map((a) => ({
+        filename: a.filename,
+        content: a.content,
+        contentType: a.contentType,
+      })),
+    });
+    return {
+      messageId: info.messageId,
+      provider: 'smtp',
+      accepted: (info.accepted?.length ?? 0) > 0,
+    };
+  }
+
+  async sendBulk(inputs: SendEmailInput[]): Promise<SendEmailResult[]> {
+    // SMTP has no native batch API — just loop send().
+    const results: SendEmailResult[] = [];
+    for (const input of inputs) {
+      results.push(await this.send(input));
+    }
+    return results;
+  }
+}


### PR DESCRIPTION
## Summary

Closes #29. Direct port of vasty-shop PR #29. Team@Once now has the same first-class email module with pluggable provider adapter.

The shape is identical to vasty-shop's adapter since both repos use the same NestJS + ConfigService + nodemailer stack. Provider files are copied verbatim; `res.json()` return types are narrowed for Team@Once's stricter tsconfig.

## What's in it

7 providers under `backend/src/modules/email/providers/`:
- **smtp** *(default)* — nodemailer, zero vendor lock-in
- **resend** / **sendgrid** / **postmark** / **mailgun** — REST via fetch, no SDKs
- **ses** — `@aws-sdk/client-ses` in `optionalDependencies`, lazy-loaded
- **none** — disabled stub, throws loudly

**`EmailService` façade**: `send(input)` + `sendBulk(inputs)` with a rich `SendEmailInput` shape. Registered in `app.module.ts` alongside `StorageModule`.

## Team@Once-specific deltas vs vasty #29

- `tsconfig` is stricter → `res.json()` cast to typed shapes in postmark + mailgun providers
- Team@Once had **no email env vars at all** in `.env.example` → added a new EMAIL section from scratch
- `@aws-sdk/client-ses` added to a new `optionalDependencies` block in `package.json` (Team@Once didn't previously have this block)

## Verification status (honest)

| Provider | Status |
|---|---|
| **resend** | written, **smoke-tested** (mocked HTTP) |
| **sendgrid** | written, **smoke-tested** (parsed "Name <addr>" + personalizations) |
| **postmark** | written, **smoke-tested** (X-Postmark-Server-Token + ErrorCode/MessageID) |
| **mailgun** | written, **smoke-tested** (US + EU region routing) |
| **none** | written, **smoke-tested** (throws as expected) |
| **smtp** | written, tsc clean, **NOT tested** against real SMTP |
| **ses** | written, tsc clean, **NOT tested** (needs AWS creds); attachments throw by design |

Full TypeScript compile: **0 errors**.

Smoke test: **45/45 assertions pass** on teamatonce.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx ts-node scripts/smoke-test-email-providers.ts` 45/45 pass
- [ ] Manual: inject `EmailService` into a controller, send via Mailtrap

## Related

- vasty-shop PR #29 — the identical adapter on the sibling repo
- Tracking issue #38 (pluggable providers meta)

🤖 Generated with [Claude Code](https://claude.com/claude-code)