### PR TITLE
feat(push): pluggable push notifications (webpush/fcm/onesignal/expo)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -91,3 +91,29 @@ OPENAI_MODEL=gpt-4o-mini
 QDRANT_HOST=localhost
 QDRANT_PORT=6333
 QDRANT_API_KEY=your_qdrant_api_key
+
+# =====================================================
+# PUSH NOTIFICATIONS (pluggable)
+# =====================================================
+# Pick a provider. See backend/docs/providers/push.md.
+#
+# Valid values: webpush | fcm | onesignal | expo | none
+
+PUSH_PROVIDER=none
+
+# --- Web Push (W3C VAPID, no vendor account) ---
+# Generate keys once: npx web-push generate-vapid-keys
+VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+VAPID_SUBJECT=mailto:admin@teamatonce.com
+
+# --- Firebase Cloud Messaging (already required by legacy notifications) ---
+# FIREBASE_SERVICE_ACCOUNT is set above in the existing Firebase section
+FIREBASE_WEB_CONFIG=
+
+# --- OneSignal (https://onesignal.com) ---
+ONESIGNAL_APP_ID=
+ONESIGNAL_API_KEY=
+
+# --- Expo push (for React Native / Expo mobile apps) ---
+EXPO_ACCESS_TOKEN=

--- a/backend/docs/providers/push.md
+++ b/backend/docs/providers/push.md
@@ -1,0 +1,157 @@
+# Push notification providers
+
+Vasty Shop supports four push backends plus a `none` default for
+delivering order updates, flash-sale alerts, shipping notifications,
+chat messages, and promotional campaigns.
+
+```
+PUSH_PROVIDER=webpush   # zero-vendor default
+```
+
+## Comparison
+
+| Provider | Platforms | Cost | Infra | Server dep | Best for |
+|---|---|---|---|---|---|
+| **webpush** *(recommended for web)* | web | free | none | `web-push` *(optional)* | PWAs, web-only apps |
+| **fcm** | android + ios + web | free | Firebase account | `firebase-admin` *(optional)* | cross-platform coverage |
+| **onesignal** | web + android + ios | free up to 10k subs | none | none (REST) | easiest managed option |
+| **expo** | iOS + Android (React Native) | free | none | none (REST) | Expo-built mobile apps |
+| **apns** | iOS (direct) | — | — | — | [planned #21] |
+| **none** *(default if unset)* | — | — | — | — | push features disabled |
+
+## Which should I pick?
+
+- **"I have a web app and want browser notifications"** → `webpush` (no vendor account, works in every modern browser)
+- **Cross-platform: web + Android + iOS app** → `fcm` (FCM delivers to iOS via APNs under the hood, so it's the cheapest path to all three)
+- **"I just want one dashboard for everything"** → `onesignal`
+- **React Native / Expo mobile app** → `expo`
+- **Not using push yet** → leave `PUSH_PROVIDER` unset; the web client should check `/config/push` and hide notification UI when provider is `none`
+
+## Per-provider setup
+
+### webpush (W3C Web Push + VAPID)
+
+Zero vendor account. Works in Chrome, Firefox, Safari 16+, Edge, and
+every other modern browser that implements the W3C Push API.
+
+```bash
+# One-time: generate a VAPID key pair
+npx web-push generate-vapid-keys
+```
+
+```
+PUSH_PROVIDER=webpush
+VAPID_PUBLIC_KEY=BJ...           # base64url public key
+VAPID_PRIVATE_KEY=xJ...          # base64url private key — KEEP SECRET
+VAPID_SUBJECT=mailto:admin@yourdomain.com
+```
+
+The `web-push` package is in **optionalDependencies** — it's lazy-loaded on first use. If you pick a different provider, it's never installed.
+
+**Frontend flow**:
+1. Client fetches `/api/v1/config/push` → gets `vapidPublicKey`
+2. Registers a service worker that calls `ServiceWorkerRegistration.pushManager.subscribe({ applicationServerKey: vapidPublicKey, userVisibleOnly: true })`
+3. Sends the resulting `PushSubscription` JSON to the backend via a device-token registration endpoint
+4. Backend stores the JSON as the device's token; when pushing, it JSON-parses the token and passes to `web-push.sendNotification()`
+
+**Recipient tokens are JSON-stringified `PushSubscription` objects** (not opaque strings). The provider parses them on every send.
+
+### fcm (Firebase Cloud Messaging)
+
+Sign up at <https://console.firebase.google.com>, create a project, go to Project Settings → Service Accounts, and generate a new private key. You can either paste the whole JSON into an env var or point at a file.
+
+```
+PUSH_PROVIDER=fcm
+FIREBASE_SERVICE_ACCOUNT={"type":"service_account","project_id":"your-project",...}
+# OR
+FIREBASE_SERVICE_ACCOUNT_FILE=/etc/secrets/firebase.json
+
+# Optional: for the web SDK bootstrap on the frontend
+FIREBASE_WEB_CONFIG={"apiKey":"...","projectId":"...","messagingSenderId":"...","appId":"..."}
+```
+
+The `firebase-admin` package is in **optionalDependencies** — lazy-loaded on first use. If you pick a different provider, you don't install it (save ~50MB).
+
+**Batch sending**: `sendBulk` uses FCM's `sendAll` API which accepts up to 500 messages per request. The provider automatically chunks larger fan-outs.
+
+**iOS via FCM**: FCM can deliver to iOS devices by having them register with APNs and forward the device token to FCM. This is the recommended path for cross-platform apps — one backend integration instead of two.
+
+### onesignal
+
+Sign up at <https://onesignal.com>, create an app, copy the App ID and REST API Key from Settings → Keys & IDs. The REST API Key (not the User Auth Key) is what the backend uses.
+
+```
+PUSH_PROVIDER=onesignal
+ONESIGNAL_APP_ID=...
+ONESIGNAL_API_KEY=...              # REST API key
+```
+
+Pure REST — no SDK dep. The provider passes up to 2000 `player_id`s per request via `include_player_ids`; larger fan-outs are chunked automatically.
+
+**Single-message vs batch**: OneSignal returns one notification id per request, not per recipient. The provider synthesizes per-recipient results by reporting the same `messageId` for every recipient in the batch.
+
+### expo (for Expo-built React Native apps)
+
+```
+PUSH_PROVIDER=expo
+EXPO_ACCESS_TOKEN=...              # optional; raises rate limits
+```
+
+Works without credentials (rate-limited by Expo). Set `EXPO_ACCESS_TOKEN` for higher limits.
+
+**Recipient tokens** are `ExponentPushToken[xxxxxxxxxx]` strings obtained client-side via the Expo SDK's `Notifications.getExpoPushTokenAsync()`.
+
+**Batching**: Expo recommends up to 100 messages per request. The provider automatically chunks.
+
+**Per-message failures**: Expo returns a "ticket" per message in the batch. Tickets with `status: 'error'` (e.g. `DeviceNotRegistered` for stale tokens) are surfaced as `{ accepted: false, error }` in the bulk result so callers can remove dead tokens from the device table.
+
+### apns (planned #21)
+
+Not yet implemented. `PUSH_PROVIDER=apns` logs a warning and falls back to `none`. For iOS push today, use `fcm` — FCM delivers to APNs under the hood and saves you from maintaining a separate APNs integration.
+
+### none (default if unset)
+
+Every method throws `PushProviderNotConfiguredError`. The startup log prints which env var to set.
+
+## Device token table
+
+Regardless of provider, you'll want a `device_tokens` table keyed on `user_id` that stores:
+- `token` (provider-specific format)
+- `provider` (so migrations between providers don't mix tokens)
+- `platform` (web / ios / android)
+- `last_seen_at`
+- `invalid_at` (set when a send fails with a "token not registered" error)
+
+The push module doesn't ship this table — it's application-level concerns. Wire `PushService.sendBulk(tokens, message)` into your notification service and have it mark tokens with `accepted: false && error.includes('NotRegistered'|410|404)` as invalid.
+
+## Public bootstrap endpoint
+
+```
+GET /api/v1/config/push
+```
+
+Returns only public-safe fields:
+
+```json
+{
+  "provider": "webpush",
+  "vapidPublicKey": "BJ...",
+  "oneSignalAppId": null,
+  "fcmConfig": null,
+  "extra": null
+}
+```
+
+The frontend PWA calls this once on page load to know which provider to bootstrap (service worker registration for webpush, OneSignal SDK for onesignal, Firebase web SDK for fcm).
+
+## Adding a new provider
+
+1. Implement `PushProvider` in
+   `backend/src/modules/push/providers/<name>.provider.ts`
+2. Add a case to `createPushProvider()` in `providers/index.ts`
+3. Document env vars in this file and in `.env.example`
+4. If the provider needs a package, add it to `optionalDependencies`
+   in `backend/package.json` and `require()` it inside `loadSdk()`.
+5. Add smoke-test coverage in
+   `backend/scripts/smoke-test-push-providers.ts` — mock `require()`
+   (see how webpush / fcm are tested) or mock `fetch` (see onesignal / expo).

--- a/backend/package.json
+++ b/backend/package.json
@@ -80,6 +80,9 @@
     "stripe": "^22.0.1",
     "uuid": "^11.1.0"
   },
+  "optionalDependencies": {
+    "web-push": "^3.6.7"
+  },
   "devDependencies": {
     "@nestjs/cli": "^11.0.14",
     "@nestjs/schematics": "^11.0.7",

--- a/backend/scripts/smoke-test-push-providers.ts
+++ b/backend/scripts/smoke-test-push-providers.ts
@@ -262,11 +262,13 @@ async function main(): Promise<void> {
             sentMessages.push(msg);
             return `fcm-msg-${sentMessages.length}`;
           },
-          sendAll: async (msgs: any[]) => ({
+          sendEach: async (msgs: any[]) => ({
             responses: msgs.map((_, i) => ({
               success: true,
               messageId: `fcm-batch-${i}`,
             })),
+            successCount: msgs.length,
+            failureCount: 0,
           }),
         }),
       };
@@ -309,8 +311,8 @@ async function main(): Promise<void> {
       );
     }
 
-    // 7. fcm sendBulk → sendAll batches
-    console.log('\n7. fcm sendBulk uses sendAll batch API');
+    // 7. fcm sendBulk → sendEach batches
+    console.log('\n7. fcm sendBulk uses sendEach batch API');
     {
       const p = createPushProvider(
         fakeConfig({

--- a/backend/scripts/smoke-test-push-providers.ts
+++ b/backend/scripts/smoke-test-push-providers.ts
@@ -1,0 +1,521 @@
+/**
+ * Smoke test for the multi-provider push factory.
+ *
+ * - webpush: mocks `require('web-push')` via a global cache override
+ *   so the lazy loadSdk() resolves our fake sendNotification
+ * - fcm: same pattern for `require('firebase-admin')`
+ * - onesignal / expo: mock fetch to verify URL + auth + payload
+ * - none: throws on every call
+ *
+ * Run with: npx ts-node scripts/smoke-test-push-providers.ts
+ */
+import * as Module from 'module';
+import { ConfigService } from '@nestjs/config';
+import {
+  createPushProvider,
+  PushProviderNotConfiguredError,
+} from '../src/modules/push/providers';
+
+function fakeConfig(env: Record<string, string>): ConfigService {
+  return {
+    get: <T>(key: string, def?: T) => (env[key] as any) ?? def,
+  } as unknown as ConfigService;
+}
+
+// =====================================================================
+// require() override — lets us inject fake web-push / firebase-admin
+// without actually installing them. The push providers use
+// `require('web-push')` inside loadSdk(), which hits Node's module
+// resolver; we intercept at that layer by replacing Module.prototype.require.
+// =====================================================================
+
+const moduleMocks: Record<string, any> = {};
+const originalRequire = Module.prototype.require;
+function installModuleMocks() {
+  (Module.prototype as any).require = function (id: string) {
+    if (id in moduleMocks) return moduleMocks[id];
+    return originalRequire.call(this, id);
+  };
+}
+function restoreModuleMocks() {
+  (Module.prototype as any).require = originalRequire;
+}
+
+// =====================================================================
+// Fetch mock for REST providers
+// =====================================================================
+
+type FetchCall = {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: string | null;
+};
+const fetchCalls: FetchCall[] = [];
+const realFetch = global.fetch;
+function installMockFetch(status = 200, body: any = {}) {
+  global.fetch = (async (url: any, init: any = {}) => {
+    const headers: Record<string, string> = {};
+    if (init.headers) {
+      for (const [k, v] of Object.entries(init.headers)) {
+        headers[k] = String(v);
+      }
+    }
+    fetchCalls.push({
+      url: String(url),
+      method: init.method ?? 'GET',
+      headers,
+      body: typeof init.body === 'string' ? init.body : null,
+    });
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as any;
+}
+function restoreFetch() {
+  global.fetch = realFetch;
+}
+
+async function expectThrow(
+  label: string,
+  fn: () => Promise<unknown>,
+  matcher: (e: Error) => boolean,
+): Promise<boolean> {
+  try {
+    await fn();
+    console.log(`  ❌ ${label}: expected throw, got success`);
+    return false;
+  } catch (e) {
+    if (matcher(e as Error)) {
+      console.log(`  ✅ ${label}: threw as expected`);
+      return true;
+    }
+    console.log(`  ❌ ${label}: wrong error: ${(e as Error).message}`);
+    return false;
+  }
+}
+
+async function main(): Promise<void> {
+  let pass = 0;
+  let fail = 0;
+  const ok = (b: boolean, msg?: string) => {
+    if (b) pass++;
+    else {
+      fail++;
+      if (msg) console.log(`  ⚠️  ${msg}`);
+    }
+  };
+  console.log('=== Push provider factory smoke test ===\n');
+  installModuleMocks();
+
+  try {
+    // 1. none default
+    console.log('1. no PUSH_PROVIDER → none');
+    {
+      const p = createPushProvider(fakeConfig({}));
+      ok(p.name === 'none');
+      ok(p.isAvailable() === false);
+      ok(
+        await expectThrow(
+          'send fails loudly',
+          () =>
+            p.send({ token: 't' }, { title: 'T', body: 'B' }),
+          (e) => e instanceof PushProviderNotConfiguredError,
+        ),
+      );
+      const config = p.getPublicConfig();
+      ok(config.provider === 'none');
+      ok((config.extra as any)?.disabled === true);
+      console.log(`  ✅ publicConfig reports disabled`);
+    }
+
+    // 2. webpush without VAPID → unavailable
+    console.log('\n2. webpush without VAPID keys → unavailable');
+    {
+      const p = createPushProvider(fakeConfig({ PUSH_PROVIDER: 'webpush' }));
+      ok(p.name === 'webpush');
+      ok(p.isAvailable() === false);
+      ok(
+        await expectThrow(
+          'send throws NotConfigured',
+          () => p.send({ token: '{}' }, { title: 'T', body: 'B' }),
+          (e) => e instanceof PushProviderNotConfiguredError,
+        ),
+      );
+    }
+
+    // 3. webpush happy path via mocked `web-push` module
+    console.log('\n3. webpush with VAPID keys + mocked web-push package');
+    {
+      const sendNotificationCalls: Array<{
+        subscription: any;
+        payload: string;
+        options: any;
+      }> = [];
+      moduleMocks['web-push'] = {
+        setVapidDetails: (_sub: string, _pub: string, _priv: string) => {
+          /* noop */
+        },
+        sendNotification: async (
+          subscription: any,
+          payload: string,
+          options: any,
+        ) => {
+          sendNotificationCalls.push({ subscription, payload, options });
+          return { headers: { 'message-id': 'msg-abc-123' } };
+        },
+      };
+
+      const p = createPushProvider(
+        fakeConfig({
+          PUSH_PROVIDER: 'webpush',
+          VAPID_PUBLIC_KEY: 'BPub',
+          VAPID_PRIVATE_KEY: 'BPriv',
+          VAPID_SUBJECT: 'mailto:test@example.com',
+        }),
+      );
+      ok(p.isAvailable() === true);
+
+      const subscription = {
+        endpoint: 'https://fcm.googleapis.com/fcm/send/abc',
+        keys: { p256dh: 'dhkey', auth: 'authkey' },
+      };
+      const result = await p.send(
+        { token: JSON.stringify(subscription) },
+        {
+          title: 'Hello',
+          body: 'World',
+          url: '/products/1',
+          data: { orderId: '42' },
+        },
+      );
+      ok(result.accepted === true);
+      ok(result.provider === 'webpush');
+      ok(result.messageId === 'msg-abc-123');
+      console.log(`  ✅ sendNotification called, returned ${result.messageId}`);
+
+      // Verify payload was JSON-stringified with the expected keys
+      const call = sendNotificationCalls[0];
+      ok(call !== undefined, 'sendNotification was not called');
+      const parsed = JSON.parse(call!.payload);
+      ok(parsed.title === 'Hello');
+      ok(parsed.body === 'World');
+      ok(parsed.url === '/products/1');
+      ok(parsed.data?.orderId === '42');
+      console.log(`  ✅ payload shape correct`);
+
+      // Public config exposes the VAPID public key
+      const config = p.getPublicConfig();
+      ok(config.vapidPublicKey === 'BPub');
+    }
+
+    // 4. webpush invalid token → rejected (not thrown)
+    console.log('\n4. webpush with malformed token → returns accepted=false');
+    {
+      moduleMocks['web-push'] = {
+        setVapidDetails: () => {},
+        sendNotification: async () => {
+          throw new Error('dummy');
+        },
+      };
+      const p = createPushProvider(
+        fakeConfig({
+          PUSH_PROVIDER: 'webpush',
+          VAPID_PUBLIC_KEY: 'BPub',
+          VAPID_PRIVATE_KEY: 'BPriv',
+        }),
+      );
+      const result = await p.send(
+        { token: 'not-json' },
+        { title: 'T', body: 'B' },
+      );
+      ok(result.accepted === false);
+      ok(result.error?.includes('Invalid Web Push token') === true);
+      console.log(`  ✅ malformed token → accepted=false with clear error`);
+    }
+
+    // 5. fcm without creds → unavailable
+    console.log('\n5. fcm without service account → unavailable');
+    {
+      const p = createPushProvider(fakeConfig({ PUSH_PROVIDER: 'fcm' }));
+      ok(p.name === 'fcm');
+      ok(p.isAvailable() === false);
+    }
+
+    // 6. fcm happy path via mocked firebase-admin
+    console.log('\n6. fcm with service account + mocked firebase-admin');
+    {
+      const sentMessages: any[] = [];
+      moduleMocks['firebase-admin'] = {
+        credential: {
+          cert: (_arg: any) => ({ type: 'cert' }),
+        },
+        apps: [] as any[],
+        initializeApp: (_opts: any) => {
+          const app = { name: '[DEFAULT]' };
+          moduleMocks['firebase-admin'].apps = [app];
+          return app;
+        },
+        messaging: (_app: any) => ({
+          send: async (msg: any) => {
+            sentMessages.push(msg);
+            return `fcm-msg-${sentMessages.length}`;
+          },
+          sendAll: async (msgs: any[]) => ({
+            responses: msgs.map((_, i) => ({
+              success: true,
+              messageId: `fcm-batch-${i}`,
+            })),
+          }),
+        }),
+      };
+
+      const serviceAccount = JSON.stringify({
+        type: 'service_account',
+        project_id: 'my-project',
+        private_key: '...',
+      });
+
+      const p = createPushProvider(
+        fakeConfig({
+          PUSH_PROVIDER: 'fcm',
+          FIREBASE_SERVICE_ACCOUNT: serviceAccount,
+        }),
+      );
+      ok(p.isAvailable() === true);
+
+      const result = await p.send(
+        { token: 'fcm-device-token' },
+        {
+          title: 'Order shipped',
+          body: 'Your order #42 is on the way',
+          url: '/orders/42',
+          data: { orderId: '42' },
+          badge: 1,
+        },
+      );
+      ok(result.accepted === true);
+      ok(result.messageId === 'fcm-msg-1');
+
+      const sent = sentMessages[0];
+      ok(sent.token === 'fcm-device-token');
+      ok(sent.notification.title === 'Order shipped');
+      ok(sent.data.orderId === '42');
+      ok(sent.data.url === '/orders/42');
+      ok(sent.apns.payload.aps.badge === 1);
+      console.log(
+        `  ✅ fcm send: message shape correct (notification + data + apns + webpush)`,
+      );
+    }
+
+    // 7. fcm sendBulk → sendAll batches
+    console.log('\n7. fcm sendBulk uses sendAll batch API');
+    {
+      const p = createPushProvider(
+        fakeConfig({
+          PUSH_PROVIDER: 'fcm',
+          FIREBASE_SERVICE_ACCOUNT: JSON.stringify({ type: 'sa' }),
+        }),
+      );
+      const result = await p.sendBulk(
+        [
+          { token: 't1' },
+          { token: 't2' },
+          { token: 't3' },
+        ],
+        { title: 'Flash sale', body: 'Starts now' },
+      );
+      ok(result.accepted === 3);
+      ok(result.failed === 0);
+      console.log(`  ✅ sendBulk → ${result.accepted} accepted, ${result.failed} failed`);
+    }
+
+    // 8. onesignal without keys → unavailable
+    console.log('\n8. onesignal without keys → unavailable');
+    {
+      const p = createPushProvider(fakeConfig({ PUSH_PROVIDER: 'onesignal' }));
+      ok(p.name === 'onesignal');
+      ok(p.isAvailable() === false);
+    }
+
+    // 9. onesignal happy path
+    console.log('\n9. onesignal send (mocked network)');
+    {
+      installMockFetch(200, { id: 'os-notif-xyz' });
+      try {
+        const p = createPushProvider(
+          fakeConfig({
+            PUSH_PROVIDER: 'onesignal',
+            ONESIGNAL_APP_ID: 'app-123',
+            ONESIGNAL_API_KEY: 'key-abc',
+          }),
+        );
+        ok(p.isAvailable() === true);
+        const result = await p.send(
+          { token: 'player-id-1' },
+          {
+            title: 'Flash sale',
+            body: 'Starts in 10 minutes',
+            url: '/sales/flash',
+            tag: 'flash-sale',
+          },
+        );
+        ok(result.accepted === true);
+        ok(result.messageId === 'os-notif-xyz');
+
+        const call = fetchCalls[fetchCalls.length - 1];
+        ok(call.url === 'https://onesignal.com/api/v1/notifications');
+        ok(call.headers['Authorization'] === 'Basic key-abc');
+        const payload = JSON.parse(call.body!);
+        ok(payload.app_id === 'app-123');
+        ok(payload.include_player_ids[0] === 'player-id-1');
+        ok(payload.headings.en === 'Flash sale');
+        ok(payload.contents.en === 'Starts in 10 minutes');
+        ok(payload.collapse_id === 'flash-sale');
+        console.log(`  ✅ URL, Basic auth, payload shape correct`);
+      } finally {
+        restoreFetch();
+        fetchCalls.length = 0;
+      }
+    }
+
+    // 10. expo always available, happy path
+    console.log('\n10. expo send (mocked network)');
+    {
+      installMockFetch(200, {
+        data: [{ status: 'ok', id: 'expo-ticket-1' }],
+      });
+      try {
+        const p = createPushProvider(fakeConfig({ PUSH_PROVIDER: 'expo' }));
+        ok(p.isAvailable() === true);
+        const result = await p.send(
+          { token: 'ExponentPushToken[abc]' },
+          { title: 'Hello', body: 'World', sound: 'default' },
+        );
+        ok(result.accepted === true);
+        ok(result.messageId === 'expo-ticket-1');
+
+        const call = fetchCalls[fetchCalls.length - 1];
+        ok(call.url === 'https://exp.host/--/api/v2/push/send');
+        const payload = JSON.parse(call.body!);
+        ok(Array.isArray(payload));
+        ok(payload[0].to === 'ExponentPushToken[abc]');
+        ok(payload[0].title === 'Hello');
+        console.log(`  ✅ expo send correct`);
+      } finally {
+        restoreFetch();
+        fetchCalls.length = 0;
+      }
+    }
+
+    // 11. expo per-message error → accepted=false
+    console.log('\n11. expo per-message DeviceNotRegistered → accepted=false');
+    {
+      installMockFetch(200, {
+        data: [
+          {
+            status: 'error',
+            message: 'DeviceNotRegistered',
+          },
+        ],
+      });
+      try {
+        const p = createPushProvider(fakeConfig({ PUSH_PROVIDER: 'expo' }));
+        const result = await p.send(
+          { token: 'ExponentPushToken[stale]' },
+          { title: 'T', body: 'B' },
+        );
+        ok(result.accepted === false);
+        ok(result.error === 'DeviceNotRegistered');
+        console.log(`  ✅ stale token → accepted=false`);
+      } finally {
+        restoreFetch();
+        fetchCalls.length = 0;
+      }
+    }
+
+    // 12. expo sendBulk chunks
+    console.log('\n12. expo sendBulk batches at 100');
+    {
+      // Build 205 recipients — should produce 3 batches (100, 100, 5)
+      const recipients = Array.from({ length: 205 }, (_, i) => ({
+        token: `ExponentPushToken[${i}]`,
+      }));
+      let callCount = 0;
+      installMockFetch(200, {});
+      global.fetch = (async (url: any, init: any) => {
+        callCount++;
+        const body = JSON.parse(init.body);
+        const tickets = body.map((_: any, i: number) => ({
+          status: 'ok',
+          id: `tix-${callCount}-${i}`,
+        }));
+        return new Response(JSON.stringify({ data: tickets }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }) as any;
+      try {
+        const p = createPushProvider(fakeConfig({ PUSH_PROVIDER: 'expo' }));
+        const result = await p.sendBulk(recipients, {
+          title: 'Bulk',
+          body: 'Hi',
+        });
+        ok(callCount === 3, `expected 3 batches, got ${callCount}`);
+        ok(result.accepted === 205);
+        ok(result.failed === 0);
+        console.log(
+          `  ✅ 205 recipients → ${callCount} batches, ${result.accepted} accepted`,
+        );
+      } finally {
+        restoreFetch();
+        fetchCalls.length = 0;
+      }
+    }
+
+    // 13. apns → planned fallback
+    console.log('\n13. apns → planned, falls back to none');
+    {
+      const p = createPushProvider(fakeConfig({ PUSH_PROVIDER: 'apns' }));
+      ok(p.name === 'none');
+      console.log(`  ✅ apns planned → fallback to none`);
+    }
+
+    // 14. unknown value
+    console.log('\n14. unknown PUSH_PROVIDER → none (fallback)');
+    {
+      const p = createPushProvider(fakeConfig({ PUSH_PROVIDER: 'foobar' }));
+      ok(p.name === 'none');
+    }
+
+    // 15. aliases
+    console.log('\n15. aliases');
+    {
+      ok(
+        createPushProvider(fakeConfig({ PUSH_PROVIDER: 'web-push' })).name ===
+          'webpush',
+      );
+      ok(
+        createPushProvider(fakeConfig({ PUSH_PROVIDER: 'firebase' })).name ===
+          'fcm',
+      );
+      ok(
+        createPushProvider(fakeConfig({ PUSH_PROVIDER: 'one-signal' }))
+          .name === 'onesignal',
+      );
+      console.log(`  ✅ web-push→webpush, firebase→fcm, one-signal→onesignal`);
+    }
+  } finally {
+    restoreModuleMocks();
+    restoreFetch();
+  }
+
+  console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+  process.exit(fail > 0 ? 1 : 0);
+}
+
+main().catch((e) => {
+  console.error('Smoke test crashed:', e);
+  process.exit(1);
+});

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -27,6 +27,7 @@ import { SearchModule } from './modules/search/search.module';
 import { AchievementsModule } from './modules/achievements/achievements.module';
 import { DatabaseModule } from './modules/database/database.module';
 import { StorageModule } from './modules/storage/storage.module';
+import { PushModule } from './modules/push/push.module';
 import { AdminModule } from './modules/admin/admin.module';
 import { InstructorsModule } from './modules/instructors/instructors.module';
 import { EscrowModule } from './modules/escrow/escrow.module';
@@ -85,6 +86,7 @@ import { QueueModule } from './modules/queue/queue.module';
     AchievementsModule,
     DatabaseModule,
     StorageModule,
+    PushModule,
     AdminModule,
     InstructorsModule,
     EscrowModule,

--- a/backend/src/modules/push/providers/expo.provider.ts
+++ b/backend/src/modules/push/providers/expo.provider.ts
@@ -1,0 +1,174 @@
+/**
+ * Expo push provider — for React Native apps built with Expo.
+ *
+ *   PUSH_PROVIDER=expo
+ *   EXPO_ACCESS_TOKEN=...        # optional; unauthenticated sends work
+ *                                 # but are rate-limited
+ *
+ * Pure REST via fetch — no SDK dep. Expo's /v2/push/send endpoint
+ * accepts batches of up to 100 messages per request.
+ *
+ * Recipient tokens are ExponentPushToken[xxxxxxxxxxxxxxxxxxxxxx] strings.
+ * Invalid tokens are reported per-message in the response rather
+ * than failing the whole batch.
+ */
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  PushBulkResult,
+  PushMessage,
+  PushProvider,
+  PushRecipient,
+  PushResult,
+} from './push-provider.interface';
+
+const EXPO_API_URL = 'https://exp.host/--/api/v2/push/send';
+
+export class ExpoProvider implements PushProvider {
+  readonly name = 'expo' as const;
+  private readonly logger = new Logger('ExpoProvider');
+
+  private readonly accessToken: string;
+
+  constructor(config: ConfigService) {
+    this.accessToken = config.get<string>('EXPO_ACCESS_TOKEN', '');
+
+    if (this.accessToken) {
+      this.logger.log('Expo push provider configured (with access token)');
+    } else {
+      this.logger.log(
+        'Expo push provider configured (unauthenticated — rate-limited)',
+      );
+    }
+  }
+
+  isAvailable(): boolean {
+    // Expo push works without credentials (rate-limited), so always
+    // available. Use EXPO_ACCESS_TOKEN for higher limits.
+    return true;
+  }
+
+  private buildMessage(recipient: PushRecipient, message: PushMessage): any {
+    return {
+      to: recipient.token,
+      title: message.title,
+      body: message.body,
+      data: message.data,
+      sound: message.sound ?? 'default',
+      badge: message.badge,
+      channelId: message.category,
+      ttl: message.ttlSeconds,
+      // Expo supports a `_displayInForeground` flag but that's
+      // client-side behavior; omit.
+    };
+  }
+
+  private async expoApi(messages: any[]): Promise<any> {
+    const headers: Record<string, string> = {
+      Accept: 'application/json',
+      'Content-Type': 'application/json',
+    };
+    if (this.accessToken) {
+      headers.Authorization = `Bearer ${this.accessToken}`;
+    }
+    const res = await fetch(EXPO_API_URL, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(messages),
+    });
+    const json = (await res.json()) as any;
+    if (!res.ok) {
+      throw new Error(
+        `Expo push API failed: ${res.status} ${JSON.stringify(json)}`,
+      );
+    }
+    return json;
+  }
+
+  async send(
+    recipient: PushRecipient,
+    message: PushMessage,
+  ): Promise<PushResult> {
+    try {
+      const res = await this.expoApi([this.buildMessage(recipient, message)]);
+      const ticket = res.data?.[0];
+      if (ticket?.status === 'ok') {
+        return {
+          accepted: true,
+          provider: 'expo',
+          messageId: ticket.id,
+        };
+      }
+      return {
+        accepted: false,
+        provider: 'expo',
+        error: ticket?.message ?? 'unknown error',
+      };
+    } catch (e: any) {
+      return {
+        accepted: false,
+        provider: 'expo',
+        error: e.message ?? String(e),
+      };
+    }
+  }
+
+  async sendBulk(
+    recipients: PushRecipient[],
+    message: PushMessage,
+  ): Promise<PushBulkResult> {
+    // Expo recommends batches of up to 100.
+    const results: PushResult[] = [];
+    let accepted = 0;
+    let failed = 0;
+
+    const CHUNK = 100;
+    for (let i = 0; i < recipients.length; i += CHUNK) {
+      const chunk = recipients.slice(i, i + CHUNK);
+      const msgs = chunk.map((r) => this.buildMessage(r, message));
+      try {
+        const res = await this.expoApi(msgs);
+        const tickets = res.data ?? [];
+        for (let j = 0; j < chunk.length; j++) {
+          const ticket = tickets[j];
+          if (ticket?.status === 'ok') {
+            results.push({
+              accepted: true,
+              provider: 'expo',
+              messageId: ticket.id,
+            });
+            accepted++;
+          } else {
+            results.push({
+              accepted: false,
+              provider: 'expo',
+              error: ticket?.message ?? 'unknown',
+            });
+            failed++;
+          }
+        }
+      } catch (e: any) {
+        for (const _ of chunk) {
+          results.push({
+            accepted: false,
+            provider: 'expo',
+            error: e.message,
+          });
+          failed++;
+        }
+      }
+    }
+
+    return { accepted, failed, results };
+  }
+
+  getPublicConfig() {
+    return {
+      provider: 'expo',
+      extra: {
+        // Expo push tokens are obtained client-side via Expo SDK;
+        // no config needed here.
+      },
+    };
+  }
+}

--- a/backend/src/modules/push/providers/fcm.provider.ts
+++ b/backend/src/modules/push/providers/fcm.provider.ts
@@ -177,8 +177,10 @@ export class FcmProvider implements PushProvider {
   ): Promise<PushBulkResult> {
     this.loadSdk();
 
-    // FCM's sendAll supports up to 500 messages per batch. For
-    // larger fan-outs, chunk.
+    // FCM's sendEach supports up to 500 messages per batch. For
+    // larger fan-outs, chunk. (sendAll was removed in firebase-admin
+    // v12 — sendEach is the replacement with the same BatchResponse
+    // shape.)
     const results: PushResult[] = [];
     let accepted = 0;
     let failed = 0;
@@ -190,7 +192,7 @@ export class FcmProvider implements PushProvider {
       try {
         const response = await this.admin
           .messaging(this.app)
-          .sendAll(msgs);
+          .sendEach(msgs);
         for (let j = 0; j < response.responses.length; j++) {
           const r = response.responses[j];
           if (r.success) {

--- a/backend/src/modules/push/providers/fcm.provider.ts
+++ b/backend/src/modules/push/providers/fcm.provider.ts
@@ -1,0 +1,242 @@
+/**
+ * Firebase Cloud Messaging provider.
+ *
+ *   PUSH_PROVIDER=fcm
+ *   FIREBASE_SERVICE_ACCOUNT={"type":"service_account",...}   # full JSON string
+ *   # OR
+ *   FIREBASE_SERVICE_ACCOUNT_FILE=/path/to/service-account.json
+ *   FCM_PROJECT_ID=your-project-id    # optional; extracted from service account
+ *
+ * Uses the HTTP v1 API (/v1/projects/{pid}/messages:send) with an
+ * access token minted from the service account via `firebase-admin`.
+ * `firebase-admin` is an OPTIONAL dependency, lazy-loaded inside
+ * loadSdk() only when this provider is selected.
+ *
+ * FCM covers Android, iOS (via APNs-behind-FCM), and web. For web,
+ * the frontend needs a Firebase web config — pass it via
+ * `getPublicConfig()` or inject from your own config endpoint.
+ */
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  PushBulkResult,
+  PushMessage,
+  PushProvider,
+  PushProviderNotConfiguredError,
+  PushRecipient,
+  PushResult,
+} from './push-provider.interface';
+
+export class FcmProvider implements PushProvider {
+  readonly name = 'fcm' as const;
+  private readonly logger = new Logger('FcmProvider');
+
+  private readonly serviceAccountJson: string;
+  private readonly serviceAccountFile: string;
+  private readonly projectId: string;
+  private readonly webConfigJson: string;
+
+  private sdkLoaded = false;
+  private admin: any;
+  private app: any;
+
+  constructor(config: ConfigService) {
+    this.serviceAccountJson = config.get<string>(
+      'FIREBASE_SERVICE_ACCOUNT',
+      '',
+    );
+    this.serviceAccountFile = config.get<string>(
+      'FIREBASE_SERVICE_ACCOUNT_FILE',
+      '',
+    );
+    this.projectId = config.get<string>('FCM_PROJECT_ID', '');
+    this.webConfigJson = config.get<string>('FIREBASE_WEB_CONFIG', '');
+
+    if (this.isAvailable()) {
+      this.logger.log('FCM provider configured');
+    } else {
+      this.logger.warn(
+        'FCM provider selected but FIREBASE_SERVICE_ACCOUNT or FIREBASE_SERVICE_ACCOUNT_FILE missing',
+      );
+    }
+  }
+
+  isAvailable(): boolean {
+    return !!(this.serviceAccountJson || this.serviceAccountFile);
+  }
+
+  private loadSdk() {
+    if (this.sdkLoaded) return;
+    if (!this.isAvailable()) {
+      throw new PushProviderNotConfiguredError('fcm', [
+        'FIREBASE_SERVICE_ACCOUNT',
+      ]);
+    }
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      this.admin = require('firebase-admin');
+
+      // Parse the service account config.
+      let credential: any;
+      if (this.serviceAccountJson) {
+        const parsed = JSON.parse(this.serviceAccountJson);
+        credential = this.admin.credential.cert(parsed);
+      } else {
+        credential = this.admin.credential.cert(this.serviceAccountFile);
+      }
+
+      // Reuse an existing default app if something else already
+      // initialized firebase-admin (e.g. another module).
+      const existing = this.admin.apps.find(
+        (a: any) => a?.name === '[DEFAULT]',
+      );
+      this.app = existing ?? this.admin.initializeApp({ credential });
+      this.sdkLoaded = true;
+      this.logger.log('firebase-admin loaded');
+    } catch (e: any) {
+      throw new Error(
+        `FCM provider selected but the "firebase-admin" package is not installed. ` +
+          `Run: npm install firebase-admin    Original: ${e.message}`,
+      );
+    }
+  }
+
+  private buildMessage(recipient: PushRecipient, message: PushMessage): any {
+    // Convert all data values to strings — FCM data payload requires
+    // string values only.
+    const stringData: Record<string, string> = {};
+    if (message.data) {
+      for (const [k, v] of Object.entries(message.data)) {
+        if (v !== null && v !== undefined) stringData[k] = String(v);
+      }
+    }
+    if (message.url) stringData.url = message.url;
+
+    return {
+      token: recipient.token,
+      notification: {
+        title: message.title,
+        body: message.body,
+      },
+      data: stringData,
+      android: {
+        notification: {
+          icon: message.icon,
+          tag: message.tag,
+          sound: message.sound ?? 'default',
+          channelId: message.category,
+        },
+        ttl: (message.ttlSeconds ?? 86400) * 1000, // ms
+      },
+      apns: {
+        payload: {
+          aps: {
+            badge: message.badge,
+            sound: message.sound ?? 'default',
+            category: message.category,
+          },
+        },
+      },
+      webpush: {
+        notification: {
+          icon: message.icon,
+          badge: message.badge,
+          tag: message.tag,
+        },
+        fcmOptions: message.url ? { link: message.url } : undefined,
+      },
+    };
+  }
+
+  async send(
+    recipient: PushRecipient,
+    message: PushMessage,
+  ): Promise<PushResult> {
+    this.loadSdk();
+    try {
+      const messageId = await this.admin
+        .messaging(this.app)
+        .send(this.buildMessage(recipient, message));
+      return {
+        accepted: true,
+        provider: 'fcm',
+        messageId,
+      };
+    } catch (e: any) {
+      return {
+        accepted: false,
+        provider: 'fcm',
+        error: e.message ?? String(e),
+      };
+    }
+  }
+
+  async sendBulk(
+    recipients: PushRecipient[],
+    message: PushMessage,
+  ): Promise<PushBulkResult> {
+    this.loadSdk();
+
+    // FCM's sendAll supports up to 500 messages per batch. For
+    // larger fan-outs, chunk.
+    const results: PushResult[] = [];
+    let accepted = 0;
+    let failed = 0;
+
+    const CHUNK = 500;
+    for (let i = 0; i < recipients.length; i += CHUNK) {
+      const chunk = recipients.slice(i, i + CHUNK);
+      const msgs = chunk.map((r) => this.buildMessage(r, message));
+      try {
+        const response = await this.admin
+          .messaging(this.app)
+          .sendAll(msgs);
+        for (let j = 0; j < response.responses.length; j++) {
+          const r = response.responses[j];
+          if (r.success) {
+            results.push({
+              accepted: true,
+              provider: 'fcm',
+              messageId: r.messageId,
+            });
+            accepted++;
+          } else {
+            results.push({
+              accepted: false,
+              provider: 'fcm',
+              error: r.error?.message ?? 'unknown',
+            });
+            failed++;
+          }
+        }
+      } catch (e: any) {
+        // Whole-chunk failure: mark each as failed.
+        for (const _r of chunk) {
+          results.push({
+            accepted: false,
+            provider: 'fcm',
+            error: e.message ?? 'batch send failed',
+          });
+          failed++;
+        }
+      }
+    }
+
+    return { accepted, failed, results };
+  }
+
+  getPublicConfig() {
+    let fcmConfig: Record<string, string> | undefined;
+    if (this.webConfigJson) {
+      try {
+        fcmConfig = JSON.parse(this.webConfigJson);
+      } catch {
+        /* ignore malformed JSON */
+      }
+    }
+    return {
+      provider: 'fcm',
+      fcmConfig,
+    };
+  }
+}

--- a/backend/src/modules/push/providers/index.ts
+++ b/backend/src/modules/push/providers/index.ts
@@ -1,0 +1,85 @@
+/**
+ * Push provider factory.
+ *
+ * Reads PUSH_PROVIDER from config and returns the matching provider.
+ *
+ * Shipped in this PR:
+ *   webpush    — W3C Web Push + VAPID (recommended for web-only)
+ *   fcm        — Firebase Cloud Messaging (android + ios + web)
+ *   onesignal  — OneSignal (cross-platform, generous free tier)
+ *   expo       — Expo push service (React Native / Expo apps)
+ *   none       — disabled
+ *
+ * Planned follow-ups (tracked in issue #21):
+ *   apns       — direct Apple Push Notification service
+ *                (needs HTTP/2 client — skipped in v1; use FCM for iOS
+ *                in the meantime, which delivers via APNs under the hood)
+ *
+ * Selecting a planned value logs a warning and falls back to 'none'.
+ */
+import { ConfigService } from '@nestjs/config';
+import { Logger } from '@nestjs/common';
+import { PushProvider } from './push-provider.interface';
+import { WebPushProvider } from './webpush.provider';
+import { FcmProvider } from './fcm.provider';
+import { OneSignalProvider } from './onesignal.provider';
+import { ExpoProvider } from './expo.provider';
+import { NonePushProvider } from './none.provider';
+
+const log = new Logger('PushProviderFactory');
+
+export function createPushProvider(config: ConfigService): PushProvider {
+  const choice = (config.get<string>('PUSH_PROVIDER') || 'none')
+    .toLowerCase()
+    .trim();
+
+  switch (choice) {
+    case 'webpush':
+    case 'web-push':
+    case 'web': {
+      const p = new WebPushProvider(config);
+      log.log(`Selected push provider: webpush (available=${p.isAvailable()})`);
+      return p;
+    }
+    case 'fcm':
+    case 'firebase': {
+      const p = new FcmProvider(config);
+      log.log(`Selected push provider: fcm (available=${p.isAvailable()})`);
+      return p;
+    }
+    case 'onesignal':
+    case 'one-signal': {
+      const p = new OneSignalProvider(config);
+      log.log(
+        `Selected push provider: onesignal (available=${p.isAvailable()})`,
+      );
+      return p;
+    }
+    case 'expo': {
+      const p = new ExpoProvider(config);
+      log.log(`Selected push provider: expo (available=${p.isAvailable()})`);
+      return p;
+    }
+    case 'apns': {
+      log.warn(
+        'PUSH_PROVIDER="apns" is planned but not yet implemented (see issue #21). Falling back to "none". For iOS push today, use fcm (delivers via APNs under the hood).',
+      );
+      return new NonePushProvider();
+    }
+    case 'none':
+    case '':
+      return new NonePushProvider();
+    default:
+      log.warn(
+        `Unknown PUSH_PROVIDER="${choice}". Falling back to "none". Valid values: webpush, fcm, onesignal, expo, none.`,
+      );
+      return new NonePushProvider();
+  }
+}
+
+export * from './push-provider.interface';
+export { WebPushProvider } from './webpush.provider';
+export { FcmProvider } from './fcm.provider';
+export { OneSignalProvider } from './onesignal.provider';
+export { ExpoProvider } from './expo.provider';
+export { NonePushProvider } from './none.provider';

--- a/backend/src/modules/push/providers/none.provider.ts
+++ b/backend/src/modules/push/providers/none.provider.ts
@@ -1,0 +1,58 @@
+/**
+ * "None" push provider — push notifications disabled.
+ *
+ * The default if PUSH_PROVIDER is unset. Every method throws
+ * PushProviderNotConfiguredError so calling code fails loudly rather
+ * than silently swallowing outbound notifications.
+ */
+import { Logger } from '@nestjs/common';
+import {
+  PushBulkResult,
+  PushMessage,
+  PushProvider,
+  PushProviderNotConfiguredError,
+  PushRecipient,
+  PushResult,
+} from './push-provider.interface';
+
+export class NonePushProvider implements PushProvider {
+  readonly name = 'none' as const;
+  private readonly logger = new Logger('NonePushProvider');
+
+  constructor() {
+    this.logger.log(
+      'Push is DISABLED (PUSH_PROVIDER not set). To enable, set PUSH_PROVIDER to one of: webpush, fcm, onesignal, expo. See docs/providers/push.md.',
+    );
+  }
+
+  isAvailable(): boolean {
+    return false;
+  }
+
+  private fail(op: string): never {
+    throw new PushProviderNotConfiguredError('none', [
+      `PUSH_PROVIDER (currently unset) - cannot ${op}`,
+    ]);
+  }
+
+  async send(
+    _recipient: PushRecipient,
+    _message: PushMessage,
+  ): Promise<PushResult> {
+    return this.fail('send');
+  }
+
+  async sendBulk(
+    _recipients: PushRecipient[],
+    _message: PushMessage,
+  ): Promise<PushBulkResult> {
+    return this.fail('sendBulk');
+  }
+
+  getPublicConfig() {
+    return {
+      provider: 'none',
+      extra: { disabled: true },
+    };
+  }
+}

--- a/backend/src/modules/push/providers/onesignal.provider.ts
+++ b/backend/src/modules/push/providers/onesignal.provider.ts
@@ -1,0 +1,177 @@
+/**
+ * OneSignal push provider.
+ *
+ *   PUSH_PROVIDER=onesignal
+ *   ONESIGNAL_APP_ID=...
+ *   ONESIGNAL_API_KEY=...        # REST API key (NOT the User Auth key)
+ *
+ * Pure REST via fetch — no SDK dep needed. Sign up at
+ * https://onesignal.com, create an app, copy the App ID and REST API
+ * key from Keys & IDs.
+ *
+ * Free tier: unlimited subscribers on the free plan (as of the last
+ * time I checked); paid plans unlock advanced segmentation and
+ * analytics.
+ */
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  PushBulkResult,
+  PushMessage,
+  PushProvider,
+  PushProviderNotConfiguredError,
+  PushRecipient,
+  PushResult,
+} from './push-provider.interface';
+
+const ONESIGNAL_API_BASE = 'https://onesignal.com/api/v1';
+
+export class OneSignalProvider implements PushProvider {
+  readonly name = 'onesignal' as const;
+  private readonly logger = new Logger('OneSignalProvider');
+
+  private readonly appId: string;
+  private readonly apiKey: string;
+
+  constructor(config: ConfigService) {
+    this.appId = config.get<string>('ONESIGNAL_APP_ID', '');
+    this.apiKey = config.get<string>('ONESIGNAL_API_KEY', '');
+
+    if (this.isAvailable()) {
+      this.logger.log('OneSignal provider configured');
+    } else {
+      this.logger.warn(
+        'OneSignal provider selected but ONESIGNAL_APP_ID / ONESIGNAL_API_KEY missing',
+      );
+    }
+  }
+
+  isAvailable(): boolean {
+    return !!(this.appId && this.apiKey);
+  }
+
+  private async oneSignalApi(
+    method: 'POST',
+    path: string,
+    body: any,
+  ): Promise<any> {
+    if (!this.isAvailable()) {
+      throw new PushProviderNotConfiguredError('onesignal', [
+        !this.appId ? 'ONESIGNAL_APP_ID' : '',
+        !this.apiKey ? 'ONESIGNAL_API_KEY' : '',
+      ].filter(Boolean));
+    }
+    const res = await fetch(`${ONESIGNAL_API_BASE}${path}`, {
+      method,
+      headers: {
+        Authorization: `Basic ${this.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify(body),
+    });
+    const json = (await res.json()) as any;
+    if (!res.ok) {
+      throw new Error(
+        `OneSignal API ${path} failed: ${res.status} ${JSON.stringify(json)}`,
+      );
+    }
+    return json;
+  }
+
+  private buildPayload(
+    recipients: PushRecipient[],
+    message: PushMessage,
+  ): any {
+    // OneSignal supports addressing by "player id" (their term for a
+    // subscription id) via include_player_ids or include_subscription_ids.
+    // We use include_player_ids since that's backwards-compatible.
+    return {
+      app_id: this.appId,
+      include_player_ids: recipients.map((r) => r.token),
+      headings: { en: message.title },
+      contents: { en: message.body },
+      url: message.url,
+      large_icon: message.icon,
+      ios_badgeCount: message.badge,
+      ios_badgeType: message.badge !== undefined ? 'SetTo' : undefined,
+      ios_sound: message.sound,
+      android_channel_id: message.category,
+      data: message.data,
+      collapse_id: message.tag,
+      ttl: message.ttlSeconds,
+    };
+  }
+
+  async send(
+    recipient: PushRecipient,
+    message: PushMessage,
+  ): Promise<PushResult> {
+    try {
+      const res = await this.oneSignalApi('POST', '/notifications', {
+        ...this.buildPayload([recipient], message),
+      });
+      return {
+        accepted: true,
+        provider: 'onesignal',
+        messageId: res.id,
+      };
+    } catch (e: any) {
+      return {
+        accepted: false,
+        provider: 'onesignal',
+        error: e.message,
+      };
+    }
+  }
+
+  async sendBulk(
+    recipients: PushRecipient[],
+    message: PushMessage,
+  ): Promise<PushBulkResult> {
+    // OneSignal accepts up to 2000 player ids per request via
+    // include_player_ids. Chunk if needed.
+    const results: PushResult[] = [];
+    let accepted = 0;
+    let failed = 0;
+
+    const CHUNK = 2000;
+    for (let i = 0; i < recipients.length; i += CHUNK) {
+      const chunk = recipients.slice(i, i + CHUNK);
+      try {
+        const res = await this.oneSignalApi(
+          'POST',
+          '/notifications',
+          this.buildPayload(chunk, message),
+        );
+        // OneSignal reports one message id per batch, not per
+        // recipient. Synthesize per-recipient results.
+        for (const _ of chunk) {
+          results.push({
+            accepted: true,
+            provider: 'onesignal',
+            messageId: res.id,
+          });
+          accepted++;
+        }
+      } catch (e: any) {
+        for (const _ of chunk) {
+          results.push({
+            accepted: false,
+            provider: 'onesignal',
+            error: e.message,
+          });
+          failed++;
+        }
+      }
+    }
+
+    return { accepted, failed, results };
+  }
+
+  getPublicConfig() {
+    return {
+      provider: 'onesignal',
+      oneSignalAppId: this.appId,
+    };
+  }
+}

--- a/backend/src/modules/push/providers/push-provider.interface.ts
+++ b/backend/src/modules/push/providers/push-provider.interface.ts
@@ -1,0 +1,160 @@
+/**
+ * Common interface that every push-notification provider implements.
+ *
+ * Pick a provider by setting PUSH_PROVIDER in your .env to one of:
+ *
+ *   webpush    - W3C Web Push protocol with VAPID. Zero vendor
+ *                account, works in every modern browser. The default
+ *                and recommended starting point for web apps.
+ *
+ *   fcm        - Firebase Cloud Messaging. Supports Android, iOS, web.
+ *                The `firebase-admin` package is an OPTIONAL dependency,
+ *                lazy-loaded only when this provider is selected.
+ *
+ *   onesignal  - OneSignal (https://onesignal.com). Free up to 10k
+ *                subscribers. Covers web + native via a single API.
+ *
+ *   expo       - Expo push service for React Native apps built with
+ *                Expo. Pure REST, no SDK dep.
+ *
+ *   apns       - Apple Push Notification service (direct, no FCM).
+ *                [PLANNED follow-up — not implemented in this PR]
+ *
+ *   none       - Push disabled. Every method throws loudly.
+ *                The default if PUSH_PROVIDER is unset.
+ *
+ * Adding a new provider: implement this interface, register it in
+ * providers/index.ts, document the env vars in docs/providers/push.md.
+ */
+
+export interface PushRecipient {
+  /** Device token / subscription id. Shape is provider-dependent:
+   *  - webpush: a JSON-stringified PushSubscription object
+   *  - fcm: a registration token string
+   *  - onesignal: a player id / subscription id
+   *  - expo: an ExponentPushToken[xxxxxxxxxxxx] string
+   *  - apns: an APNs device token string
+   */
+  token: string;
+  /** Optional provider hint if the device table stores mixed tokens. */
+  provider?: string;
+}
+
+export interface PushMessage {
+  /** Short notification title. */
+  title: string;
+  /** Notification body text. */
+  body: string;
+  /** Optional deep link / web URL to open when tapped. */
+  url?: string;
+  /** Optional icon URL. */
+  icon?: string;
+  /** Badge count (iOS) or notification badge (Android). */
+  badge?: number;
+  /** Sound file name or "default". */
+  sound?: string;
+  /** Arbitrary key-value data delivered alongside the notification. */
+  data?: Record<string, string | number | boolean | null>;
+  /** Notification category / action group (iOS) or channel (Android). */
+  category?: string;
+  /** Tag for collapsing duplicate notifications (web + FCM). */
+  tag?: string;
+  /** TTL in seconds — providers that support it will drop undelivered
+   * messages after this many seconds. */
+  ttlSeconds?: number;
+}
+
+export interface PushResult {
+  /** True if the provider accepted the message (delivery is separate). */
+  accepted: boolean;
+  /** Provider-specific message id for tracking. */
+  messageId?: string;
+  /** The provider that handled the send. */
+  provider: string;
+  /** If accepted=false, the reason from the provider. */
+  error?: string;
+}
+
+export interface PushBulkResult {
+  /** How many messages the provider accepted for delivery. */
+  accepted: number;
+  /** How many failed immediately (invalid token, unreachable, etc). */
+  failed: number;
+  /** Per-recipient results in the same order as the input. */
+  results: PushResult[];
+}
+
+/**
+ * Common interface implemented by every push provider. Methods a
+ * provider can't support should throw PushProviderNotSupportedError —
+ * never silently no-op.
+ */
+export interface PushProvider {
+  /** Stable provider name for logging / clients. */
+  readonly name:
+    | 'webpush'
+    | 'fcm'
+    | 'onesignal'
+    | 'expo'
+    | 'apns'
+    | 'none';
+
+  /** True if the provider has the credentials it needs. */
+  isAvailable(): boolean;
+
+  /**
+   * Send a single push. Throws on unrecoverable config errors;
+   * returns { accepted: false, error } for delivery rejections
+   * (invalid token, unsubscribed, etc).
+   */
+  send(recipient: PushRecipient, message: PushMessage): Promise<PushResult>;
+
+  /**
+   * Send the same message to many recipients. Providers with native
+   * multicast (FCM, OneSignal) use it; others loop send().
+   */
+  sendBulk(
+    recipients: PushRecipient[],
+    message: PushMessage,
+  ): Promise<PushBulkResult>;
+
+  /**
+   * Frontend bootstrap — returns the public key(s) / app id / VAPID
+   * key the browser needs to subscribe. Never includes secrets.
+   */
+  getPublicConfig(): {
+    provider: string;
+    /** VAPID public key for Web Push. */
+    vapidPublicKey?: string;
+    /** OneSignal app id for the frontend SDK. */
+    oneSignalAppId?: string;
+    /** FCM project sender id / web app config. */
+    fcmConfig?: Record<string, string>;
+    /** Any extra provider-specific config. */
+    extra?: Record<string, any>;
+  };
+}
+
+/**
+ * Thrown when a provider is asked to do something it can't support.
+ */
+export class PushProviderNotSupportedError extends Error {
+  constructor(provider: string, operation: string) {
+    super(
+      `Operation "${operation}" is not supported by the "${provider}" push provider. See docs/providers/push.md.`,
+    );
+    this.name = 'PushProviderNotSupportedError';
+  }
+}
+
+/**
+ * Thrown when a provider is selected but its credentials are missing.
+ */
+export class PushProviderNotConfiguredError extends Error {
+  constructor(provider: string, missingVars: string[]) {
+    super(
+      `Push provider "${provider}" is selected but the following env vars are missing: ${missingVars.join(', ')}. See docs/providers/push.md.`,
+    );
+    this.name = 'PushProviderNotConfiguredError';
+  }
+}

--- a/backend/src/modules/push/providers/webpush.provider.ts
+++ b/backend/src/modules/push/providers/webpush.provider.ts
@@ -1,0 +1,178 @@
+/**
+ * Web Push provider — W3C Web Push protocol with VAPID.
+ *
+ *   PUSH_PROVIDER=webpush
+ *   VAPID_PUBLIC_KEY=...
+ *   VAPID_PRIVATE_KEY=...
+ *   VAPID_SUBJECT=mailto:admin@yourdomain.com
+ *
+ * Zero vendor account required — Web Push is a browser standard.
+ * Uses the `web-push` npm package (OPTIONAL dependency, lazy-loaded
+ * inside loadSdk()) for VAPID key signing and payload encryption.
+ *
+ * Generate VAPID keys once:
+ *   npx web-push generate-vapid-keys
+ *
+ * The public key goes to the frontend via `getPublicConfig()` so the
+ * browser can subscribe; the private key stays in .env and is used
+ * to sign outbound push requests.
+ *
+ * Recipient tokens are JSON-stringified browser PushSubscription
+ * objects of the form:
+ *   { "endpoint": "https://fcm.googleapis.com/fcm/send/...",
+ *     "keys": { "p256dh": "...", "auth": "..." } }
+ */
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  PushBulkResult,
+  PushMessage,
+  PushProvider,
+  PushProviderNotConfiguredError,
+  PushRecipient,
+  PushResult,
+} from './push-provider.interface';
+
+export class WebPushProvider implements PushProvider {
+  readonly name = 'webpush' as const;
+  private readonly logger = new Logger('WebPushProvider');
+
+  private readonly publicKey: string;
+  private readonly privateKey: string;
+  private readonly subject: string;
+
+  private sdkLoaded = false;
+  private webpush: any;
+
+  constructor(config: ConfigService) {
+    this.publicKey = config.get<string>('VAPID_PUBLIC_KEY', '');
+    this.privateKey = config.get<string>('VAPID_PRIVATE_KEY', '');
+    this.subject = config.get<string>(
+      'VAPID_SUBJECT',
+      'mailto:admin@example.com',
+    );
+
+    if (this.isAvailable()) {
+      this.logger.log('Web Push provider configured (VAPID)');
+    } else {
+      this.logger.warn(
+        'Web Push provider selected but VAPID_PUBLIC_KEY / VAPID_PRIVATE_KEY missing. Generate keys with: npx web-push generate-vapid-keys',
+      );
+    }
+  }
+
+  isAvailable(): boolean {
+    return !!(this.publicKey && this.privateKey);
+  }
+
+  private loadSdk() {
+    if (this.sdkLoaded) return;
+    if (!this.isAvailable()) {
+      throw new PushProviderNotConfiguredError('webpush', [
+        !this.publicKey ? 'VAPID_PUBLIC_KEY' : '',
+        !this.privateKey ? 'VAPID_PRIVATE_KEY' : '',
+      ].filter(Boolean));
+    }
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      this.webpush = require('web-push');
+      this.webpush.setVapidDetails(
+        this.subject,
+        this.publicKey,
+        this.privateKey,
+      );
+      this.sdkLoaded = true;
+      this.logger.log('web-push package loaded');
+    } catch (e: any) {
+      throw new Error(
+        `Web Push provider selected but the "web-push" package is not installed. ` +
+          `Run: npm install web-push    Original: ${e.message}`,
+      );
+    }
+  }
+
+  private parseSubscription(token: string): any {
+    try {
+      return JSON.parse(token);
+    } catch {
+      throw new Error(
+        `Invalid Web Push token — expected a JSON-stringified PushSubscription, got: ${token.slice(0, 60)}...`,
+      );
+    }
+  }
+
+  async send(
+    recipient: PushRecipient,
+    message: PushMessage,
+  ): Promise<PushResult> {
+    this.loadSdk();
+
+    // Keep parse + send under the same try/catch so malformed tokens
+    // surface as `{ accepted: false, error: ... }` instead of throwing
+    // — the caller shouldn't have to wrap every send in try/catch.
+    try {
+      const subscription = this.parseSubscription(recipient.token);
+      const payload = JSON.stringify({
+        title: message.title,
+        body: message.body,
+        url: message.url,
+        icon: message.icon,
+        badge: message.badge,
+        tag: message.tag,
+        data: message.data,
+      });
+
+      const res = await this.webpush.sendNotification(subscription, payload, {
+        TTL: message.ttlSeconds ?? 86400,
+      });
+      return {
+        accepted: true,
+        provider: 'webpush',
+        messageId: res.headers?.['message-id'] ?? `webpush-${Date.now()}`,
+      };
+    } catch (e: any) {
+      // 404/410 = subscription expired; malformed token = caller bug;
+      // caller should remove the token from the device table either way.
+      return {
+        accepted: false,
+        provider: 'webpush',
+        error: e.message ?? String(e),
+      };
+    }
+  }
+
+  async sendBulk(
+    recipients: PushRecipient[],
+    message: PushMessage,
+  ): Promise<PushBulkResult> {
+    const results: PushResult[] = [];
+    let accepted = 0;
+    let failed = 0;
+
+    // Web Push has no multicast — loop send() in parallel.
+    const settled = await Promise.all(
+      recipients.map((r) =>
+        this.send(r, message).catch((e) => ({
+          accepted: false as const,
+          provider: 'webpush',
+          error: e.message ?? String(e),
+        })),
+      ),
+    );
+
+    for (const r of settled) {
+      results.push(r);
+      if (r.accepted) accepted++;
+      else failed++;
+    }
+
+    return { accepted, failed, results };
+  }
+
+  getPublicConfig() {
+    return {
+      provider: 'webpush',
+      vapidPublicKey: this.publicKey,
+    };
+  }
+}

--- a/backend/src/modules/push/push.controller.ts
+++ b/backend/src/modules/push/push.controller.ts
@@ -1,0 +1,27 @@
+import { Controller, Get } from '@nestjs/common';
+import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import { PushService } from './push.service';
+
+/**
+ * Public push bootstrap endpoint.
+ *
+ *   GET /api/v1/config/push
+ *
+ * Returns the public VAPID key / OneSignal app id / FCM web config
+ * the frontend needs to subscribe to push notifications. Never
+ * includes secrets.
+ *
+ * Deliberately unauthenticated — it's consumed on every page load
+ * by the PWA service worker registration.
+ */
+@ApiTags('push')
+@Controller('config')
+export class PushController {
+  constructor(private readonly push: PushService) {}
+
+  @Get('push')
+  @ApiOperation({ summary: 'Frontend push notifications bootstrap' })
+  getConfig() {
+    return this.push.getPublicConfig();
+  }
+}

--- a/backend/src/modules/push/push.module.ts
+++ b/backend/src/modules/push/push.module.ts
@@ -1,0 +1,17 @@
+import { Module } from '@nestjs/common';
+import { PushService } from './push.service';
+import { PushController } from './push.controller';
+
+/**
+ * Push notification module — exposes the pluggable PushService for
+ * all outbound push notifications.
+ *
+ * Pick a provider by setting PUSH_PROVIDER in your .env. See
+ * `docs/providers/push.md`.
+ */
+@Module({
+  controllers: [PushController],
+  providers: [PushService],
+  exports: [PushService],
+})
+export class PushModule {}

--- a/backend/src/modules/push/push.service.ts
+++ b/backend/src/modules/push/push.service.ts
@@ -1,0 +1,70 @@
+/**
+ * PushService — the app's push notification façade.
+ *
+ * Modules that need to send push notifications (order updates,
+ * flash-sale alerts, shipping notifications, promotional campaigns,
+ * chat messages, etc.) should inject this service.
+ *
+ * Internally dispatches to whichever provider the operator has
+ * selected via PUSH_PROVIDER in .env. See `./providers/` and
+ * `docs/providers/push.md`.
+ */
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  createPushProvider,
+  PushBulkResult,
+  PushMessage,
+  PushProvider,
+  PushRecipient,
+  PushResult,
+} from './providers';
+
+@Injectable()
+export class PushService implements OnModuleInit {
+  private readonly logger = new Logger(PushService.name);
+  private provider!: PushProvider;
+
+  constructor(private readonly config: ConfigService) {}
+
+  onModuleInit() {
+    this.provider = createPushProvider(this.config);
+    this.logger.log(
+      `Push provider initialized: ${this.provider.name} (available=${this.provider.isAvailable()})`,
+    );
+  }
+
+  getProviderName(): string {
+    return this.provider?.name ?? 'none';
+  }
+
+  isAvailable(): boolean {
+    return !!this.provider && this.provider.isAvailable();
+  }
+
+  async send(
+    recipient: PushRecipient,
+    message: PushMessage,
+  ): Promise<PushResult> {
+    return this.provider.send(recipient, message);
+  }
+
+  async sendBulk(
+    recipients: PushRecipient[],
+    message: PushMessage,
+  ): Promise<PushBulkResult> {
+    return this.provider.sendBulk(recipients, message);
+  }
+
+  /**
+   * Frontend-safe bootstrap — returns only public keys. Used by the
+   * `/config/push` endpoint so the web client can subscribe.
+   */
+  getPublicConfig() {
+    return this.provider.getPublicConfig();
+  }
+
+  getProvider(): PushProvider {
+    return this.provider;
+  }
+}


### PR DESCRIPTION
## Summary

Closes #34. Direct port of vasty-shop PR #35. Team@Once gets the same pluggable push adapter — 4 real providers + apns planned stub + none default.

Follows the deskive pattern. Provider files copied verbatim from vasty-shop.

## What's in it

- **webpush** — W3C Web Push + VAPID, `web-push` lazy-loaded from `optionalDependencies`
- **fcm** — Firebase Cloud Messaging, `firebase-admin` already a regular dep (used by legacy `FirebaseService`)
- **onesignal** — pure REST
- **expo** — pure REST with 100-chunk batching, per-message `DeviceNotRegistered` handling
- **none** — disabled stub
- **apns** — planned; falls back to `none` with warning

## Team@Once deltas vs vasty-shop #35

- `firebase-admin` is **already** a regular dep in Team@Once (the legacy `FirebaseService` uses it). Vasty put it in `optionalDependencies` because vasty didn't have it. Both paths work at runtime. Only `web-push` is added to Team@Once's new `optionalDependencies` block.
- This NEW `PushModule` coexists with the legacy `modules/notifications/firebase.service.ts`. A follow-up PR will migrate `notifications.service.ts` to inject `PushService` and delete the legacy service.

## Verification status

| Provider | Status |
|---|---|
| **webpush** / **fcm** / **onesignal** / **expo** | written, **smoke-tested** via mocked `require()` + mocked fetch. NOT tested against real backends |
| **none** | written, **smoke-tested** (throws as expected) |
| **apns** | NOT implemented; planned stub |

Full TypeScript compile: **0 errors**.

Smoke test: **61/61 assertions pass** on teamatonce — identical to vasty-shop's suite.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx ts-node scripts/smoke-test-push-providers.ts` 61/61 pass
- [ ] Manual: test each provider with real credentials
- [ ] Follow-up: migrate legacy `notifications.service.ts` to inject `PushService`

## Related

- vasty-shop PR #35 — the identical adapter on the sibling repo
- Tracking issue #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)