### PR TITLE
feat(ai): pluggable LLM + vision adapter (openai/anthropic/gemini/ollama/groq)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -91,3 +91,38 @@ OPENAI_MODEL=gpt-4o-mini
 QDRANT_HOST=localhost
 QDRANT_PORT=6333
 QDRANT_API_KEY=your_qdrant_api_key
+
+# =====================================================
+# AI / LLM (pluggable, replaces the hardcoded OpenAI above)
+# =====================================================
+# Pick a provider. See backend/docs/providers/ai.md.
+#
+# Valid values: openai | anthropic | gemini | ollama | groq | none
+#
+# Recommended defaults:
+#   dev      → ollama (zero API keys, runs locally)
+#   prod     → openai (highest quality)
+#   EU/cheap → gemini
+#   latency  → groq
+
+AI_PROVIDER=openai
+AI_MODEL=gpt-4o-mini
+AI_VISION_MODEL=gpt-4o
+AI_EMBEDDING_MODEL=text-embedding-3-small
+
+# OPENAI_API_KEY is already set above under "OPENAI" section —
+# the new provider reads from the same env var for backwards compat.
+OPENAI_BASE_URL=
+
+# --- Anthropic Claude (https://console.anthropic.com) ---
+ANTHROPIC_API_KEY=
+
+# --- Google Gemini (https://ai.google.dev) ---
+GEMINI_API_KEY=
+
+# --- Ollama (local, https://ollama.com) ---
+OLLAMA_BASE_URL=http://localhost:11434
+
+# --- Groq (https://console.groq.com) ---
+GROQ_API_KEY=
+GROQ_BASE_URL=

--- a/backend/docs/providers/ai.md
+++ b/backend/docs/providers/ai.md
@@ -1,0 +1,141 @@
+# AI / LLM providers
+
+Vasty Shop supports five AI backends plus a `none` default. Pick one by
+setting `AI_PROVIDER` in your `.env`.
+
+```
+AI_PROVIDER=openai   # highest-quality default
+```
+
+## Comparison
+
+| Provider | Cost | Vision | Embeddings | JSON mode | Best for |
+|---|---|---|---|---|---|
+| **openai** | paid (3k-tier free trial) | ✅ | ✅ | native | highest quality, default |
+| **anthropic** | paid | ✅ | ❌ | prompt-based | long-context reasoning, product copy |
+| **gemini** | generous free tier | ✅ | ✅ | native | cheap vision, multimodal |
+| **ollama** | free (local) | ✅ *(LLaVA)* | ✅ *(nomic-embed-text)* | `format=json` | fully offline dev, zero API cost |
+| **groq** | generous free tier | ⚠️ *(model-dependent)* | ❌ | via prompt | ultra-low latency |
+| **none** | — | — | — | — | default — AI features disabled |
+
+## Which should I pick?
+
+- **"I'm a new contributor cloning the repo"** → `ollama` (zero API keys needed, fully offline)
+- **Production default, highest quality** → `openai`
+- **Long product descriptions / reasoning-heavy flows** → `anthropic`
+- **Cheap vision (product photo autofill) at scale** → `gemini`
+- **Real-time UX where latency matters** → `groq`
+- **Haven't decided yet** → leave `AI_PROVIDER` unset; AI features fail loudly instead of silently returning empty
+
+## Per-provider setup
+
+### openai (recommended for production)
+
+```
+AI_PROVIDER=openai
+OPENAI_API_KEY=sk-...
+AI_MODEL=gpt-4o-mini              # text model
+AI_VISION_MODEL=gpt-4o            # vision model
+AI_EMBEDDING_MODEL=text-embedding-3-small
+```
+
+**OpenAI-compatible gateways** (Azure OpenAI, LiteLLM, LocalAI, etc.) are supported via the optional `OPENAI_BASE_URL` override:
+
+```
+OPENAI_BASE_URL=https://your-azure-gateway.openai.azure.com/v1
+```
+
+### anthropic
+
+```
+AI_PROVIDER=anthropic
+ANTHROPIC_API_KEY=sk-ant-...
+AI_MODEL=claude-sonnet-4-5        # or claude-opus-4-5, claude-haiku-4-5
+```
+
+**JSON mode**: Anthropic has no native JSON mode, so the provider prepends a system instruction asking for "ONLY a valid JSON object, no prose, no markdown code fences" when `jsonMode: true`. Works well in practice but isn't as reliable as native-JSON providers.
+
+**Embeddings**: Not supported. Anthropic has no embeddings endpoint. The provider throws `AiProviderNotSupportedError` with a pointer to Voyage AI, OpenAI, or a local embedding model.
+
+**Vision**: Pass a `data:image/...;base64,...` URI or a public URL. The provider translates to Anthropic's `{ type: 'image', source: { type: 'base64'|'url', ... } }` block format.
+
+### gemini
+
+```
+AI_PROVIDER=gemini
+GEMINI_API_KEY=...
+AI_MODEL=gemini-2.0-flash-exp
+AI_VISION_MODEL=gemini-2.0-flash-exp
+AI_EMBEDDING_MODEL=text-embedding-004
+```
+
+The provider translates our `{ role: 'system' }` messages to Gemini's top-level `system_instruction` field, and `{ role: 'assistant' }` to `{ role: 'model' }`.
+
+**JSON mode**: native via `response_mime_type: 'application/json'`.
+
+### ollama (recommended for dev)
+
+```
+AI_PROVIDER=ollama
+OLLAMA_BASE_URL=http://localhost:11434    # default
+AI_MODEL=llama3.2                         # text model
+AI_VISION_MODEL=llava                     # vision model
+AI_EMBEDDING_MODEL=nomic-embed-text
+```
+
+Install and pull models once:
+
+```bash
+# One-time setup
+ollama pull llama3.2
+ollama pull llava               # for vision
+ollama pull nomic-embed-text    # for embeddings
+```
+
+Or run via Docker once the install wizard PR (#27) lands:
+
+```bash
+docker compose --profile ollama up -d
+```
+
+**JSON mode**: native via `format: 'json'`.
+
+**Vision**: accepts `data:` URIs and public URLs. For URLs, the provider fetches the image and base64-encodes it before sending (Ollama doesn't accept remote URLs directly).
+
+**Reachability**: if Ollama isn't running, the provider throws `AiProviderNotConfiguredError` on first call with a clear message: `"OLLAMA_BASE_URL (http://localhost:11434 unreachable — start with 'ollama serve' or 'docker compose --profile ollama up -d')"`.
+
+### groq
+
+```
+AI_PROVIDER=groq
+GROQ_API_KEY=gsk_...
+AI_MODEL=llama-3.3-70b-versatile
+```
+
+Groq's API is OpenAI-compatible — the provider composes an `OpenAiProvider` internally at `https://api.groq.com/openai/v1` with your Groq credentials. Same payload shape, same response shape, ~10x faster inference.
+
+**Vision**: model-dependent. `llama-3.2-90b-vision-preview` supports images; other Groq models don't. Pick a vision-capable model in `AI_VISION_MODEL`.
+
+**Embeddings**: not supported. Groq has no embeddings endpoint. The provider throws `AiProviderNotSupportedError`.
+
+### none (default if unset)
+
+Every method throws `AiProviderNotConfiguredError`. The startup log prints which env var to set.
+
+## Migration from the existing `AiService`
+
+`backend/src/modules/ai/ai.service.ts` currently:
+1. Calls `this.db.getAI().analyzeImage()` — a "database SDK" method that doesn't exist in practice
+2. Falls back to a direct `fetch` to `https://api.openai.com/v1/chat/completions`
+
+The new `AiProvider` interface covers the same shape (`generateText`, `analyzeImage`, `generateEmbedding`). A follow-up PR will migrate `AiService` to inject `createAiProvider(config)` and delete the dead database-SDK path. This PR just lands the adapter; the migration is intentionally out of scope to keep the diff reviewable.
+
+## Adding a new provider
+
+1. Implement `AiProvider` in
+   `backend/src/modules/ai/providers/<name>.provider.ts`
+2. Add a case to `createAiProvider()` in `providers/index.ts`
+3. Document env vars in this file and in `.env.example`
+4. Add smoke-test coverage in
+   `backend/scripts/smoke-test-ai-providers.ts` — mock `fetch`, assert
+   URL / auth / payload translation per method.

--- a/backend/scripts/smoke-test-ai-providers.ts
+++ b/backend/scripts/smoke-test-ai-providers.ts
@@ -320,7 +320,11 @@ async function main(): Promise<void> {
 
       const call = fetchCalls[fetchCalls.length - 1];
       ok(call.url.startsWith('https://generativelanguage.googleapis.com'));
-      ok(call.url.includes('key=gem-key'));
+      // API key MUST be in the x-goog-api-key header, NOT the URL.
+      // URL-embedded keys leak into access logs / error tracking /
+      // Sentry on any non-2xx response.
+      ok(call.headers['x-goog-api-key'] === 'gem-key');
+      ok(!call.url.includes('key='));
       const payload = JSON.parse(call.body!);
       ok(payload.system_instruction?.parts?.[0]?.text === 'Be brief.');
       ok(payload.contents.length === 3); // system removed

--- a/backend/scripts/smoke-test-ai-providers.ts
+++ b/backend/scripts/smoke-test-ai-providers.ts
@@ -1,0 +1,470 @@
+/**
+ * Smoke test for the multi-provider AI factory.
+ *
+ * Mocks `fetch` so no real API calls are made to any LLM vendor.
+ * Verifies factory instantiation, URL / auth / payload shape per
+ * provider, translation from the unified GenerateTextInput shape to
+ * each vendor's native format, and NotConfigured / NotSupported
+ * error behaviour.
+ *
+ * Run with: npx ts-node scripts/smoke-test-ai-providers.ts
+ */
+import { ConfigService } from '@nestjs/config';
+import {
+  createAiProvider,
+  AiProviderNotConfiguredError,
+  AiProviderNotSupportedError,
+} from '../src/modules/ai/providers';
+
+function fakeConfig(env: Record<string, string>): ConfigService {
+  return {
+    get: <T>(key: string, def?: T) => (env[key] as any) ?? def,
+  } as unknown as ConfigService;
+}
+
+type FetchCall = {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: string | null;
+};
+const fetchCalls: FetchCall[] = [];
+const realFetch = global.fetch;
+function installMockFetch(status = 200, body: any = {}) {
+  global.fetch = (async (url: any, init: any = {}) => {
+    const headers: Record<string, string> = {};
+    if (init.headers) {
+      for (const [k, v] of Object.entries(init.headers)) {
+        headers[k] = String(v);
+      }
+    }
+    fetchCalls.push({
+      url: String(url),
+      method: init.method ?? 'GET',
+      headers,
+      body: typeof init.body === 'string' ? init.body : null,
+    });
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as any;
+}
+function restoreFetch() {
+  global.fetch = realFetch;
+}
+
+async function expectThrow(
+  label: string,
+  fn: () => Promise<unknown>,
+  matcher: (e: Error) => boolean,
+): Promise<boolean> {
+  try {
+    await fn();
+    console.log(`  ❌ ${label}: expected throw, got success`);
+    return false;
+  } catch (e) {
+    if (matcher(e as Error)) {
+      console.log(`  ✅ ${label}: threw as expected`);
+      return true;
+    }
+    console.log(`  ❌ ${label}: wrong error: ${(e as Error).message}`);
+    return false;
+  }
+}
+
+async function main(): Promise<void> {
+  let pass = 0;
+  let fail = 0;
+  const ok = (b: boolean) => (b ? pass++ : fail++);
+  console.log('=== AI provider factory smoke test ===\n');
+
+  // 1. none default
+  console.log('1. no AI_PROVIDER → none');
+  {
+    const p = createAiProvider(fakeConfig({}));
+    ok(p.name === 'none');
+    ok(p.isAvailable() === false);
+    ok(
+      await expectThrow(
+        'generateText fails loudly',
+        () =>
+          p.generateText({
+            messages: [{ role: 'user', content: 'hi' }],
+          }),
+        (e) => e instanceof AiProviderNotConfiguredError,
+      ),
+    );
+  }
+
+  // 2. openai without key → unavailable
+  console.log('\n2. openai without key → unavailable');
+  {
+    const p = createAiProvider(fakeConfig({ AI_PROVIDER: 'openai' }));
+    ok(p.name === 'openai');
+    ok(p.isAvailable() === false);
+    ok(
+      await expectThrow(
+        'generateText throws NotConfigured',
+        () => p.generateText({ messages: [{ role: 'user', content: 'hi' }] }),
+        (e) => e instanceof AiProviderNotConfiguredError,
+      ),
+    );
+  }
+
+  // 3. openai happy path
+  console.log('\n3. openai generateText (mocked)');
+  {
+    installMockFetch(200, {
+      choices: [{ message: { content: 'Hello there!' } }],
+      model: 'gpt-4o-mini',
+      usage: {
+        prompt_tokens: 5,
+        completion_tokens: 3,
+        total_tokens: 8,
+      },
+    });
+    try {
+      const p = createAiProvider(
+        fakeConfig({
+          AI_PROVIDER: 'openai',
+          OPENAI_API_KEY: 'sk-test-123',
+        }),
+      );
+      ok(p.isAvailable() === true);
+      const result = await p.generateText({
+        messages: [
+          { role: 'system', content: 'Be concise.' },
+          { role: 'user', content: 'Say hi' },
+        ],
+        jsonMode: false,
+      });
+      ok(result.text === 'Hello there!');
+      ok(result.provider === 'openai');
+      ok(result.usage?.totalTokens === 8);
+      console.log(`  ✅ text: "${result.text}" (${result.usage?.totalTokens} tokens)`);
+
+      const call = fetchCalls[fetchCalls.length - 1];
+      ok(call.url === 'https://api.openai.com/v1/chat/completions');
+      ok(call.headers['Authorization'] === 'Bearer sk-test-123');
+      const payload = JSON.parse(call.body!);
+      ok(payload.model === 'gpt-4o-mini');
+      ok(payload.messages.length === 2);
+      ok(payload.messages[0].role === 'system');
+      console.log(`  ✅ correct URL, auth, messages passed through`);
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
+  // 4. openai jsonMode sets response_format
+  console.log('\n4. openai jsonMode sets response_format');
+  {
+    installMockFetch(200, {
+      choices: [{ message: { content: '{"ok":true}' } }],
+      model: 'gpt-4o-mini',
+    });
+    try {
+      const p = createAiProvider(
+        fakeConfig({ AI_PROVIDER: 'openai', OPENAI_API_KEY: 'k' }),
+      );
+      await p.generateText({
+        messages: [{ role: 'user', content: 'return json' }],
+        jsonMode: true,
+      });
+      const payload = JSON.parse(fetchCalls[fetchCalls.length - 1].body!);
+      ok(payload.response_format?.type === 'json_object');
+      console.log(`  ✅ jsonMode → response_format.type=json_object`);
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
+  // 5. openai analyzeImage
+  console.log('\n5. openai analyzeImage — multipart content with image_url');
+  {
+    installMockFetch(200, {
+      choices: [{ message: { content: 'I see a red shirt.' } }],
+      model: 'gpt-4o',
+    });
+    try {
+      const p = createAiProvider(
+        fakeConfig({ AI_PROVIDER: 'openai', OPENAI_API_KEY: 'k' }),
+      );
+      const result = await p.analyzeImage({
+        image: 'https://example.com/shirt.jpg',
+        prompt: 'What is in this image?',
+      });
+      ok(result.text === 'I see a red shirt.');
+      ok(result.provider === 'openai');
+      const payload = JSON.parse(fetchCalls[fetchCalls.length - 1].body!);
+      ok(Array.isArray(payload.messages[0].content));
+      ok(payload.messages[0].content.some((c: any) => c.type === 'image_url'));
+      ok(payload.messages[0].content.some((c: any) => c.type === 'text'));
+      console.log(`  ✅ image_url + text parts in message content`);
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
+  // 6. openai generateEmbedding
+  console.log('\n6. openai generateEmbedding (batch)');
+  {
+    installMockFetch(200, {
+      data: [
+        { embedding: [0.1, 0.2, 0.3] },
+        { embedding: [0.4, 0.5, 0.6] },
+      ],
+      model: 'text-embedding-3-small',
+    });
+    try {
+      const p = createAiProvider(
+        fakeConfig({ AI_PROVIDER: 'openai', OPENAI_API_KEY: 'k' }),
+      );
+      const result = await p.generateEmbedding({ text: ['a', 'b'] });
+      ok(result.embeddings.length === 2);
+      ok(result.dimensions === 3);
+      console.log(`  ✅ returned ${result.embeddings.length} vectors, dim=${result.dimensions}`);
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
+  // 7. anthropic happy path — splits system message correctly
+  console.log('\n7. anthropic generateText — system split + content blocks');
+  {
+    installMockFetch(200, {
+      content: [{ type: 'text', text: 'Hello from Claude' }],
+      model: 'claude-sonnet-4-5',
+      usage: { input_tokens: 10, output_tokens: 5 },
+    });
+    try {
+      const p = createAiProvider(
+        fakeConfig({
+          AI_PROVIDER: 'anthropic',
+          ANTHROPIC_API_KEY: 'sk-ant-test',
+        }),
+      );
+      const result = await p.generateText({
+        messages: [
+          { role: 'system', content: 'You are helpful.' },
+          { role: 'user', content: 'Hi' },
+        ],
+      });
+      ok(result.text === 'Hello from Claude');
+      ok(result.provider === 'anthropic');
+
+      const call = fetchCalls[fetchCalls.length - 1];
+      ok(call.url === 'https://api.anthropic.com/v1/messages');
+      ok(call.headers['x-api-key'] === 'sk-ant-test');
+      ok(call.headers['anthropic-version'] === '2023-06-01');
+      const payload = JSON.parse(call.body!);
+      ok(payload.system === 'You are helpful.');
+      ok(payload.messages.length === 1); // system stripped out
+      ok(payload.messages[0].role === 'user');
+      console.log(`  ✅ system split, x-api-key header, messages stripped of system`);
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
+  // 8. anthropic generateEmbedding → NotSupported
+  console.log('\n8. anthropic generateEmbedding → NotSupported');
+  {
+    const p = createAiProvider(
+      fakeConfig({ AI_PROVIDER: 'anthropic', ANTHROPIC_API_KEY: 'k' }),
+    );
+    ok(
+      await expectThrow(
+        'anthropic embeddings throws NotSupported',
+        () => p.generateEmbedding({ text: 'hi' }),
+        (e) => e instanceof AiProviderNotSupportedError,
+      ),
+    );
+  }
+
+  // 9. gemini translation
+  console.log('\n9. gemini generateText — role translation + system_instruction');
+  {
+    installMockFetch(200, {
+      candidates: [
+        {
+          content: { parts: [{ text: 'Hi from Gemini' }] },
+        },
+      ],
+      usageMetadata: {
+        promptTokenCount: 8,
+        candidatesTokenCount: 4,
+        totalTokenCount: 12,
+      },
+    });
+    try {
+      const p = createAiProvider(
+        fakeConfig({ AI_PROVIDER: 'gemini', GEMINI_API_KEY: 'gem-key' }),
+      );
+      const result = await p.generateText({
+        messages: [
+          { role: 'system', content: 'Be brief.' },
+          { role: 'user', content: 'Hi' },
+          { role: 'assistant', content: 'Hello!' },
+          { role: 'user', content: 'Again?' },
+        ],
+      });
+      ok(result.text === 'Hi from Gemini');
+      ok(result.provider === 'gemini');
+
+      const call = fetchCalls[fetchCalls.length - 1];
+      ok(call.url.startsWith('https://generativelanguage.googleapis.com'));
+      ok(call.url.includes('key=gem-key'));
+      const payload = JSON.parse(call.body!);
+      ok(payload.system_instruction?.parts?.[0]?.text === 'Be brief.');
+      ok(payload.contents.length === 3); // system removed
+      ok(payload.contents[0].role === 'user');
+      ok(payload.contents[1].role === 'model'); // assistant → model
+      ok(payload.contents[2].role === 'user');
+      console.log(`  ✅ system_instruction + role translation (assistant→model)`);
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
+  // 10. gemini jsonMode → response_mime_type
+  console.log('\n10. gemini jsonMode → response_mime_type=application/json');
+  {
+    installMockFetch(200, {
+      candidates: [{ content: { parts: [{ text: '{}' }] } }],
+    });
+    try {
+      const p = createAiProvider(
+        fakeConfig({ AI_PROVIDER: 'gemini', GEMINI_API_KEY: 'k' }),
+      );
+      await p.generateText({
+        messages: [{ role: 'user', content: 'json please' }],
+        jsonMode: true,
+      });
+      const payload = JSON.parse(fetchCalls[fetchCalls.length - 1].body!);
+      ok(payload.generationConfig.response_mime_type === 'application/json');
+      console.log(`  ✅ jsonMode → response_mime_type correct`);
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
+  // 11. ollama is always available, uses local URL
+  console.log('\n11. ollama generateText');
+  {
+    installMockFetch(200, {
+      message: { content: 'Local response' },
+      model: 'llama3.2',
+      prompt_eval_count: 3,
+      eval_count: 5,
+    });
+    try {
+      const p = createAiProvider(fakeConfig({ AI_PROVIDER: 'ollama' }));
+      ok(p.name === 'ollama');
+      ok(p.isAvailable() === true);
+      const result = await p.generateText({
+        messages: [{ role: 'user', content: 'Hi' }],
+      });
+      ok(result.text === 'Local response');
+      ok(result.provider === 'ollama');
+      ok(result.usage?.totalTokens === 8);
+
+      const call = fetchCalls[fetchCalls.length - 1];
+      ok(call.url === 'http://localhost:11434/api/chat');
+      const payload = JSON.parse(call.body!);
+      ok(payload.stream === false);
+      ok(payload.options.num_predict === 2000);
+      console.log(`  ✅ local URL + stream=false + num_predict option`);
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
+  // 12. ollama jsonMode → format=json
+  console.log('\n12. ollama jsonMode → format=json');
+  {
+    installMockFetch(200, { message: { content: '{}' }, model: 'llama3.2' });
+    try {
+      const p = createAiProvider(fakeConfig({ AI_PROVIDER: 'ollama' }));
+      await p.generateText({
+        messages: [{ role: 'user', content: 'json' }],
+        jsonMode: true,
+      });
+      const payload = JSON.parse(fetchCalls[fetchCalls.length - 1].body!);
+      ok(payload.format === 'json');
+      console.log(`  ✅ jsonMode → format=json`);
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
+  // 13. groq — composes OpenAI, routes to Groq base URL
+  console.log('\n13. groq uses OpenAI shape at api.groq.com');
+  {
+    installMockFetch(200, {
+      choices: [{ message: { content: 'Fast response' } }],
+      model: 'llama-3.3-70b-versatile',
+    });
+    try {
+      const p = createAiProvider(
+        fakeConfig({ AI_PROVIDER: 'groq', GROQ_API_KEY: 'gsk_test' }),
+      );
+      ok(p.name === 'groq');
+      ok(p.isAvailable() === true);
+      const result = await p.generateText({
+        messages: [{ role: 'user', content: 'Hi' }],
+      });
+      ok(result.provider === 'groq');
+      ok(result.text === 'Fast response');
+
+      const call = fetchCalls[fetchCalls.length - 1];
+      ok(call.url === 'https://api.groq.com/openai/v1/chat/completions');
+      ok(call.headers['Authorization'] === 'Bearer gsk_test');
+      console.log(`  ✅ groq routed to api.groq.com with gsk_ token`);
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
+  // 14. groq generateEmbedding → NotSupported
+  console.log('\n14. groq generateEmbedding → NotSupported');
+  {
+    const p = createAiProvider(
+      fakeConfig({ AI_PROVIDER: 'groq', GROQ_API_KEY: 'k' }),
+    );
+    ok(
+      await expectThrow(
+        'groq embeddings throws NotSupported',
+        () => p.generateEmbedding({ text: 'hi' }),
+        (e) => e instanceof AiProviderNotSupportedError,
+      ),
+    );
+  }
+
+  // 15. unknown value
+  console.log('\n15. AI_PROVIDER=foobar → none (fallback)');
+  {
+    const p = createAiProvider(fakeConfig({ AI_PROVIDER: 'foobar' }));
+    ok(p.name === 'none');
+    console.log(`  ✅ fallback to none`);
+  }
+
+  console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+  process.exit(fail > 0 ? 1 : 0);
+}
+
+main().catch((e) => {
+  console.error('Smoke test crashed:', e);
+  process.exit(1);
+});

--- a/backend/src/modules/ai/ai-provider.service.ts
+++ b/backend/src/modules/ai/ai-provider.service.ts
@@ -1,0 +1,71 @@
+/**
+ * AiProviderService — thin façade around the pluggable AI provider.
+ *
+ * New code should inject this instead of the legacy `AIService`.
+ * Every module that needs text generation, vision analysis, or
+ * embeddings goes through this single service — switching the
+ * backend is just a matter of changing `AI_PROVIDER` in .env.
+ *
+ * The legacy `AIService` (ai.service.ts) still exists and still
+ * directly calls OpenAI — a follow-up PR will migrate its internals
+ * to delegate to this service and then delete the dead code paths.
+ * This PR deliberately doesn't touch it to keep the diff reviewable.
+ *
+ * See `./providers/` and `docs/providers/ai.md`.
+ */
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  createAiProvider,
+  AiProvider,
+  AnalyzeImageInput,
+  GenerateEmbeddingInput,
+  GenerateEmbeddingResult,
+  GenerateTextInput,
+  GenerateTextResult,
+} from './providers';
+
+@Injectable()
+export class AiProviderService implements OnModuleInit {
+  private readonly logger = new Logger(AiProviderService.name);
+  private provider!: AiProvider;
+
+  constructor(private readonly config: ConfigService) {}
+
+  onModuleInit() {
+    this.provider = createAiProvider(this.config);
+    this.logger.log(
+      `AI provider initialized: ${this.provider.name} (available=${this.provider.isAvailable()})`,
+    );
+  }
+
+  getProviderName(): string {
+    return this.provider?.name ?? 'none';
+  }
+
+  isAvailable(): boolean {
+    return !!this.provider && this.provider.isAvailable();
+  }
+
+  async generateText(input: GenerateTextInput): Promise<GenerateTextResult> {
+    return this.provider.generateText(input);
+  }
+
+  async analyzeImage(input: AnalyzeImageInput): Promise<GenerateTextResult> {
+    return this.provider.analyzeImage(input);
+  }
+
+  async generateEmbedding(
+    input: GenerateEmbeddingInput,
+  ): Promise<GenerateEmbeddingResult> {
+    return this.provider.generateEmbedding(input);
+  }
+
+  /**
+   * Direct access to the underlying provider for advanced call sites.
+   * Prefer the higher-level methods above.
+   */
+  getProvider(): AiProvider {
+    return this.provider;
+  }
+}

--- a/backend/src/modules/ai/ai.module.ts
+++ b/backend/src/modules/ai/ai.module.ts
@@ -3,12 +3,31 @@ import { ConfigModule } from '@nestjs/config';
 import { AIController } from './ai.controller';
 import { AIService } from './ai.service';
 import { EmbeddingService } from './embedding.service';
+import { AiProviderService } from './ai-provider.service';
 import { AuthModule } from '../auth/auth.module';
 
+/**
+ * AI module.
+ *
+ * Exposes three services:
+ *
+ * - `AiProviderService` (NEW, pluggable)
+ *   The façade over the multi-provider adapter. New code should inject
+ *   this. Switch providers with `AI_PROVIDER` in .env — see
+ *   `docs/providers/ai.md`.
+ *
+ * - `AIService` (legacy, OpenAI-hardcoded)
+ *   Still exported for backwards compatibility. A follow-up PR will
+ *   migrate its internals to delegate to `AiProviderService`.
+ *
+ * - `EmbeddingService` (legacy, OpenAI-hardcoded)
+ *   Still exported for backwards compatibility. A follow-up PR will
+ *   route its calls through `AiProviderService.generateEmbedding()`.
+ */
 @Module({
   imports: [AuthModule, ConfigModule],
   controllers: [AIController],
-  providers: [AIService, EmbeddingService],
-  exports: [AIService, EmbeddingService],
+  providers: [AIService, EmbeddingService, AiProviderService],
+  exports: [AIService, EmbeddingService, AiProviderService],
 })
 export class AIModule {}

--- a/backend/src/modules/ai/providers/ai-provider.interface.ts
+++ b/backend/src/modules/ai/providers/ai-provider.interface.ts
@@ -1,0 +1,143 @@
+/**
+ * Common interface that every AI / LLM provider implements.
+ *
+ * Pick a provider by setting AI_PROVIDER in your .env to one of:
+ *
+ *   openai     - OpenAI (https://platform.openai.com). GPT-4o family,
+ *                vision, highest-quality default.
+ *
+ *   anthropic  - Anthropic Claude (https://console.anthropic.com).
+ *                Best for long-context reasoning, product copy.
+ *
+ *   gemini     - Google Gemini (https://ai.google.dev). Cheap
+ *                multimodal + long context.
+ *
+ *   ollama     - Ollama (https://ollama.com). Run LLMs on your own
+ *                machine. Zero API cost, fully offline. Great for dev.
+ *
+ *   groq       - Groq (https://groq.com). Ultra-low latency Llama,
+ *                Mixtral, DeepSeek. OpenAI-compatible API.
+ *
+ *   none       - AI disabled. Every method throws loudly.
+ *                The default if AI_PROVIDER is unset.
+ *
+ * Adding a new provider: implement this interface, register it in
+ * providers/index.ts, document the env vars in docs/providers/ai.md.
+ */
+
+export interface ChatMessage {
+  role: 'system' | 'user' | 'assistant';
+  content: string;
+}
+
+export interface GenerateTextInput {
+  /** Messages array (system + user turns). */
+  messages: ChatMessage[];
+  /** Model id override; defaults to each provider's sensible default. */
+  model?: string;
+  /** Max tokens to generate. Default 2000. */
+  maxTokens?: number;
+  /** Sampling temperature. Default 0.7. */
+  temperature?: number;
+  /** If set, the provider will try to return JSON (OpenAI/Gemini support
+   * this natively; others will prompt for it in the system message). */
+  jsonMode?: boolean;
+}
+
+export interface GenerateTextResult {
+  /** Full generated text. */
+  text: string;
+  /** Model the provider actually used. */
+  model: string;
+  /** Provider name. */
+  provider: string;
+  /** Token usage if the provider reports it. */
+  usage?: {
+    promptTokens?: number;
+    completionTokens?: number;
+    totalTokens?: number;
+  };
+}
+
+export interface AnalyzeImageInput {
+  /** Image as a publicly-reachable URL OR a base64 data URI. */
+  image: string;
+  /** Instruction / question about the image. */
+  prompt: string;
+  /** Vision model override. */
+  model?: string;
+  /** Max tokens for the response. */
+  maxTokens?: number;
+}
+
+export interface GenerateEmbeddingInput {
+  /** Text to embed. Batches are allowed — providers will split if needed. */
+  text: string | string[];
+  /** Embedding model override. */
+  model?: string;
+}
+
+export interface GenerateEmbeddingResult {
+  /** One vector per input string. */
+  embeddings: number[][];
+  /** Embedding model used. */
+  model: string;
+  /** Provider name. */
+  provider: string;
+  /** Dimensionality of each vector. */
+  dimensions: number;
+}
+
+/**
+ * Common interface implemented by every AI provider. Methods a provider
+ * can't support should throw AiProviderNotSupportedError — never silently
+ * no-op.
+ */
+export interface AiProvider {
+  /** Stable provider name for logging / clients. */
+  readonly name:
+    | 'openai'
+    | 'anthropic'
+    | 'gemini'
+    | 'ollama'
+    | 'groq'
+    | 'none';
+
+  /** True if the provider has the credentials/infra it needs. */
+  isAvailable(): boolean;
+
+  /** Generate text from a chat-message input. */
+  generateText(input: GenerateTextInput): Promise<GenerateTextResult>;
+
+  /** Analyze an image. Throws NotSupported for providers without vision. */
+  analyzeImage(input: AnalyzeImageInput): Promise<GenerateTextResult>;
+
+  /** Generate an embedding vector. Throws NotSupported for providers
+   * without an embeddings endpoint (e.g. Ollama without the right model). */
+  generateEmbedding(input: GenerateEmbeddingInput): Promise<GenerateEmbeddingResult>;
+}
+
+/**
+ * Thrown when a provider is asked to do something it can't support
+ * (e.g. image analysis on a text-only model).
+ */
+export class AiProviderNotSupportedError extends Error {
+  constructor(provider: string, operation: string) {
+    super(
+      `Operation "${operation}" is not supported by the "${provider}" AI provider. See docs/providers/ai.md for provider capabilities.`,
+    );
+    this.name = 'AiProviderNotSupportedError';
+  }
+}
+
+/**
+ * Thrown when a provider is selected but its credentials are missing.
+ */
+export class AiProviderNotConfiguredError extends Error {
+  constructor(provider: string, missingVars: string[]) {
+    super(
+      `AI provider "${provider}" is selected but the following env vars are missing: ${missingVars.join(', ')}. See docs/providers/ai.md.`,
+    );
+    this.name = 'AiProviderNotConfiguredError';
+  }
+}

--- a/backend/src/modules/ai/providers/anthropic.provider.ts
+++ b/backend/src/modules/ai/providers/anthropic.provider.ts
@@ -149,21 +149,49 @@ export class AnthropicProvider implements AiProvider {
   }
 
   async analyzeImage(input: AnalyzeImageInput): Promise<GenerateTextResult> {
-    // Anthropic accepts images as `{ type: 'image', source: { type:
-    // 'base64'|'url', ... } }` blocks inside a user message.
-    const imageBlock = input.image.startsWith('data:')
-      ? {
-          type: 'image' as const,
-          source: {
-            type: 'base64' as const,
-            media_type: this.extractDataUriMediaType(input.image) ?? 'image/jpeg',
-            data: input.image.replace(/^data:[^;]+;base64,/, ''),
-          },
-        }
-      : {
-          type: 'image' as const,
-          source: { type: 'url' as const, url: input.image },
-        };
+    // Anthropic accepts images as `{ type: 'image', source: ... }`
+    // blocks inside a user message. The Messages API ONLY accepts
+    // source.type === 'base64' (plus file_id for pre-uploaded
+    // assets) — it does NOT accept arbitrary https:// URLs. An
+    // earlier version of this provider used `source: { type: 'url' }`
+    // which failed at runtime with a confusing 400.
+    //
+    // For HTTPS URLs we fetch the image and base64-encode it
+    // ourselves so the public contract stays the same.
+    let imageBlock: any;
+    if (input.image.startsWith('data:')) {
+      imageBlock = {
+        type: 'image' as const,
+        source: {
+          type: 'base64' as const,
+          media_type:
+            this.extractDataUriMediaType(input.image) ?? 'image/jpeg',
+          data: input.image.replace(/^data:[^;]+;base64,/, ''),
+        },
+      };
+    } else if (/^https?:\/\//.test(input.image)) {
+      const fetched = await fetch(input.image);
+      if (!fetched.ok) {
+        throw new Error(
+          `Anthropic analyzeImage could not fetch ${input.image}: ${fetched.status}`,
+        );
+      }
+      const mediaType =
+        fetched.headers.get('content-type')?.split(';')[0] ?? 'image/jpeg';
+      const buf = Buffer.from(await fetched.arrayBuffer());
+      imageBlock = {
+        type: 'image' as const,
+        source: {
+          type: 'base64' as const,
+          media_type: mediaType,
+          data: buf.toString('base64'),
+        },
+      };
+    } else {
+      throw new Error(
+        `Anthropic analyzeImage: unsupported image reference "${input.image.slice(0, 60)}...". Use data: or http(s): URLs.`,
+      );
+    }
 
     const res = (await this.api('/messages', {
       model: input.model ?? this.defaultVisionModel,

--- a/backend/src/modules/ai/providers/anthropic.provider.ts
+++ b/backend/src/modules/ai/providers/anthropic.provider.ts
@@ -1,0 +1,217 @@
+/**
+ * Anthropic (Claude) provider.
+ *
+ *   AI_PROVIDER=anthropic
+ *   ANTHROPIC_API_KEY=sk-ant-...
+ *   AI_MODEL=claude-sonnet-4-5          # optional (default shown)
+ *
+ * Pure REST via fetch. Anthropic's Messages API (/v1/messages) takes
+ * a separate `system` field outside the messages array, and returns
+ * content as an array of blocks instead of a single string — this
+ * provider translates to/from the unified `GenerateTextInput/Result`
+ * shape so callers stay provider-agnostic.
+ *
+ * Claude is excellent at long-context reasoning and product copy.
+ * Embeddings are NOT supported (Anthropic has no embeddings endpoint
+ * as of this writing) — the provider throws AiProviderNotSupportedError.
+ */
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  AiProvider,
+  AiProviderNotConfiguredError,
+  AiProviderNotSupportedError,
+  AnalyzeImageInput,
+  GenerateEmbeddingInput,
+  GenerateEmbeddingResult,
+  GenerateTextInput,
+  GenerateTextResult,
+} from './ai-provider.interface';
+
+const ANTHROPIC_API_BASE = 'https://api.anthropic.com/v1';
+const ANTHROPIC_VERSION = '2023-06-01';
+
+export class AnthropicProvider implements AiProvider {
+  readonly name = 'anthropic' as const;
+  private readonly logger = new Logger('AnthropicProvider');
+
+  private readonly apiKey: string;
+  private readonly defaultModel: string;
+  private readonly defaultVisionModel: string;
+
+  constructor(config: ConfigService) {
+    this.apiKey = config.get<string>('ANTHROPIC_API_KEY', '');
+    this.defaultModel = config.get<string>('AI_MODEL', 'claude-sonnet-4-5');
+    this.defaultVisionModel = config.get<string>(
+      'AI_VISION_MODEL',
+      this.defaultModel,
+    );
+
+    if (this.isAvailable()) {
+      this.logger.log(
+        `Anthropic provider configured (model=${this.defaultModel})`,
+      );
+    } else {
+      this.logger.warn(
+        'Anthropic provider selected but ANTHROPIC_API_KEY missing',
+      );
+    }
+  }
+
+  isAvailable(): boolean {
+    return !!this.apiKey;
+  }
+
+  private async api(path: string, body: any): Promise<any> {
+    if (!this.isAvailable()) {
+      throw new AiProviderNotConfiguredError('anthropic', ['ANTHROPIC_API_KEY']);
+    }
+    const res = await fetch(`${ANTHROPIC_API_BASE}${path}`, {
+      method: 'POST',
+      headers: {
+        'x-api-key': this.apiKey,
+        'anthropic-version': ANTHROPIC_VERSION,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(`Anthropic API ${path} failed: ${res.status} ${text}`);
+    }
+    return res.json();
+  }
+
+  /**
+   * Anthropic's Messages API takes `system` as a separate top-level
+   * field, not as a message. Split the caller's messages accordingly.
+   */
+  private splitSystemMessages(input: GenerateTextInput): {
+    system?: string;
+    messages: Array<{ role: 'user' | 'assistant'; content: string }>;
+  } {
+    const systems: string[] = [];
+    const rest: Array<{ role: 'user' | 'assistant'; content: string }> = [];
+    for (const msg of input.messages) {
+      if (msg.role === 'system') {
+        systems.push(msg.content);
+      } else {
+        rest.push({ role: msg.role, content: msg.content });
+      }
+    }
+    return {
+      system: systems.length > 0 ? systems.join('\n\n') : undefined,
+      messages: rest,
+    };
+  }
+
+  async generateText(input: GenerateTextInput): Promise<GenerateTextResult> {
+    const { system, messages } = this.splitSystemMessages(input);
+
+    // jsonMode: Anthropic doesn't have a native JSON mode, so prepend
+    // a system instruction asking for JSON only.
+    const systemText = input.jsonMode
+      ? `${system ?? ''}\n\nRespond with ONLY a valid JSON object. No prose, no markdown code fences.`.trim()
+      : system;
+
+    const res = (await this.api('/messages', {
+      model: input.model ?? this.defaultModel,
+      max_tokens: input.maxTokens ?? 2000,
+      temperature: input.temperature ?? 0.7,
+      system: systemText,
+      messages,
+    })) as {
+      content: Array<{ type: string; text?: string }>;
+      model: string;
+      usage?: { input_tokens?: number; output_tokens?: number };
+    };
+
+    // Claude returns content as an array of content blocks; we only
+    // emit text blocks (no tool use yet).
+    const text = (res.content ?? [])
+      .filter((block) => block.type === 'text')
+      .map((block) => block.text ?? '')
+      .join('');
+
+    return {
+      text,
+      model: res.model,
+      provider: 'anthropic',
+      usage: res.usage
+        ? {
+            promptTokens: res.usage.input_tokens,
+            completionTokens: res.usage.output_tokens,
+            totalTokens:
+              (res.usage.input_tokens ?? 0) + (res.usage.output_tokens ?? 0),
+          }
+        : undefined,
+    };
+  }
+
+  async analyzeImage(input: AnalyzeImageInput): Promise<GenerateTextResult> {
+    // Anthropic accepts images as `{ type: 'image', source: { type:
+    // 'base64'|'url', ... } }` blocks inside a user message.
+    const imageBlock = input.image.startsWith('data:')
+      ? {
+          type: 'image' as const,
+          source: {
+            type: 'base64' as const,
+            media_type: this.extractDataUriMediaType(input.image) ?? 'image/jpeg',
+            data: input.image.replace(/^data:[^;]+;base64,/, ''),
+          },
+        }
+      : {
+          type: 'image' as const,
+          source: { type: 'url' as const, url: input.image },
+        };
+
+    const res = (await this.api('/messages', {
+      model: input.model ?? this.defaultVisionModel,
+      max_tokens: input.maxTokens ?? 2000,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            imageBlock,
+            { type: 'text', text: input.prompt },
+          ],
+        },
+      ],
+    })) as {
+      content: Array<{ type: string; text?: string }>;
+      model: string;
+      usage?: any;
+    };
+
+    const text = (res.content ?? [])
+      .filter((block) => block.type === 'text')
+      .map((block) => block.text ?? '')
+      .join('');
+
+    return {
+      text,
+      model: res.model,
+      provider: 'anthropic',
+      usage: res.usage
+        ? {
+            promptTokens: res.usage.input_tokens,
+            completionTokens: res.usage.output_tokens,
+          }
+        : undefined,
+    };
+  }
+
+  async generateEmbedding(
+    _input: GenerateEmbeddingInput,
+  ): Promise<GenerateEmbeddingResult> {
+    throw new AiProviderNotSupportedError(
+      'anthropic',
+      'generateEmbedding (Anthropic has no embeddings endpoint — use Voyage AI, OpenAI, or a local embedding model for vectors)',
+    );
+  }
+
+  private extractDataUriMediaType(dataUri: string): string | null {
+    const m = /^data:([^;]+);/.exec(dataUri);
+    return m?.[1] ?? null;
+  }
+}

--- a/backend/src/modules/ai/providers/gemini.provider.ts
+++ b/backend/src/modules/ai/providers/gemini.provider.ts
@@ -67,10 +67,19 @@ export class GeminiProvider implements AiProvider {
     if (!this.isAvailable()) {
       throw new AiProviderNotConfiguredError('gemini', ['GEMINI_API_KEY']);
     }
-    const url = `${GEMINI_API_BASE}/models/${model}:${endpoint}?key=${this.apiKey}`;
+    // Send the key via the x-goog-api-key header rather than a
+    // URL query string. Middleware / access logs / error-tracking
+    // (Sentry, Datadog) routinely capture full URLs on failure,
+    // and a key in ?key=... ends up leaked in plaintext the first
+    // time Gemini returns a non-2xx. Header placement keeps it
+    // out of URL-based telemetry.
+    const url = `${GEMINI_API_BASE}/models/${model}:${endpoint}`;
     const res = await fetch(url, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        'x-goog-api-key': this.apiKey,
+      },
       body: JSON.stringify(body),
     });
     if (!res.ok) {
@@ -159,7 +168,16 @@ export class GeminiProvider implements AiProvider {
   async analyzeImage(input: AnalyzeImageInput): Promise<GenerateTextResult> {
     const model = input.model ?? this.defaultVisionModel;
 
-    // Gemini image parts: either inlineData (base64) or fileData (URL).
+    // Gemini image parts: either inlineData (base64) or fileData (URI).
+    // IMPORTANT: fileData.fileUri ONLY accepts `gs://` URIs returned
+    // from the File API; it does NOT accept arbitrary https:// URLs.
+    // The earlier version of this provider just passed the HTTPS URL
+    // through, which produced opaque 400s at runtime.
+    //
+    // For HTTPS URLs we fetch the image ourselves, base64-encode it,
+    // and send it via inlineData. The caller-side contract is
+    // unchanged: `AnalyzeImageInput.image` may be a data URL or an
+    // HTTPS URL.
     let imagePart: any;
     if (input.image.startsWith('data:')) {
       const m = /^data:([^;]+);base64,(.+)$/.exec(input.image);
@@ -169,13 +187,33 @@ export class GeminiProvider implements AiProvider {
           data: m?.[2] ?? '',
         },
       };
-    } else {
+    } else if (input.image.startsWith('gs://')) {
       imagePart = {
         fileData: {
           mimeType: 'image/jpeg',
           fileUri: input.image,
         },
       };
+    } else if (/^https?:\/\//.test(input.image)) {
+      const fetched = await fetch(input.image);
+      if (!fetched.ok) {
+        throw new Error(
+          `Gemini analyzeImage could not fetch ${input.image}: ${fetched.status}`,
+        );
+      }
+      const mimeType =
+        fetched.headers.get('content-type')?.split(';')[0] ?? 'image/jpeg';
+      const buf = Buffer.from(await fetched.arrayBuffer());
+      imagePart = {
+        inlineData: {
+          mimeType,
+          data: buf.toString('base64'),
+        },
+      };
+    } else {
+      throw new Error(
+        `Gemini analyzeImage: unsupported image reference "${input.image.slice(0, 60)}...". Use data:, http(s):, or gs:// URIs.`,
+      );
     }
 
     const payload = {

--- a/backend/src/modules/ai/providers/gemini.provider.ts
+++ b/backend/src/modules/ai/providers/gemini.provider.ts
@@ -1,0 +1,250 @@
+/**
+ * Google Gemini provider.
+ *
+ *   AI_PROVIDER=gemini
+ *   GEMINI_API_KEY=...
+ *   AI_MODEL=gemini-2.0-flash-exp        # optional text default
+ *   AI_VISION_MODEL=gemini-2.0-flash-exp # optional vision default
+ *   AI_EMBEDDING_MODEL=text-embedding-004
+ *
+ * Pure REST via fetch. Gemini's API lives at generativelanguage.googleapis.com
+ * and uses a `contents` array of `{ role, parts: [{ text } | { inlineData } | ...] }`.
+ *
+ * System instructions go in a separate `system_instruction` field — the
+ * provider handles the translation.
+ *
+ * Free tier is generous and multimodal handling is excellent. Great
+ * default for vision-heavy e-commerce workflows (product photo
+ * autofill) when budget matters.
+ */
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  AiProvider,
+  AiProviderNotConfiguredError,
+  AnalyzeImageInput,
+  GenerateEmbeddingInput,
+  GenerateEmbeddingResult,
+  GenerateTextInput,
+  GenerateTextResult,
+} from './ai-provider.interface';
+
+const GEMINI_API_BASE = 'https://generativelanguage.googleapis.com/v1beta';
+
+export class GeminiProvider implements AiProvider {
+  readonly name = 'gemini' as const;
+  private readonly logger = new Logger('GeminiProvider');
+
+  private readonly apiKey: string;
+  private readonly defaultModel: string;
+  private readonly defaultVisionModel: string;
+  private readonly defaultEmbeddingModel: string;
+
+  constructor(config: ConfigService) {
+    this.apiKey = config.get<string>('GEMINI_API_KEY', '');
+    this.defaultModel = config.get<string>('AI_MODEL', 'gemini-2.0-flash-exp');
+    this.defaultVisionModel = config.get<string>(
+      'AI_VISION_MODEL',
+      this.defaultModel,
+    );
+    this.defaultEmbeddingModel = config.get<string>(
+      'AI_EMBEDDING_MODEL',
+      'text-embedding-004',
+    );
+
+    if (this.isAvailable()) {
+      this.logger.log(`Gemini provider configured (model=${this.defaultModel})`);
+    } else {
+      this.logger.warn('Gemini provider selected but GEMINI_API_KEY missing');
+    }
+  }
+
+  isAvailable(): boolean {
+    return !!this.apiKey;
+  }
+
+  private async api(model: string, endpoint: string, body: any): Promise<any> {
+    if (!this.isAvailable()) {
+      throw new AiProviderNotConfiguredError('gemini', ['GEMINI_API_KEY']);
+    }
+    const url = `${GEMINI_API_BASE}/models/${model}:${endpoint}?key=${this.apiKey}`;
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(
+        `Gemini API ${endpoint}(${model}) failed: ${res.status} ${text}`,
+      );
+    }
+    return res.json();
+  }
+
+  private translateMessages(input: GenerateTextInput): {
+    system?: { parts: Array<{ text: string }> };
+    contents: Array<{ role: 'user' | 'model'; parts: Array<{ text: string }> }>;
+  } {
+    const systems: string[] = [];
+    const contents: Array<{
+      role: 'user' | 'model';
+      parts: Array<{ text: string }>;
+    }> = [];
+    for (const msg of input.messages) {
+      if (msg.role === 'system') {
+        systems.push(msg.content);
+      } else {
+        contents.push({
+          role: msg.role === 'assistant' ? 'model' : 'user',
+          parts: [{ text: msg.content }],
+        });
+      }
+    }
+    return {
+      system:
+        systems.length > 0
+          ? { parts: [{ text: systems.join('\n\n') }] }
+          : undefined,
+      contents,
+    };
+  }
+
+  async generateText(input: GenerateTextInput): Promise<GenerateTextResult> {
+    const { system, contents } = this.translateMessages(input);
+    const model = input.model ?? this.defaultModel;
+
+    const payload: any = {
+      contents,
+      generationConfig: {
+        temperature: input.temperature ?? 0.7,
+        maxOutputTokens: input.maxTokens ?? 2000,
+      },
+    };
+    if (system) payload.system_instruction = system;
+    if (input.jsonMode) {
+      payload.generationConfig.response_mime_type = 'application/json';
+    }
+
+    const res = (await this.api(model, 'generateContent', payload)) as {
+      candidates: Array<{
+        content: { parts: Array<{ text?: string }> };
+      }>;
+      usageMetadata?: {
+        promptTokenCount?: number;
+        candidatesTokenCount?: number;
+        totalTokenCount?: number;
+      };
+    };
+
+    const text =
+      res.candidates?.[0]?.content?.parts
+        ?.map((p) => p.text ?? '')
+        .join('') ?? '';
+
+    return {
+      text,
+      model,
+      provider: 'gemini',
+      usage: res.usageMetadata
+        ? {
+            promptTokens: res.usageMetadata.promptTokenCount,
+            completionTokens: res.usageMetadata.candidatesTokenCount,
+            totalTokens: res.usageMetadata.totalTokenCount,
+          }
+        : undefined,
+    };
+  }
+
+  async analyzeImage(input: AnalyzeImageInput): Promise<GenerateTextResult> {
+    const model = input.model ?? this.defaultVisionModel;
+
+    // Gemini image parts: either inlineData (base64) or fileData (URL).
+    let imagePart: any;
+    if (input.image.startsWith('data:')) {
+      const m = /^data:([^;]+);base64,(.+)$/.exec(input.image);
+      imagePart = {
+        inlineData: {
+          mimeType: m?.[1] ?? 'image/jpeg',
+          data: m?.[2] ?? '',
+        },
+      };
+    } else {
+      imagePart = {
+        fileData: {
+          mimeType: 'image/jpeg',
+          fileUri: input.image,
+        },
+      };
+    }
+
+    const payload = {
+      contents: [
+        {
+          role: 'user',
+          parts: [imagePart, { text: input.prompt }],
+        },
+      ],
+      generationConfig: {
+        maxOutputTokens: input.maxTokens ?? 2000,
+      },
+    };
+
+    const res = (await this.api(model, 'generateContent', payload)) as {
+      candidates: Array<{ content: { parts: Array<{ text?: string }> } }>;
+      usageMetadata?: any;
+    };
+    const text =
+      res.candidates?.[0]?.content?.parts
+        ?.map((p) => p.text ?? '')
+        .join('') ?? '';
+
+    return {
+      text,
+      model,
+      provider: 'gemini',
+      usage: res.usageMetadata
+        ? {
+            promptTokens: res.usageMetadata.promptTokenCount,
+            completionTokens: res.usageMetadata.candidatesTokenCount,
+            totalTokens: res.usageMetadata.totalTokenCount,
+          }
+        : undefined,
+    };
+  }
+
+  async generateEmbedding(
+    input: GenerateEmbeddingInput,
+  ): Promise<GenerateEmbeddingResult> {
+    const model = input.model ?? this.defaultEmbeddingModel;
+    const texts = Array.isArray(input.text) ? input.text : [input.text];
+
+    // Gemini embeddings uses a slightly different endpoint
+    // batchEmbedContents for multi-text, embedContent for single.
+    if (texts.length === 1) {
+      const res = (await this.api(model, 'embedContent', {
+        content: { parts: [{ text: texts[0] }] },
+      })) as { embedding: { values: number[] } };
+      return {
+        embeddings: [res.embedding.values],
+        model,
+        provider: 'gemini',
+        dimensions: res.embedding.values.length,
+      };
+    }
+
+    const res = (await this.api(model, 'batchEmbedContents', {
+      requests: texts.map((t) => ({
+        model: `models/${model}`,
+        content: { parts: [{ text: t }] },
+      })),
+    })) as { embeddings: Array<{ values: number[] }> };
+
+    return {
+      embeddings: res.embeddings.map((e) => e.values),
+      model,
+      provider: 'gemini',
+      dimensions: res.embeddings[0]?.values.length ?? 0,
+    };
+  }
+}

--- a/backend/src/modules/ai/providers/groq.provider.ts
+++ b/backend/src/modules/ai/providers/groq.provider.ts
@@ -1,0 +1,104 @@
+/**
+ * Groq provider — ultra-low-latency LLM inference.
+ *
+ *   AI_PROVIDER=groq
+ *   GROQ_API_KEY=gsk_...
+ *   AI_MODEL=llama-3.3-70b-versatile    # optional default
+ *
+ * Groq's API is OpenAI-compatible — same `/v1/chat/completions` shape.
+ * This provider composes an `OpenAiProvider` internally and routes it
+ * at Groq's base URL with Groq's credentials. Composition (not
+ * inheritance) keeps the `readonly name` type-narrow for each class.
+ *
+ * Groq currently doesn't expose an embeddings endpoint — the provider
+ * throws `AiProviderNotSupportedError` on `generateEmbedding`.
+ *
+ * Sign up at https://console.groq.com.
+ */
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  AiProvider,
+  AiProviderNotSupportedError,
+  AnalyzeImageInput,
+  GenerateEmbeddingInput,
+  GenerateEmbeddingResult,
+  GenerateTextInput,
+  GenerateTextResult,
+} from './ai-provider.interface';
+import { OpenAiProvider } from './openai.provider';
+
+/**
+ * Proxy a ConfigService so lookups for the OpenAI-shaped env vars
+ * transparently return the Groq-equivalent values. Everything else
+ * passes through unchanged.
+ */
+function groqConfigProxy(real: ConfigService): ConfigService {
+  return new Proxy(real, {
+    get(target, prop) {
+      if (prop === 'get') {
+        return <T>(key: string, def?: T) => {
+          if (key === 'OPENAI_API_KEY') {
+            return (target as ConfigService).get<T>('GROQ_API_KEY', def as T);
+          }
+          if (key === 'OPENAI_BASE_URL') {
+            return (target as ConfigService).get<T>(
+              'GROQ_BASE_URL',
+              'https://api.groq.com/openai/v1' as unknown as T,
+            );
+          }
+          if (key === 'AI_MODEL') {
+            return (target as ConfigService).get<T>(
+              'AI_MODEL',
+              'llama-3.3-70b-versatile' as unknown as T,
+            );
+          }
+          return (target as ConfigService).get<T>(key, def as T);
+        };
+      }
+      return (target as any)[prop];
+    },
+  }) as ConfigService;
+}
+
+export class GroqProvider implements AiProvider {
+  readonly name = 'groq' as const;
+  private readonly logger = new Logger('GroqProvider');
+
+  /** Internal OpenAI-compatible client wired to api.groq.com. */
+  private readonly inner: OpenAiProvider;
+
+  constructor(config: ConfigService) {
+    this.inner = new OpenAiProvider(groqConfigProxy(config));
+    if (this.isAvailable()) {
+      this.logger.log('Groq provider configured (OpenAI-compatible)');
+    } else {
+      this.logger.warn('Groq provider selected but GROQ_API_KEY missing');
+    }
+  }
+
+  isAvailable(): boolean {
+    return this.inner.isAvailable();
+  }
+
+  async generateText(input: GenerateTextInput): Promise<GenerateTextResult> {
+    const res = await this.inner.generateText(input);
+    return { ...res, provider: 'groq' };
+  }
+
+  async analyzeImage(input: AnalyzeImageInput): Promise<GenerateTextResult> {
+    // Groq supports vision on a subset of models (e.g. llama-3.2-90b-vision).
+    // We pass through; any model mismatch surfaces as a clear API error.
+    const res = await this.inner.analyzeImage(input);
+    return { ...res, provider: 'groq' };
+  }
+
+  async generateEmbedding(
+    _input: GenerateEmbeddingInput,
+  ): Promise<GenerateEmbeddingResult> {
+    throw new AiProviderNotSupportedError(
+      'groq',
+      'generateEmbedding (Groq has no embeddings endpoint — use OpenAI, Gemini, or Ollama for vectors)',
+    );
+  }
+}

--- a/backend/src/modules/ai/providers/index.ts
+++ b/backend/src/modules/ai/providers/index.ts
@@ -1,0 +1,78 @@
+/**
+ * AI provider factory.
+ *
+ * Reads AI_PROVIDER from config and returns the matching provider.
+ * Unknown values fall back to 'none' with a warning.
+ *
+ * Add a new provider by:
+ *   1. Implementing AiProvider in <name>.provider.ts
+ *   2. Adding a case to createAiProvider() below
+ *   3. Documenting env vars in docs/providers/ai.md
+ */
+import { ConfigService } from '@nestjs/config';
+import { Logger } from '@nestjs/common';
+import { AiProvider } from './ai-provider.interface';
+import { OpenAiProvider } from './openai.provider';
+import { AnthropicProvider } from './anthropic.provider';
+import { GeminiProvider } from './gemini.provider';
+import { OllamaProvider } from './ollama.provider';
+import { GroqProvider } from './groq.provider';
+import { NoneAiProvider } from './none.provider';
+
+const log = new Logger('AiProviderFactory');
+
+export function createAiProvider(config: ConfigService): AiProvider {
+  const choice = (config.get<string>('AI_PROVIDER') || 'none')
+    .toLowerCase()
+    .trim();
+
+  switch (choice) {
+    case 'openai':
+    case 'gpt': {
+      const p = new OpenAiProvider(config);
+      log.log(`Selected AI provider: openai (available=${p.isAvailable()})`);
+      return p;
+    }
+    case 'anthropic':
+    case 'claude': {
+      const p = new AnthropicProvider(config);
+      log.log(
+        `Selected AI provider: anthropic (available=${p.isAvailable()})`,
+      );
+      return p;
+    }
+    case 'gemini':
+    case 'google': {
+      const p = new GeminiProvider(config);
+      log.log(`Selected AI provider: gemini (available=${p.isAvailable()})`);
+      return p;
+    }
+    case 'ollama':
+    case 'local': {
+      const p = new OllamaProvider(config);
+      log.log(`Selected AI provider: ollama (available=${p.isAvailable()})`);
+      return p;
+    }
+    case 'groq': {
+      const p = new GroqProvider(config);
+      log.log(`Selected AI provider: groq (available=${p.isAvailable()})`);
+      return p;
+    }
+    case 'none':
+    case '':
+      return new NoneAiProvider();
+    default:
+      log.warn(
+        `Unknown AI_PROVIDER="${choice}". Falling back to "none". Valid values: openai, anthropic, gemini, ollama, groq, none.`,
+      );
+      return new NoneAiProvider();
+  }
+}
+
+export * from './ai-provider.interface';
+export { OpenAiProvider } from './openai.provider';
+export { AnthropicProvider } from './anthropic.provider';
+export { GeminiProvider } from './gemini.provider';
+export { OllamaProvider } from './ollama.provider';
+export { GroqProvider } from './groq.provider';
+export { NoneAiProvider } from './none.provider';

--- a/backend/src/modules/ai/providers/none.provider.ts
+++ b/backend/src/modules/ai/providers/none.provider.ts
@@ -1,0 +1,53 @@
+/**
+ * "None" AI provider — AI features disabled.
+ *
+ * The default if AI_PROVIDER is unset. Every method throws
+ * AiProviderNotConfiguredError so calling code fails loudly rather
+ * than silently returning empty results (which would mask real
+ * wiring bugs during development).
+ */
+import { Logger } from '@nestjs/common';
+import {
+  AiProvider,
+  AiProviderNotConfiguredError,
+  AnalyzeImageInput,
+  GenerateEmbeddingInput,
+  GenerateEmbeddingResult,
+  GenerateTextInput,
+  GenerateTextResult,
+} from './ai-provider.interface';
+
+export class NoneAiProvider implements AiProvider {
+  readonly name = 'none' as const;
+  private readonly logger = new Logger('NoneAiProvider');
+
+  constructor() {
+    this.logger.log(
+      'AI is DISABLED (AI_PROVIDER not set). To enable, set AI_PROVIDER to one of: openai, anthropic, gemini, ollama, groq. See docs/providers/ai.md.',
+    );
+  }
+
+  isAvailable(): boolean {
+    return false;
+  }
+
+  private fail(op: string): never {
+    throw new AiProviderNotConfiguredError('none', [
+      `AI_PROVIDER (currently unset) - cannot ${op}`,
+    ]);
+  }
+
+  async generateText(_input: GenerateTextInput): Promise<GenerateTextResult> {
+    return this.fail('generateText');
+  }
+
+  async analyzeImage(_input: AnalyzeImageInput): Promise<GenerateTextResult> {
+    return this.fail('analyzeImage');
+  }
+
+  async generateEmbedding(
+    _input: GenerateEmbeddingInput,
+  ): Promise<GenerateEmbeddingResult> {
+    return this.fail('generateEmbedding');
+  }
+}

--- a/backend/src/modules/ai/providers/ollama.provider.ts
+++ b/backend/src/modules/ai/providers/ollama.provider.ts
@@ -1,0 +1,199 @@
+/**
+ * Ollama provider — local LLMs, fully offline, zero API cost.
+ *
+ *   AI_PROVIDER=ollama
+ *   OLLAMA_BASE_URL=http://localhost:11434    # default
+ *   AI_MODEL=llama3.2                         # text model
+ *   AI_VISION_MODEL=llava                     # vision model
+ *   AI_EMBEDDING_MODEL=nomic-embed-text       # embeddings model
+ *
+ * Ollama (https://ollama.com) is a local LLM runner. Install it,
+ * `ollama pull llama3.2 && ollama pull llava && ollama pull nomic-embed-text`,
+ * and set `AI_PROVIDER=ollama`. You get unlimited offline text
+ * generation, vision, and embeddings for free.
+ *
+ * This is the recommended default for local development — new
+ * contributors don't need an OpenAI API key to run the app.
+ *
+ * Run via `docker compose --profile ollama up -d` (once install PR #27 lands).
+ *
+ * Pure REST via fetch — no SDK needed.
+ */
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  AiProvider,
+  AiProviderNotConfiguredError,
+  AnalyzeImageInput,
+  GenerateEmbeddingInput,
+  GenerateEmbeddingResult,
+  GenerateTextInput,
+  GenerateTextResult,
+} from './ai-provider.interface';
+
+export class OllamaProvider implements AiProvider {
+  readonly name = 'ollama' as const;
+  private readonly logger = new Logger('OllamaProvider');
+
+  private readonly baseUrl: string;
+  private readonly defaultModel: string;
+  private readonly defaultVisionModel: string;
+  private readonly defaultEmbeddingModel: string;
+
+  constructor(config: ConfigService) {
+    this.baseUrl = (
+      config.get<string>('OLLAMA_BASE_URL', 'http://localhost:11434') ||
+      'http://localhost:11434'
+    ).replace(/\/+$/, '');
+    this.defaultModel = config.get<string>('AI_MODEL', 'llama3.2');
+    this.defaultVisionModel = config.get<string>('AI_VISION_MODEL', 'llava');
+    this.defaultEmbeddingModel = config.get<string>(
+      'AI_EMBEDDING_MODEL',
+      'nomic-embed-text',
+    );
+
+    this.logger.log(
+      `Ollama provider configured (${this.baseUrl}, model=${this.defaultModel})`,
+    );
+  }
+
+  isAvailable(): boolean {
+    // Always reportable-available; actual reachability is checked on
+    // first call. Unlike a cloud provider, there's no "credential"
+    // that could be missing — just a local HTTP server that might or
+    // might not be running.
+    return true;
+  }
+
+  private async api(path: string, body: any): Promise<any> {
+    try {
+      const res = await fetch(`${this.baseUrl}${path}`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!res.ok) {
+        const text = await res.text();
+        throw new Error(`Ollama API ${path} failed: ${res.status} ${text}`);
+      }
+      return res.json();
+    } catch (e: any) {
+      if (e.cause?.code === 'ECONNREFUSED' || /ECONNREFUSED/.test(e.message)) {
+        throw new AiProviderNotConfiguredError('ollama', [
+          `OLLAMA_BASE_URL (${this.baseUrl} unreachable — start with "ollama serve" or "docker compose --profile ollama up -d")`,
+        ]);
+      }
+      throw e;
+    }
+  }
+
+  async generateText(input: GenerateTextInput): Promise<GenerateTextResult> {
+    const model = input.model ?? this.defaultModel;
+    // Ollama's /api/chat endpoint accepts { messages } in the same
+    // shape as OpenAI, except `options.temperature` instead of
+    // top-level temperature, and `num_predict` instead of max_tokens.
+    const payload: any = {
+      model,
+      messages: input.messages,
+      stream: false,
+      options: {
+        temperature: input.temperature ?? 0.7,
+        num_predict: input.maxTokens ?? 2000,
+      },
+    };
+    if (input.jsonMode) {
+      payload.format = 'json';
+    }
+
+    const res = (await this.api('/api/chat', payload)) as {
+      message: { content: string };
+      model: string;
+      prompt_eval_count?: number;
+      eval_count?: number;
+    };
+
+    return {
+      text: res.message?.content ?? '',
+      model: res.model,
+      provider: 'ollama',
+      usage: {
+        promptTokens: res.prompt_eval_count,
+        completionTokens: res.eval_count,
+        totalTokens:
+          (res.prompt_eval_count ?? 0) + (res.eval_count ?? 0),
+      },
+    };
+  }
+
+  async analyzeImage(input: AnalyzeImageInput): Promise<GenerateTextResult> {
+    const model = input.model ?? this.defaultVisionModel;
+
+    // Ollama expects base64 images (without data: prefix) in an
+    // `images` array on the user message.
+    let base64: string;
+    if (input.image.startsWith('data:')) {
+      base64 = input.image.replace(/^data:[^;]+;base64,/, '');
+    } else if (/^https?:\/\//.test(input.image)) {
+      // Fetch the URL and base64-encode locally. Ollama doesn't
+      // accept remote URLs directly.
+      const res = await fetch(input.image);
+      if (!res.ok) {
+        throw new Error(
+          `Ollama provider: failed to fetch image URL ${input.image}: ${res.status}`,
+        );
+      }
+      const buf = Buffer.from(await res.arrayBuffer());
+      base64 = buf.toString('base64');
+    } else {
+      // Assume it's already base64.
+      base64 = input.image;
+    }
+
+    const payload = {
+      model,
+      messages: [
+        {
+          role: 'user',
+          content: input.prompt,
+          images: [base64],
+        },
+      ],
+      stream: false,
+      options: {
+        num_predict: input.maxTokens ?? 2000,
+      },
+    };
+
+    const res = (await this.api('/api/chat', payload)) as {
+      message: { content: string };
+      model: string;
+    };
+
+    return {
+      text: res.message?.content ?? '',
+      model: res.model,
+      provider: 'ollama',
+    };
+  }
+
+  async generateEmbedding(
+    input: GenerateEmbeddingInput,
+  ): Promise<GenerateEmbeddingResult> {
+    const model = input.model ?? this.defaultEmbeddingModel;
+    const texts = Array.isArray(input.text) ? input.text : [input.text];
+
+    // Ollama's /api/embed takes `input: string | string[]` and
+    // returns `{ embeddings: number[][] }`.
+    const res = (await this.api('/api/embed', {
+      model,
+      input: texts,
+    })) as { embeddings: number[][] };
+
+    return {
+      embeddings: res.embeddings ?? [],
+      model,
+      provider: 'ollama',
+      dimensions: res.embeddings?.[0]?.length ?? 0,
+    };
+  }
+}

--- a/backend/src/modules/ai/providers/openai.provider.ts
+++ b/backend/src/modules/ai/providers/openai.provider.ts
@@ -1,0 +1,182 @@
+/**
+ * OpenAI provider.
+ *
+ *   AI_PROVIDER=openai
+ *   OPENAI_API_KEY=sk-...
+ *   AI_MODEL=gpt-4o-mini                # optional text default
+ *   AI_VISION_MODEL=gpt-4o              # optional vision default
+ *   AI_EMBEDDING_MODEL=text-embedding-3-small   # optional
+ *
+ * Pure REST via fetch — no SDK dep. The provider exposes chat
+ * completions, vision, and embeddings through the standard /v1
+ * endpoints.
+ *
+ * Also handles "OpenAI-compatible" services by honoring OPENAI_BASE_URL,
+ * so you can point this at Azure OpenAI (different base URL), LiteLLM,
+ * LocalAI, or any other compatible gateway.
+ */
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  AiProvider,
+  AiProviderNotConfiguredError,
+  AnalyzeImageInput,
+  GenerateEmbeddingInput,
+  GenerateEmbeddingResult,
+  GenerateTextInput,
+  GenerateTextResult,
+} from './ai-provider.interface';
+
+const DEFAULT_BASE_URL = 'https://api.openai.com/v1';
+
+export class OpenAiProvider implements AiProvider {
+  readonly name = 'openai' as const;
+  private readonly logger = new Logger('OpenAiProvider');
+
+  protected readonly apiKey: string;
+  protected readonly baseUrl: string;
+  protected readonly defaultModel: string;
+  protected readonly defaultVisionModel: string;
+  protected readonly defaultEmbeddingModel: string;
+
+  constructor(config: ConfigService) {
+    this.apiKey = config.get<string>('OPENAI_API_KEY', '');
+    this.baseUrl = (
+      config.get<string>('OPENAI_BASE_URL', DEFAULT_BASE_URL) || DEFAULT_BASE_URL
+    ).replace(/\/+$/, '');
+    this.defaultModel = config.get<string>('AI_MODEL', 'gpt-4o-mini');
+    this.defaultVisionModel = config.get<string>('AI_VISION_MODEL', 'gpt-4o');
+    this.defaultEmbeddingModel = config.get<string>(
+      'AI_EMBEDDING_MODEL',
+      'text-embedding-3-small',
+    );
+
+    if (this.isAvailable()) {
+      this.logger.log(
+        `OpenAI provider configured (${this.baseUrl}, model=${this.defaultModel})`,
+      );
+    } else {
+      this.logger.warn('OpenAI provider selected but OPENAI_API_KEY missing');
+    }
+  }
+
+  isAvailable(): boolean {
+    return !!this.apiKey;
+  }
+
+  protected async api(path: string, body: any): Promise<any> {
+    if (!this.isAvailable()) {
+      throw new AiProviderNotConfiguredError(this.name, ['OPENAI_API_KEY']);
+    }
+    const res = await fetch(`${this.baseUrl}${path}`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(
+        `${this.name} API ${path} failed: ${res.status} ${text}`,
+      );
+    }
+    return res.json();
+  }
+
+  async generateText(input: GenerateTextInput): Promise<GenerateTextResult> {
+    const payload: any = {
+      model: input.model ?? this.defaultModel,
+      messages: input.messages,
+      max_tokens: input.maxTokens ?? 2000,
+      temperature: input.temperature ?? 0.7,
+    };
+    if (input.jsonMode) {
+      payload.response_format = { type: 'json_object' };
+    }
+
+    const res = (await this.api('/chat/completions', payload)) as {
+      choices: Array<{ message: { content: string } }>;
+      model: string;
+      usage?: {
+        prompt_tokens?: number;
+        completion_tokens?: number;
+        total_tokens?: number;
+      };
+    };
+
+    return {
+      text: res.choices?.[0]?.message?.content ?? '',
+      model: res.model,
+      provider: this.name,
+      usage: res.usage
+        ? {
+            promptTokens: res.usage.prompt_tokens,
+            completionTokens: res.usage.completion_tokens,
+            totalTokens: res.usage.total_tokens,
+          }
+        : undefined,
+    };
+  }
+
+  async analyzeImage(input: AnalyzeImageInput): Promise<GenerateTextResult> {
+    // OpenAI's vision input goes through /chat/completions with a
+    // user message containing multiple content parts.
+    const payload: any = {
+      model: input.model ?? this.defaultVisionModel,
+      max_tokens: input.maxTokens ?? 2000,
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: input.prompt },
+            {
+              type: 'image_url',
+              image_url: { url: input.image },
+            },
+          ],
+        },
+      ],
+    };
+
+    const res = (await this.api('/chat/completions', payload)) as {
+      choices: Array<{ message: { content: string } }>;
+      model: string;
+      usage?: any;
+    };
+    return {
+      text: res.choices?.[0]?.message?.content ?? '',
+      model: res.model,
+      provider: this.name,
+      usage: res.usage
+        ? {
+            promptTokens: res.usage.prompt_tokens,
+            completionTokens: res.usage.completion_tokens,
+            totalTokens: res.usage.total_tokens,
+          }
+        : undefined,
+    };
+  }
+
+  async generateEmbedding(
+    input: GenerateEmbeddingInput,
+  ): Promise<GenerateEmbeddingResult> {
+    const texts = Array.isArray(input.text) ? input.text : [input.text];
+    const model = input.model ?? this.defaultEmbeddingModel;
+    const res = (await this.api('/embeddings', {
+      model,
+      input: texts,
+    })) as {
+      data: Array<{ embedding: number[] }>;
+      model: string;
+    };
+    const embeddings = res.data.map((d) => d.embedding);
+    return {
+      embeddings,
+      model: res.model,
+      provider: this.name,
+      dimensions: embeddings[0]?.length ?? 0,
+    };
+  }
+}


### PR DESCRIPTION
## Summary

Closes #27. Direct port of vasty-shop PR #32. Team@Once now has the same pluggable AI provider adapter — swap OpenAI for Anthropic / Gemini / Ollama / Groq by changing a single env var.

Provider files are copied verbatim from vasty-shop's branch. Both repos use the same NestJS + ConfigService stack.

## What's in it

6 providers under `backend/src/modules/ai/providers/`:
- **openai** *(default)* — chat completions + vision + embeddings
- **anthropic** — Messages API, system-message split, vision blocks; NotSupported on embeddings
- **gemini** — generateContent + native JSON mode + role translation
- **ollama** — local, fully offline, LLaVA vision, nomic-embed-text
- **groq** — OpenAI-compatible, composes OpenAiProvider at api.groq.com
- **none** — disabled stub

**`AiProviderService`** new façade; `AIModule` exports it alongside the legacy `AIService` + `EmbeddingService` for backwards compatibility.

## Team@Once-specific deltas vs vasty #32

- **Three services exported** from `AIModule`: the legacy `AIService` (~assessments/courses pipeline), legacy `EmbeddingService`, and the new `AiProviderService`. All three stay for backwards compatibility.
- **Default `AI_PROVIDER=openai`** — Team@Once ships with a working OpenAI stack today, so the default keeps existing deployments unchanged. Vasty defaulted to `none` because its legacy service wasn't wired up.
- **`.env.example`** adds a new AI section **below** the existing OPENAI block. The legacy `OPENAI_API_KEY` / `OPENAI_MODEL` vars stay — the new provider reads the same `OPENAI_API_KEY`, so existing `.env` files continue working.

## Verification status (honest)

| Provider | Status |
|---|---|
| **openai** / **anthropic** / **gemini** / **ollama** / **groq** | written, **smoke-tested** (mocked HTTP verifies URL, auth, payload translation). **NOT tested** against real APIs |
| **none** | written, **smoke-tested** (throws as expected) |

Full TypeScript compile: **0 errors**.

Smoke test: **59/59 assertions pass** on teamatonce — identical to vasty-shop's suite.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx ts-node scripts/smoke-test-ai-providers.ts` 59/59 pass
- [ ] Manual: set `AI_PROVIDER=ollama`, start local Ollama, hit the existing `/ai/*` endpoints and verify they still work via the new façade once the AIService migration lands
- [ ] Manual: test each paid provider with real credentials

## Out of scope

- Migrating `AIService` (~900 lines of assessment / course content generation) to delegate to `AiProviderService`
- Migrating `EmbeddingService` to use `AiProviderService.generateEmbedding`
- Deleting the hardcoded OpenAI code paths

Those are 3 separate follow-up PRs — keeping this one narrow to just ship the adapter.

## Related

- vasty-shop PR #32 — the identical adapter on the sibling repo
- Tracking issue #38 (pluggable providers meta)

🤖 Generated with [Claude Code](https://claude.com/claude-code)