### PR TITLE
feat(search): pluggable search adapter (pg-trgm/meilisearch/typesense) alongside legacy SearchService

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -91,3 +91,23 @@ OPENAI_MODEL=gpt-4o-mini
 QDRANT_HOST=localhost
 QDRANT_PORT=6333
 QDRANT_API_KEY=your_qdrant_api_key
+
+# =====================================================
+# SEARCH (pluggable — alongside the legacy QDRANT section)
+# =====================================================
+# Pick a provider. See backend/docs/providers/search.md.
+#
+# Valid values: pg-trgm | meilisearch | typesense | none
+#
+# Implemented: pg-trgm (zero-infra default), meilisearch, typesense, none.
+# Planned follow-ups: qdrant, weaviate, elasticsearch.
+
+SEARCH_PROVIDER=pg-trgm
+
+# --- Meilisearch ---
+MEILI_URL=http://localhost:7700
+MEILI_MASTER_KEY=
+
+# --- Typesense ---
+TYPESENSE_URL=http://localhost:8108
+TYPESENSE_API_KEY=

--- a/backend/docs/providers/search.md
+++ b/backend/docs/providers/search.md
@@ -1,0 +1,162 @@
+# Search providers
+
+Vasty Shop supports pluggable product/catalog search. Pick a provider
+by setting `SEARCH_PROVIDER` in your `.env`.
+
+```
+SEARCH_PROVIDER=pg-trgm   # zero-infra default
+```
+
+## Comparison
+
+| Provider | Free tier | Infra | Indexing | Typo tolerance | Facets | Best for |
+|---|---|---|---|---|---|---|
+| **pg-trgm** *(default)* | ♾️ | none (uses existing Postgres) | no-op (Postgres is source of truth) | good (trigram) | no | dev + small prod |
+| **meilisearch** | ♾️ self-hosted | docker | batch upsert | excellent | ✅ | recommended for prod e-commerce |
+| **typesense** | ♾️ self-hosted | docker | JSONL import | excellent | ✅ | simpler schema than Meilisearch |
+| **qdrant** | ♾️ self-hosted | docker | [planned #22] | — | ✅ (via payload) | semantic/vector |
+| **weaviate** | ♾️ self-hosted | docker | [planned #22] | — | ✅ | hybrid keyword + vector |
+| **elasticsearch** | ♾️ self-hosted | docker | [planned #22] | ✅ | ✅ | enterprise stack |
+| **none** | — | — | — | — | — | default — search disabled |
+
+## Which should I pick?
+
+- **"I just want product search to work"** → `pg-trgm` (zero infra,
+  works against existing Postgres, no separate index to maintain)
+- **Production e-commerce with typo tolerance and faceting** →
+  `meilisearch` (exceptional UX out of the box)
+- **Alternative to Meilisearch with simpler schema config** →
+  `typesense`
+- **Semantic search / "find products similar to X"** → `qdrant`
+  *(coming in follow-up PR)*
+- **Existing Elasticsearch / OpenSearch cluster** →
+  `elasticsearch` *(coming in follow-up PR)*
+
+## Per-provider setup
+
+### pg-trgm (default)
+
+No setup beyond what you already have. On first search, the provider:
+
+1. Runs `CREATE EXTENSION IF NOT EXISTS pg_trgm` (idempotent)
+2. Creates GIN indexes on `products(name)`, `products(description)`,
+   `products(short_description)` for fast trigram similarity lookup
+3. Searches use `col % $query` (trigram match) OR `col ILIKE '%query%'`
+   (substring match), scored by `similarity(name, $query)`
+
+```
+SEARCH_PROVIDER=pg-trgm
+```
+
+**Permissions**: if the app's Postgres user doesn't have
+`CREATE EXTENSION` privilege, the provider logs a warning once and
+falls back to plain `ILIKE`. Run this as a superuser to enable the
+fast path:
+
+```sql
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+```
+
+**Indexing**: no-op. The moment a row exists in `products`, it's
+searchable. No separate reindex step on schema changes.
+
+**Not suitable for**: semantic/vector search, faceted search on
+arbitrary fields. Graduate to Meilisearch / Typesense / Qdrant when
+you need those.
+
+**Security**: filter field names are matched against
+`^[a-zA-Z_][a-zA-Z0-9_]*$` before being interpolated into SQL.
+Attempts to inject via `{"name; DROP TABLE...": 1}` are logged and
+dropped. Values are always bound via pg parameters.
+
+### meilisearch
+
+Run via `docker compose --profile meilisearch up -d` (once install
+PR #27 lands) or any `getmeili/meilisearch` image.
+
+```
+SEARCH_PROVIDER=meilisearch
+MEILI_URL=http://localhost:7700
+MEILI_MASTER_KEY=your-master-key
+```
+
+Meilisearch "indexes" map 1:1 to our "collections" concept. The
+provider translates our filter shape to Meili's string filter syntax:
+
+```js
+{ category: 'shoes', status: 'active' }
+// → "category = 'shoes' AND status = 'active'"
+
+{ price: { gte: 10, lte: 100 } }
+// → "price >= 10 AND price <= 100"
+```
+
+**Faceting**: pass `facets: ['category', 'brand']` in the query;
+Meilisearch returns counts in the response.
+
+**Reindexing**: `reindex()` deletes all documents in the index and
+re-uploads from the source iterator in batches of 1000.
+
+### typesense
+
+Run via `docker compose --profile typesense up -d` or any
+`typesense/typesense` image.
+
+```
+SEARCH_PROVIDER=typesense
+TYPESENSE_URL=http://localhost:8108
+TYPESENSE_API_KEY=your-api-key
+```
+
+Typesense requires an explicit schema per collection. The provider's
+default `reindex()` deletes the collection and recreates it with a
+minimal `id: string, .*: auto` schema. For production, create the
+collection yourself with properly typed fields (`price: float`,
+`created_at: int64`, etc.) before calling `indexBatch()`.
+
+**Filters**: translated to Typesense's `field:=value` syntax:
+
+```js
+{ category: 'shoes' }
+// → "category:=`shoes`"
+
+{ price: { gte: 10, lte: 100 } }
+// → "price:>=10 && price:<=100"
+```
+
+Typesense uses backticks around string values to allow spaces.
+
+### qdrant / weaviate / elasticsearch (planned)
+
+These are listed in the factory as valid `SEARCH_PROVIDER` values but
+currently log a warning and fall back to `none`. Follow-up PRs will
+implement them, tracked under issue #22. Picking one now is a no-op
+rather than a silent bug — you'll get a clear warning at startup.
+
+### none (default if unset)
+
+Every method throws `SearchProviderNotConfiguredError`. The startup
+log prints which env var to set.
+
+## Migration from the old ProductsService.search()
+
+`ProductsService.search()` currently:
+1. Calls `DatabaseService.unifiedSearch()` — a non-existent method
+   that always throws
+2. Falls back to `manualSearch()` which runs a plain `ILIKE '%q%'`
+   query against the products table
+
+A follow-up PR will migrate `ProductsService.search()` to inject
+`SearchService` instead, removing the dead `unifiedSearch()` call.
+The pg-trgm provider is a straight upgrade over the current manual
+fallback: trigram similarity gives better relevance than raw ILIKE
+and the GIN index makes it fast.
+
+## Adding a new provider
+
+1. Implement `SearchProvider` in
+   `backend/src/modules/search/providers/<name>.provider.ts`
+2. Add a case to `createSearchProvider()` in `providers/index.ts`
+3. Document env vars in this file and in `.env.example`
+4. Add smoke-test coverage in
+   `backend/scripts/smoke-test-search-providers.ts`

--- a/backend/scripts/smoke-test-search-providers.ts
+++ b/backend/scripts/smoke-test-search-providers.ts
@@ -1,0 +1,379 @@
+/**
+ * Smoke test for the multi-provider search factory.
+ *
+ * Exercises the factory + each provider without touching real infra:
+ * - pg-trgm: uses an in-memory mock query function that captures the
+ *   SQL generated and returns canned rows. Verifies the SQL shape,
+ *   parameter binding, and filter translation.
+ * - meilisearch / typesense: mocks fetch and verifies URL, auth header,
+ *   payload translation.
+ * - none: throws loudly on every call.
+ *
+ * Run with: npx ts-node scripts/smoke-test-search-providers.ts
+ */
+import { ConfigService } from '@nestjs/config';
+import {
+  createSearchProvider,
+  SearchProviderNotConfiguredError,
+  SearchProviderNotSupportedError,
+} from '../src/modules/search/providers';
+
+function fakeConfig(env: Record<string, string>): ConfigService {
+  return {
+    get: <T>(key: string, def?: T) => (env[key] as any) ?? def,
+  } as unknown as ConfigService;
+}
+
+type FetchCall = {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: string | null;
+};
+const fetchCalls: FetchCall[] = [];
+const realFetch = global.fetch;
+function installMockFetch(status = 200, body: any = {}) {
+  global.fetch = (async (url: any, init: any = {}) => {
+    const headers: Record<string, string> = {};
+    if (init.headers) {
+      for (const [k, v] of Object.entries(init.headers)) {
+        headers[k] = String(v);
+      }
+    }
+    fetchCalls.push({
+      url: String(url),
+      method: init.method ?? 'GET',
+      headers,
+      body: typeof init.body === 'string' ? init.body : null,
+    });
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as any;
+}
+function restoreFetch() {
+  global.fetch = realFetch;
+}
+
+async function expectThrow(
+  label: string,
+  fn: () => Promise<unknown>,
+  matcher: (e: Error) => boolean,
+): Promise<boolean> {
+  try {
+    await fn();
+    console.log(`  ❌ ${label}: expected throw, got success`);
+    return false;
+  } catch (e) {
+    if (matcher(e as Error)) {
+      console.log(`  ✅ ${label}: threw as expected`);
+      return true;
+    }
+    console.log(`  ❌ ${label}: wrong error: ${(e as Error).message}`);
+    return false;
+  }
+}
+
+// Mock pg query function that records executed SQL + params and
+// returns canned rows for each kind of query.
+type PgCall = { sql: string; params: any[] };
+function makeMockPg(
+  searchRows: any[],
+  countRow: { count: number },
+): { query: (sql: string, params?: any[]) => Promise<{ rows: any[] }>; calls: PgCall[] } {
+  const calls: PgCall[] = [];
+  const query = async (sql: string, params: any[] = []) => {
+    calls.push({ sql, params });
+    const normalized = sql.trim().toLowerCase();
+    if (normalized.startsWith('create extension') || normalized.startsWith('create index')) {
+      return { rows: [] };
+    }
+    if (normalized.startsWith('select count')) {
+      return { rows: [countRow] };
+    }
+    if (normalized.startsWith('select')) {
+      return { rows: searchRows };
+    }
+    return { rows: [] };
+  };
+  return { query, calls };
+}
+
+async function main(): Promise<void> {
+  let pass = 0;
+  let fail = 0;
+  const ok = (b: boolean) => (b ? pass++ : fail++);
+  console.log('=== Search provider factory smoke test ===\n');
+
+  // 1. none default
+  console.log('1. no SEARCH_PROVIDER → none');
+  {
+    const p = createSearchProvider({
+      config: fakeConfig({}),
+      pgQuery: async () => ({ rows: [] }),
+    });
+    ok(p.name === 'none');
+    console.log(`  ✅ factory returned: ${p.name}`);
+    ok(p.isAvailable() === false);
+    ok(
+      await expectThrow(
+        'search fails loudly',
+        () => p.search('products', { q: 'x' }),
+        (e) => e instanceof SearchProviderNotConfiguredError,
+      ),
+    );
+  }
+
+  // 2. planned providers fall back to none with warning
+  console.log('\n2. planned (qdrant/weaviate/elastic) → fallback to none');
+  {
+    for (const choice of ['qdrant', 'weaviate', 'elasticsearch', 'elastic']) {
+      const p = createSearchProvider({
+        config: fakeConfig({ SEARCH_PROVIDER: choice }),
+        pgQuery: async () => ({ rows: [] }),
+      });
+      ok(p.name === 'none');
+    }
+    console.log(`  ✅ all 4 planned values fell back to none`);
+  }
+
+  // 3. pg-trgm happy path with mock SQL (teamatonce uses `projects` table)
+  console.log('\n3. pg-trgm with mock SQL');
+  {
+    const { query, calls } = makeMockPg(
+      [
+        { id: 'p1', name: 'Auth Refactor', description: 'Keycloak migration', _score: 0.9 },
+        { id: 'p2', name: 'Auth Cleanup', description: 'Remove legacy', _score: 0.6 },
+      ],
+      { count: 2 },
+    );
+    const p = createSearchProvider({
+      config: fakeConfig({ SEARCH_PROVIDER: 'pg-trgm' }),
+      pgQuery: query,
+    });
+    ok(p.name === 'pg-trgm');
+    ok(p.isAvailable() === true);
+
+    const result = await p.search('projects', {
+      q: 'auth',
+      limit: 10,
+      filters: { status: 'active' },
+    });
+
+    ok(result.hits.length === 2);
+    ok(result.total === 2);
+    ok(result.hits[0].document.name === 'Auth Refactor');
+    ok(result.hits[0].score === 0.9);
+    console.log(`  ✅ returned ${result.hits.length} hits, total=${result.total}`);
+
+    // Verify SQL shape
+    const mainQuery = calls.find((c) =>
+      c.sql.toLowerCase().includes('from projects'),
+    );
+    ok(!!mainQuery);
+    ok(mainQuery!.sql.includes('similarity'));
+    ok(mainQuery!.sql.includes('name %'));
+    ok(mainQuery!.sql.includes('status = '));
+    ok(mainQuery!.params.includes('auth'));
+    console.log(`  ✅ SQL shape + bound params correct`);
+
+    // Verify pg_trgm extension + index creation attempted
+    const extensionCall = calls.find((c) =>
+      c.sql.toLowerCase().includes('create extension'),
+    );
+    ok(!!extensionCall);
+    const indexCalls = calls.filter((c) =>
+      c.sql.toLowerCase().includes('create index if not exists'),
+    );
+    // projects(name, description) + project_tasks(title, description)
+    // + project_proposals(title, description) = 6 indexes expected
+    ok(indexCalls.length >= 6);
+    console.log(`  ✅ pg_trgm extension + ${indexCalls.length} GIN indexes ensured`);
+  }
+
+  // 4. pg-trgm rejects unsafe filter field names (SQL injection attempt)
+  console.log('\n4. pg-trgm rejects unsafe filter field names');
+  {
+    const { query, calls } = makeMockPg([], { count: 0 });
+    const p = createSearchProvider({
+      config: fakeConfig({ SEARCH_PROVIDER: 'pg-trgm' }),
+      pgQuery: query,
+    });
+    await p.search('projects', {
+      q: '',
+      filters: { "name; DROP TABLE projects; --": 'x' } as any,
+    });
+    const mainQuery = calls.find((c) =>
+      c.sql.toLowerCase().includes('from projects'),
+    );
+    ok(!mainQuery!.sql.includes('DROP TABLE'));
+    console.log(`  ✅ unsafe field name rejected (no DROP TABLE in SQL)`);
+  }
+
+  // 5. pg-trgm on unknown collection → NotSupported
+  console.log('\n5. pg-trgm on unknown collection throws NotSupported');
+  {
+    const p = createSearchProvider({
+      config: fakeConfig({ SEARCH_PROVIDER: 'pg-trgm' }),
+      pgQuery: async () => ({ rows: [] }),
+    });
+    ok(
+      await expectThrow(
+        'unknown collection throws',
+        () => p.search('unknown_collection', { q: 'x' }),
+        (e) => e instanceof SearchProviderNotSupportedError,
+      ),
+    );
+  }
+
+  // 6. meilisearch with creds + mocked fetch
+  console.log('\n6. meilisearch with creds (mocked network)');
+  {
+    installMockFetch(200, {
+      hits: [{ id: 'p1', name: 'Widget' }],
+      estimatedTotalHits: 1,
+      processingTimeMs: 5,
+    });
+    try {
+      const p = createSearchProvider({
+        config: fakeConfig({
+          SEARCH_PROVIDER: 'meilisearch',
+          MEILI_URL: 'http://localhost:7700',
+          MEILI_MASTER_KEY: 'master-key',
+        }),
+        pgQuery: async () => ({ rows: [] }),
+      });
+      ok(p.name === 'meilisearch');
+      ok(p.isAvailable() === true);
+
+      const result = await p.search('products', {
+        q: 'widget',
+        filters: { category: 'tools', status: 'active' },
+        rangeFilters: { price: { gte: 5, lte: 50 } },
+        facets: ['category', 'brand'],
+      });
+
+      ok(result.hits.length === 1);
+      ok((result.hits[0].document as any).name === 'Widget');
+
+      const call = fetchCalls[fetchCalls.length - 1];
+      ok(call.url === 'http://localhost:7700/indexes/products/search');
+      ok(call.headers['Authorization'] === 'Bearer master-key');
+      const payload = JSON.parse(call.body!);
+      ok(payload.q === 'widget');
+      ok(payload.filter.includes("category = 'tools'"));
+      ok(payload.filter.includes("status = 'active'"));
+      ok(payload.filter.includes('price >= 5'));
+      ok(payload.filter.includes('price <= 50'));
+      ok(payload.facets.length === 2);
+      console.log(`  ✅ meilisearch POST /search + filter translation correct`);
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
+  // 7. meilisearch without creds → unavailable
+  console.log('\n7. meilisearch without creds → unavailable');
+  {
+    const p = createSearchProvider({
+      config: fakeConfig({ SEARCH_PROVIDER: 'meilisearch' }),
+      pgQuery: async () => ({ rows: [] }),
+    });
+    ok(p.name === 'meilisearch');
+    ok(p.isAvailable() === false);
+  }
+
+  // 8. typesense with creds + mocked fetch
+  console.log('\n8. typesense with creds (mocked network)');
+  {
+    installMockFetch(200, {
+      hits: [
+        { document: { id: 'p1', name: 'Widget' }, text_match: 999, highlights: [] },
+      ],
+      found: 1,
+      search_time_ms: 3,
+    });
+    try {
+      const p = createSearchProvider({
+        config: fakeConfig({
+          SEARCH_PROVIDER: 'typesense',
+          TYPESENSE_URL: 'http://localhost:8108',
+          TYPESENSE_API_KEY: 'xyz',
+        }),
+        pgQuery: async () => ({ rows: [] }),
+      });
+      ok(p.name === 'typesense');
+      ok(p.isAvailable() === true);
+
+      const result = await p.search('products', {
+        q: 'widget',
+        filters: { category: 'tools' },
+        rangeFilters: { price: { gte: 5 } },
+      });
+
+      ok(result.hits.length === 1);
+      ok(result.total === 1);
+
+      const call = fetchCalls[fetchCalls.length - 1];
+      ok(call.url.startsWith('http://localhost:8108/collections/products/documents/search'));
+      ok(call.headers['X-TYPESENSE-API-KEY'] === 'xyz');
+      ok(call.url.includes('q=widget'));
+      ok(call.url.includes('filter_by=category%3A%3D%60tools%60+%26%26+price%3A%3E%3D5'));
+      console.log(`  ✅ typesense GET /search + filter syntax correct`);
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
+  // 9. typesense indexBatch generates JSONL
+  console.log('\n9. typesense indexBatch generates JSONL body');
+  {
+    installMockFetch(200, {});
+    try {
+      const p = createSearchProvider({
+        config: fakeConfig({
+          SEARCH_PROVIDER: 'typesense',
+          TYPESENSE_URL: 'http://localhost:8108',
+          TYPESENSE_API_KEY: 'xyz',
+        }),
+        pgQuery: async () => ({ rows: [] }),
+      });
+      await p.indexBatch('products', [
+        { id: 'p1', name: 'A' },
+        { id: 'p2', name: 'B' },
+      ]);
+      const call = fetchCalls[fetchCalls.length - 1];
+      ok(call.url.includes('documents/import?action=upsert'));
+      ok(call.body?.includes('"id":"p1"') === true);
+      ok(call.body?.includes('\n"id":"p2"'.replace(/"id"/, '\n{"id"')) === false); // just sanity
+      // JSONL means two lines separated by \n
+      ok((call.body ?? '').split('\n').length === 2);
+      console.log(`  ✅ indexBatch sends JSONL (2 lines)`);
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
+  // 10. unknown value
+  console.log('\n10. unknown SEARCH_PROVIDER → none (fallback)');
+  {
+    const p = createSearchProvider({
+      config: fakeConfig({ SEARCH_PROVIDER: 'foobar' }),
+      pgQuery: async () => ({ rows: [] }),
+    });
+    ok(p.name === 'none');
+    console.log(`  ✅ fallback to: ${p.name}`);
+  }
+
+  console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+  process.exit(fail > 0 ? 1 : 0);
+}
+
+main().catch((e) => {
+  console.error('Smoke test crashed:', e);
+  process.exit(1);
+});

--- a/backend/src/modules/search/providers/index.ts
+++ b/backend/src/modules/search/providers/index.ts
@@ -1,0 +1,92 @@
+/**
+ * Search provider factory.
+ *
+ * Reads SEARCH_PROVIDER from config and returns the matching provider.
+ *
+ * Shipped in this PR:
+ *   pg-trgm       — zero-infra Postgres default (recommended for dev)
+ *   meilisearch   — production recommendation
+ *   typesense     — alternative to meilisearch
+ *   none          — disabled
+ *
+ * Planned follow-ups (tracked in issue #22):
+ *   qdrant        — vector search
+ *   weaviate      — hybrid search
+ *   elasticsearch — enterprise search stack
+ *
+ * Selecting one of the planned values logs a warning and falls back
+ * to 'none' until its provider is implemented. This is intentional:
+ * a fake stub would hide the fact that the adapter isn't ready.
+ */
+import { ConfigService } from '@nestjs/config';
+import { Logger } from '@nestjs/common';
+import { SearchProvider } from './search-provider.interface';
+import { PgTrgmProvider, PgQueryFn } from './pg-trgm.provider';
+import { MeilisearchProvider } from './meilisearch.provider';
+import { TypesenseProvider } from './typesense.provider';
+import { NoneSearchProvider } from './none.provider';
+
+const log = new Logger('SearchProviderFactory');
+
+export interface SearchProviderFactoryDeps {
+  config: ConfigService;
+  /** Raw SQL query function, needed by the pg-trgm provider. */
+  pgQuery: PgQueryFn;
+}
+
+export function createSearchProvider(
+  deps: SearchProviderFactoryDeps,
+): SearchProvider {
+  const choice = (deps.config.get<string>('SEARCH_PROVIDER') || 'none')
+    .toLowerCase()
+    .trim();
+
+  switch (choice) {
+    case 'pg-trgm':
+    case 'pg_trgm':
+    case 'postgres':
+    case 'pg': {
+      const p = new PgTrgmProvider(deps.pgQuery);
+      log.log(`Selected search provider: pg-trgm (available=${p.isAvailable()})`);
+      return p;
+    }
+    case 'meilisearch':
+    case 'meili': {
+      const p = new MeilisearchProvider(deps.config);
+      log.log(
+        `Selected search provider: meilisearch (available=${p.isAvailable()})`,
+      );
+      return p;
+    }
+    case 'typesense': {
+      const p = new TypesenseProvider(deps.config);
+      log.log(
+        `Selected search provider: typesense (available=${p.isAvailable()})`,
+      );
+      return p;
+    }
+    case 'qdrant':
+    case 'weaviate':
+    case 'elasticsearch':
+    case 'elastic': {
+      log.warn(
+        `SEARCH_PROVIDER="${choice}" is planned but not yet implemented (see issue #22). Falling back to "none". Implemented providers: pg-trgm, meilisearch, typesense.`,
+      );
+      return new NoneSearchProvider();
+    }
+    case 'none':
+    case '':
+      return new NoneSearchProvider();
+    default:
+      log.warn(
+        `Unknown SEARCH_PROVIDER="${choice}". Falling back to "none". Valid values: pg-trgm, meilisearch, typesense, none.`,
+      );
+      return new NoneSearchProvider();
+  }
+}
+
+export * from './search-provider.interface';
+export { PgTrgmProvider, PgQueryFn } from './pg-trgm.provider';
+export { MeilisearchProvider } from './meilisearch.provider';
+export { TypesenseProvider } from './typesense.provider';
+export { NoneSearchProvider } from './none.provider';

--- a/backend/src/modules/search/providers/meilisearch.provider.ts
+++ b/backend/src/modules/search/providers/meilisearch.provider.ts
@@ -1,0 +1,182 @@
+/**
+ * Meilisearch provider.
+ *
+ *   SEARCH_PROVIDER=meilisearch
+ *   MEILI_URL=http://localhost:7700
+ *   MEILI_MASTER_KEY=your-master-key
+ *
+ * Pure REST via fetch — no SDK dep. Meilisearch is the recommended
+ * production default for e-commerce catalogs because of its exceptional
+ * typo tolerance, fast faceted search, and tiny footprint.
+ *
+ * Run via `docker compose --profile meilisearch up -d` (once the install
+ * wizard PR #27 lands).
+ *
+ * Meilisearch's "indexes" map 1:1 to our "collections" concept.
+ */
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  SearchableDocument,
+  SearchProvider,
+  SearchProviderNotConfiguredError,
+  SearchQuery,
+  SearchResult,
+} from './search-provider.interface';
+
+export class MeilisearchProvider implements SearchProvider {
+  readonly name = 'meilisearch' as const;
+  private readonly logger = new Logger('MeilisearchProvider');
+
+  private readonly url: string;
+  private readonly masterKey: string;
+
+  constructor(config: ConfigService) {
+    this.url = (config.get<string>('MEILI_URL', '') || '').replace(/\/+$/, '');
+    this.masterKey = config.get<string>('MEILI_MASTER_KEY', '');
+
+    if (this.isAvailable()) {
+      this.logger.log(`Meilisearch provider configured (${this.url})`);
+    } else {
+      this.logger.warn(
+        'Meilisearch provider selected but MEILI_URL / MEILI_MASTER_KEY missing',
+      );
+    }
+  }
+
+  isAvailable(): boolean {
+    return !!(this.url && this.masterKey);
+  }
+
+  private async meiliApi(
+    method: 'GET' | 'POST' | 'PUT' | 'DELETE',
+    path: string,
+    body?: any,
+  ): Promise<any> {
+    if (!this.isAvailable()) {
+      throw new SearchProviderNotConfiguredError('meilisearch', [
+        !this.url ? 'MEILI_URL' : '',
+        !this.masterKey ? 'MEILI_MASTER_KEY' : '',
+      ].filter(Boolean));
+    }
+    const res = await fetch(`${this.url}${path}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${this.masterKey}`,
+        'Content-Type': 'application/json',
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(
+        `Meilisearch API ${method} ${path} failed: ${res.status} ${text}`,
+      );
+    }
+    if (res.status === 204) return null;
+    return res.json();
+  }
+
+  async indexDocument(
+    collection: string,
+    document: SearchableDocument,
+  ): Promise<void> {
+    await this.meiliApi('POST', `/indexes/${collection}/documents`, [document]);
+  }
+
+  async indexBatch(
+    collection: string,
+    documents: SearchableDocument[],
+  ): Promise<void> {
+    if (documents.length === 0) return;
+    await this.meiliApi('POST', `/indexes/${collection}/documents`, documents);
+  }
+
+  async deleteDocument(collection: string, id: string): Promise<void> {
+    await this.meiliApi(
+      'DELETE',
+      `/indexes/${collection}/documents/${encodeURIComponent(id)}`,
+    );
+  }
+
+  async search<T = SearchableDocument>(
+    collection: string,
+    query: SearchQuery,
+  ): Promise<SearchResult<T>> {
+    // Translate our filter shape to Meili's string filter syntax:
+    //   filters: { category: 'shoes', status: 'active' }
+    //   → "category = 'shoes' AND status = 'active'"
+    const filterParts: string[] = [];
+    if (query.filters) {
+      for (const [field, value] of Object.entries(query.filters)) {
+        filterParts.push(
+          `${field} = ${typeof value === 'string' ? `'${value.replace(/'/g, "\\'")}'` : value}`,
+        );
+      }
+    }
+    if (query.rangeFilters) {
+      for (const [field, range] of Object.entries(query.rangeFilters)) {
+        if (range.gte !== undefined) {
+          filterParts.push(`${field} >= ${range.gte}`);
+        }
+        if (range.lte !== undefined) {
+          filterParts.push(`${field} <= ${range.lte}`);
+        }
+      }
+    }
+
+    const payload: any = {
+      q: query.q,
+      limit: query.limit ?? 20,
+      offset: query.offset ?? 0,
+    };
+    if (filterParts.length > 0) payload.filter = filterParts.join(' AND ');
+    if (query.facets && query.facets.length > 0) payload.facets = query.facets;
+    if (query.sort) payload.sort = [query.sort];
+
+    const res = await this.meiliApi(
+      'POST',
+      `/indexes/${collection}/search`,
+      payload,
+    );
+
+    const hits = (res.hits ?? []).map((doc: any) => ({
+      document: doc as T,
+      // Meili doesn't return per-hit score by default. Use position as
+      // a proxy so callers that sort by score get sensible ordering.
+      score: 1,
+    }));
+
+    return {
+      hits,
+      total: res.estimatedTotalHits ?? res.totalHits ?? hits.length,
+      facets: res.facetDistribution,
+      tookMs: res.processingTimeMs,
+    };
+  }
+
+  async reindex(
+    collection: string,
+    source: AsyncIterable<SearchableDocument>,
+  ): Promise<number> {
+    // Wipe and re-populate. Meili provides a "delete all documents"
+    // endpoint; we batch the source in groups of 1000.
+    await this.meiliApi('DELETE', `/indexes/${collection}/documents`);
+
+    let count = 0;
+    let batch: SearchableDocument[] = [];
+    for await (const doc of source) {
+      batch.push(doc);
+      if (batch.length >= 1000) {
+        await this.indexBatch(collection, batch);
+        count += batch.length;
+        batch = [];
+      }
+    }
+    if (batch.length > 0) {
+      await this.indexBatch(collection, batch);
+      count += batch.length;
+    }
+    return count;
+  }
+}

--- a/backend/src/modules/search/providers/none.provider.ts
+++ b/backend/src/modules/search/providers/none.provider.ts
@@ -1,0 +1,69 @@
+/**
+ * "None" search provider — search is disabled.
+ *
+ * The default if SEARCH_PROVIDER is unset. Every method throws
+ * SearchProviderNotConfiguredError so calling code fails loudly
+ * rather than silently returning empty results (which would mask
+ * real wiring bugs in development).
+ */
+import { Logger } from '@nestjs/common';
+import {
+  SearchableDocument,
+  SearchProvider,
+  SearchProviderNotConfiguredError,
+  SearchQuery,
+  SearchResult,
+} from './search-provider.interface';
+
+export class NoneSearchProvider implements SearchProvider {
+  readonly name = 'none' as const;
+  private readonly logger = new Logger('NoneSearchProvider');
+
+  constructor() {
+    this.logger.log(
+      'Search is DISABLED (SEARCH_PROVIDER not set). To enable, set SEARCH_PROVIDER to one of: pg-trgm, meilisearch, typesense. See docs/providers/search.md.',
+    );
+  }
+
+  isAvailable(): boolean {
+    return false;
+  }
+
+  private fail(op: string): never {
+    throw new SearchProviderNotConfiguredError('none', [
+      `SEARCH_PROVIDER (currently unset) - cannot ${op}`,
+    ]);
+  }
+
+  async indexDocument(
+    _collection: string,
+    _document: SearchableDocument,
+  ): Promise<void> {
+    return this.fail('indexDocument');
+  }
+
+  async indexBatch(
+    _collection: string,
+    _documents: SearchableDocument[],
+  ): Promise<void> {
+    return this.fail('indexBatch');
+  }
+
+  async deleteDocument(_collection: string, _id: string): Promise<void> {
+    return this.fail('deleteDocument');
+  }
+
+  async search<T = SearchableDocument>(
+    _collection: string,
+    _query: SearchQuery,
+  ): Promise<SearchResult<T>> {
+    return this.fail('search');
+  }
+
+  async reindex(
+    _collection: string,
+    _source: AsyncIterable<SearchableDocument>,
+  ): Promise<number> {
+    return this.fail('reindex');
+  }
+}

--- a/backend/src/modules/search/providers/pg-trgm.provider.ts
+++ b/backend/src/modules/search/providers/pg-trgm.provider.ts
@@ -1,0 +1,274 @@
+/**
+ * Postgres pg_trgm search provider.
+ *
+ *   SEARCH_PROVIDER=pg-trgm
+ *
+ * Zero extra infrastructure — uses the Postgres you're already running.
+ * The first time the provider is touched, it ensures the `pg_trgm`
+ * extension exists (idempotent CREATE EXTENSION) and creates a GIN
+ * index on each collection's `name + description` columns for fast
+ * trigram similarity search.
+ *
+ * Search uses the `%` similarity operator (trigram match) for fuzzy
+ * matching PLUS `ILIKE` for substring matching, combined with OR. The
+ * relevance score is `similarity(name, q)` so exact-or-near-exact
+ * matches float to the top.
+ *
+ * Indexing is a no-op because Postgres IS the source of truth — the
+ * moment the `products` row exists, it's searchable. This is a huge
+ * UX win over external search engines that need a separate reindex
+ * step on schema changes.
+ *
+ * Not suitable for: semantic/vector search, cross-field ranking beyond
+ * trigram similarity, faceted search on arbitrary fields. For those,
+ * graduate to Meilisearch / Typesense / Qdrant.
+ *
+ * Supported collections (mapped to real table names):
+ *   'products'    → products (columns: name, description, short_description, tags)
+ *
+ * Add more collections by editing `TABLE_MAP` below.
+ */
+import { Logger } from '@nestjs/common';
+import {
+  SearchableDocument,
+  SearchProvider,
+  SearchProviderNotSupportedError,
+  SearchQuery,
+  SearchResult,
+} from './search-provider.interface';
+
+/** (sql, params) → rows[] — the minimum surface of a pg client the provider needs. */
+export type PgQueryFn = (
+  sql: string,
+  params?: any[],
+) => Promise<{ rows: any[] }>;
+
+interface CollectionMap {
+  table: string;
+  searchColumns: string[];
+  idColumn: string;
+}
+
+/**
+ * Collections the pg-trgm provider knows how to search. Every entry
+ * here gets a GIN index per search column on first search.
+ *
+ * Team@Once's initial search surface is projects + tasks + proposals —
+ * add more collections as the rest of the app migrates to the
+ * pluggable layer (conversations, contracts, courses, companies, etc).
+ */
+const TABLE_MAP: Record<string, CollectionMap> = {
+  projects: {
+    table: 'projects',
+    searchColumns: ['name', 'description'],
+    idColumn: 'id',
+  },
+  project_tasks: {
+    table: 'project_tasks',
+    searchColumns: ['title', 'description'],
+    idColumn: 'id',
+  },
+  project_proposals: {
+    table: 'project_proposals',
+    searchColumns: ['title', 'description'],
+    idColumn: 'id',
+  },
+};
+
+export class PgTrgmProvider implements SearchProvider {
+  readonly name = 'pg-trgm' as const;
+  private readonly logger = new Logger('PgTrgmProvider');
+
+  private readonly query: PgQueryFn;
+  private initialized = false;
+
+  constructor(query: PgQueryFn) {
+    this.query = query;
+    this.logger.log('pg-trgm provider constructed (indexes will be ensured on first search)');
+  }
+
+  isAvailable(): boolean {
+    // pg-trgm is always available if Postgres is up — whether the
+    // extension is installed is checked lazily on first search.
+    return true;
+  }
+
+  /**
+   * Lazy one-time setup: ensure the pg_trgm extension exists and
+   * create GIN indexes on the mapped tables for fast similarity search.
+   * Every step is idempotent so it's safe to re-run.
+   */
+  private async ensureReady(): Promise<void> {
+    if (this.initialized) return;
+    try {
+      await this.query('CREATE EXTENSION IF NOT EXISTS pg_trgm');
+      for (const [collection, map] of Object.entries(TABLE_MAP)) {
+        for (const col of map.searchColumns) {
+          const idxName = `${map.table}_${col}_trgm_idx`;
+          // Use the sanitized identifier path so there's zero injection
+          // surface: TABLE_MAP is a compile-time constant and col is
+          // drawn from a whitelisted array above.
+          await this.query(
+            `CREATE INDEX IF NOT EXISTS ${idxName} ON ${map.table} USING gin (${col} gin_trgm_ops)`,
+          );
+        }
+        this.logger.log(`pg_trgm indexes ensured for ${collection} (${map.table})`);
+      }
+      this.initialized = true;
+    } catch (e: any) {
+      // Don't permanently fail — maybe the user doesn't have
+      // CREATE EXTENSION privs. Log loudly once and let search queries
+      // fall back to plain ILIKE.
+      this.logger.warn(
+        `pg_trgm setup failed (${e.message}). Falling back to ILIKE-only search. ` +
+          `Run "CREATE EXTENSION IF NOT EXISTS pg_trgm;" as a superuser to enable fast fuzzy search.`,
+      );
+      this.initialized = true; // don't retry on every query
+    }
+  }
+
+  private resolveCollection(collection: string): CollectionMap {
+    const map = TABLE_MAP[collection];
+    if (!map) {
+      throw new SearchProviderNotSupportedError(
+        'pg-trgm',
+        `search on collection "${collection}" — add it to TABLE_MAP in pg-trgm.provider.ts`,
+      );
+    }
+    return map;
+  }
+
+  async indexDocument(_collection: string, _document: SearchableDocument): Promise<void> {
+    // No-op: Postgres IS the source of truth. The row is searchable
+    // the moment the app's main write path writes it.
+  }
+
+  async indexBatch(
+    _collection: string,
+    _documents: SearchableDocument[],
+  ): Promise<void> {
+    // No-op, same reason.
+  }
+
+  async deleteDocument(_collection: string, _id: string): Promise<void> {
+    // No-op — the main delete path removes the row from Postgres
+    // directly, which is also the search index.
+  }
+
+  async search<T = SearchableDocument>(
+    collection: string,
+    query: SearchQuery,
+  ): Promise<SearchResult<T>> {
+    await this.ensureReady();
+    const map = this.resolveCollection(collection);
+    const limit = Math.min(query.limit ?? 20, 100);
+    const offset = Math.max(query.offset ?? 0, 0);
+
+    const whereClauses: string[] = [];
+    const params: any[] = [];
+    let paramIdx = 1;
+
+    // Free-text: trigram similarity OR ILIKE across searchColumns.
+    if (query.q && query.q.trim().length > 0) {
+      const q = query.q.trim();
+      const cols = map.searchColumns;
+      // For each column: (col % $q) OR (col ILIKE $qLike)
+      const orParts: string[] = [];
+      params.push(q); // $paramIdx — bare query (for similarity)
+      const qParamBare = paramIdx++;
+      params.push(`%${q}%`); // next param — ILIKE wildcard
+      const qParamLike = paramIdx++;
+      for (const col of cols) {
+        orParts.push(`(${col} % $${qParamBare} OR ${col} ILIKE $${qParamLike})`);
+      }
+      whereClauses.push(`(${orParts.join(' OR ')})`);
+    }
+
+    // Equality filters
+    if (query.filters) {
+      for (const [field, value] of Object.entries(query.filters)) {
+        // Only allow identifier-safe field names to prevent SQL injection.
+        if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(field)) {
+          this.logger.warn(`Rejected unsafe filter field: ${field}`);
+          continue;
+        }
+        whereClauses.push(`${field} = $${paramIdx}`);
+        params.push(value);
+        paramIdx++;
+      }
+    }
+
+    // Range filters
+    if (query.rangeFilters) {
+      for (const [field, range] of Object.entries(query.rangeFilters)) {
+        if (!/^[a-zA-Z_][a-zA-Z0-9_]*$/.test(field)) {
+          this.logger.warn(`Rejected unsafe range field: ${field}`);
+          continue;
+        }
+        if (range.gte !== undefined) {
+          whereClauses.push(`${field} >= $${paramIdx}`);
+          params.push(range.gte);
+          paramIdx++;
+        }
+        if (range.lte !== undefined) {
+          whereClauses.push(`${field} <= $${paramIdx}`);
+          params.push(range.lte);
+          paramIdx++;
+        }
+      }
+    }
+
+    const whereSql =
+      whereClauses.length > 0 ? `WHERE ${whereClauses.join(' AND ')}` : '';
+
+    // Score: similarity of the primary search column (first in the list)
+    // to the query, or 0 if no text query.
+    const primaryCol = map.searchColumns[0];
+    const scoreSql = query.q
+      ? `similarity(${primaryCol}, $1)`
+      : '0';
+
+    const sql = `
+      SELECT
+        *,
+        ${scoreSql} AS _score
+      FROM ${map.table}
+      ${whereSql}
+      ORDER BY ${query.q ? '_score DESC,' : ''} ${map.idColumn}
+      LIMIT ${limit} OFFSET ${offset}
+    `;
+
+    const countSql = `SELECT COUNT(*)::int AS count FROM ${map.table} ${whereSql}`;
+
+    const start = Date.now();
+    const [rowsResult, countResult] = await Promise.all([
+      this.query(sql, params),
+      this.query(countSql, params),
+    ]);
+    const tookMs = Date.now() - start;
+
+    const hits = rowsResult.rows.map((row: any) => {
+      const score = Number(row._score) || 0;
+      const { _score, ...document } = row;
+      return { document: document as T, score };
+    });
+
+    return {
+      hits,
+      total: countResult.rows[0]?.count ?? 0,
+      tookMs,
+    };
+  }
+
+  async reindex(
+    _collection: string,
+    _source: AsyncIterable<SearchableDocument>,
+  ): Promise<number> {
+    // No-op — Postgres is the source of truth. We could re-run
+    // ensureReady() to rebuild the GIN indexes, but REINDEX is an
+    // expensive operation and not typically needed. Callers that
+    // really want to rebuild should run `REINDEX TABLE products`
+    // manually.
+    return 0;
+  }
+}

--- a/backend/src/modules/search/providers/search-provider.interface.ts
+++ b/backend/src/modules/search/providers/search-provider.interface.ts
@@ -1,0 +1,151 @@
+/**
+ * Common interface that every search provider implements.
+ *
+ * Pick a provider by setting SEARCH_PROVIDER in your .env to one of:
+ *
+ *   pg-trgm       - Postgres pg_trgm + tsvector full-text. Zero extra
+ *                   infrastructure. Uses the existing Postgres you're
+ *                   already running. The default and recommended
+ *                   starting point for dev.
+ *
+ *   meilisearch   - Meilisearch (https://meilisearch.com). Best typo
+ *                   tolerance + faceting for e-commerce. Recommended
+ *                   default for production.
+ *
+ *   typesense     - Typesense (https://typesense.org). Fast, simple,
+ *                   self-hosted alternative to Meilisearch.
+ *
+ *   qdrant        - Qdrant vector search. [PLANNED follow-up PR]
+ *
+ *   weaviate      - Weaviate hybrid search. [PLANNED follow-up PR]
+ *
+ *   elasticsearch - Elasticsearch/OpenSearch. [PLANNED follow-up PR]
+ *
+ *   none          - Search disabled. Every method throws loudly.
+ *                   The default if SEARCH_PROVIDER is unset.
+ *
+ * Adding a new provider: implement this interface, register it in
+ * providers/index.ts, document the env vars in docs/providers/search.md.
+ */
+
+export interface SearchableDocument {
+  /** Stable document id (usually the row's primary key). */
+  id: string;
+  /** Arbitrary fields to index. Provider-specific handling. */
+  [key: string]: any;
+}
+
+export interface SearchQuery {
+  /** Free-text query. Empty string returns all documents (paginated). */
+  q: string;
+  /** Max results to return. Default 20. */
+  limit?: number;
+  /** Pagination offset. Default 0. */
+  offset?: number;
+  /** Field equality filters, e.g. { category: 'shoes', status: 'active' }. */
+  filters?: Record<string, string | number | boolean>;
+  /** Numeric range filters, e.g. { price: { gte: 10, lte: 100 } }. */
+  rangeFilters?: Record<string, { gte?: number; lte?: number }>;
+  /** Fields to request facet counts on. */
+  facets?: string[];
+  /** Sort field, provider-dependent. */
+  sort?: string;
+}
+
+export interface SearchHit<T = SearchableDocument> {
+  /** The raw document as stored in the index. */
+  document: T;
+  /** Relevance score from the search engine. Higher is better. */
+  score: number;
+  /** Highlighted snippets (provider-dependent, may be empty). */
+  highlights?: Record<string, string[]>;
+}
+
+export interface SearchResult<T = SearchableDocument> {
+  /** Matching documents. */
+  hits: SearchHit<T>[];
+  /** Total number of matches (may be an estimate depending on provider). */
+  total: number;
+  /** Facet counts, keyed by facet field name. */
+  facets?: Record<string, Record<string, number>>;
+  /** Query time in milliseconds, as reported by the provider. */
+  tookMs?: number;
+}
+
+/**
+ * Common interface implemented by every search provider. Methods a
+ * provider can't support should throw SearchProviderNotSupportedError —
+ * never silently no-op.
+ */
+export interface SearchProvider {
+  /** Stable provider name for logging / clients. */
+  readonly name:
+    | 'pg-trgm'
+    | 'meilisearch'
+    | 'typesense'
+    | 'qdrant'
+    | 'weaviate'
+    | 'elasticsearch'
+    | 'none';
+
+  /** True if the provider has the credentials/infra it needs. */
+  isAvailable(): boolean;
+
+  /**
+   * Insert or update a single document in the given collection/index.
+   * Providers that index directly from Postgres (pg-trgm) may no-op
+   * since the source of truth IS the Postgres table — the document
+   * becomes searchable the moment it's written.
+   */
+  indexDocument(collection: string, document: SearchableDocument): Promise<void>;
+
+  /**
+   * Bulk insert/update documents in one batch. Default implementation
+   * loops indexDocument(); providers with a native batch API override.
+   */
+  indexBatch(collection: string, documents: SearchableDocument[]): Promise<void>;
+
+  /** Remove a document from the index. */
+  deleteDocument(collection: string, id: string): Promise<void>;
+
+  /** Run a search query against a collection. */
+  search<T = SearchableDocument>(
+    collection: string,
+    query: SearchQuery,
+  ): Promise<SearchResult<T>>;
+
+  /**
+   * Rebuild the index for a collection from a source iterator. Used
+   * during initial setup and after schema changes. For pg-trgm this
+   * is a no-op because there's no separate index; for Meilisearch /
+   * Typesense this wipes and repopulates.
+   */
+  reindex(
+    collection: string,
+    source: AsyncIterable<SearchableDocument>,
+  ): Promise<number>;
+}
+
+/**
+ * Thrown when a provider is asked to do something it can't support.
+ */
+export class SearchProviderNotSupportedError extends Error {
+  constructor(provider: string, operation: string) {
+    super(
+      `Operation "${operation}" is not supported by the "${provider}" search provider. See docs/providers/search.md for provider capabilities.`,
+    );
+    this.name = 'SearchProviderNotSupportedError';
+  }
+}
+
+/**
+ * Thrown when a provider is selected but its credentials/infra are missing.
+ */
+export class SearchProviderNotConfiguredError extends Error {
+  constructor(provider: string, missingVars: string[]) {
+    super(
+      `Search provider "${provider}" is selected but the following env vars are missing: ${missingVars.join(', ')}. See docs/providers/search.md.`,
+    );
+    this.name = 'SearchProviderNotConfiguredError';
+  }
+}

--- a/backend/src/modules/search/providers/typesense.provider.ts
+++ b/backend/src/modules/search/providers/typesense.provider.ts
@@ -1,0 +1,235 @@
+/**
+ * Typesense provider.
+ *
+ *   SEARCH_PROVIDER=typesense
+ *   TYPESENSE_URL=http://localhost:8108
+ *   TYPESENSE_API_KEY=your-api-key
+ *
+ * Pure REST via fetch. Typesense is a fast, simple, self-hosted
+ * alternative to Meilisearch with a similar feature set. Run via
+ * `docker compose --profile typesense up -d` (install PR #27).
+ *
+ * Typesense's "collections" map 1:1 to our "collections" concept.
+ *
+ * NOTE: Typesense requires an explicit schema for each collection,
+ * with typed fields and a designated `id` field. This provider assumes
+ * the caller has already created the collection via
+ * `POST /collections` with an appropriate schema before indexing.
+ * The `reindex()` method will create a minimal schema if none exists.
+ */
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  SearchableDocument,
+  SearchProvider,
+  SearchProviderNotConfiguredError,
+  SearchQuery,
+  SearchResult,
+} from './search-provider.interface';
+
+export class TypesenseProvider implements SearchProvider {
+  readonly name = 'typesense' as const;
+  private readonly logger = new Logger('TypesenseProvider');
+
+  private readonly url: string;
+  private readonly apiKey: string;
+
+  constructor(config: ConfigService) {
+    this.url = (config.get<string>('TYPESENSE_URL', '') || '').replace(
+      /\/+$/,
+      '',
+    );
+    this.apiKey = config.get<string>('TYPESENSE_API_KEY', '');
+
+    if (this.isAvailable()) {
+      this.logger.log(`Typesense provider configured (${this.url})`);
+    } else {
+      this.logger.warn(
+        'Typesense provider selected but TYPESENSE_URL / TYPESENSE_API_KEY missing',
+      );
+    }
+  }
+
+  isAvailable(): boolean {
+    return !!(this.url && this.apiKey);
+  }
+
+  private async typesenseApi(
+    method: 'GET' | 'POST' | 'PUT' | 'DELETE' | 'PATCH',
+    path: string,
+    body?: any,
+    contentType = 'application/json',
+  ): Promise<any> {
+    if (!this.isAvailable()) {
+      throw new SearchProviderNotConfiguredError('typesense', [
+        !this.url ? 'TYPESENSE_URL' : '',
+        !this.apiKey ? 'TYPESENSE_API_KEY' : '',
+      ].filter(Boolean));
+    }
+    const res = await fetch(`${this.url}${path}`, {
+      method,
+      headers: {
+        'X-TYPESENSE-API-KEY': this.apiKey,
+        'Content-Type': contentType,
+      },
+      body:
+        body === undefined
+          ? undefined
+          : contentType === 'application/json'
+            ? JSON.stringify(body)
+            : body,
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      throw new Error(
+        `Typesense API ${method} ${path} failed: ${res.status} ${text}`,
+      );
+    }
+    if (res.status === 204) return null;
+    // Typesense's /documents/import returns JSONL, not JSON.
+    const ct = res.headers.get('content-type') ?? '';
+    if (!ct.includes('json')) return res.text();
+    return res.json();
+  }
+
+  async indexDocument(
+    collection: string,
+    document: SearchableDocument,
+  ): Promise<void> {
+    // Typesense expects `id` as a string field. Normalize.
+    const doc = { ...document, id: String(document.id) };
+    await this.typesenseApi(
+      'POST',
+      `/collections/${collection}/documents?action=upsert`,
+      doc,
+    );
+  }
+
+  async indexBatch(
+    collection: string,
+    documents: SearchableDocument[],
+  ): Promise<void> {
+    if (documents.length === 0) return;
+    // Typesense /documents/import expects JSONL with action=upsert.
+    const jsonl = documents
+      .map((d) => JSON.stringify({ ...d, id: String(d.id) }))
+      .join('\n');
+    await this.typesenseApi(
+      'POST',
+      `/collections/${collection}/documents/import?action=upsert`,
+      jsonl,
+      'text/plain',
+    );
+  }
+
+  async deleteDocument(collection: string, id: string): Promise<void> {
+    await this.typesenseApi(
+      'DELETE',
+      `/collections/${collection}/documents/${encodeURIComponent(id)}`,
+    );
+  }
+
+  async search<T = SearchableDocument>(
+    collection: string,
+    query: SearchQuery,
+  ): Promise<SearchResult<T>> {
+    // Typesense's filter syntax is very similar to Meili's:
+    //   "category:=shoes && status:=active"
+    const filterParts: string[] = [];
+    if (query.filters) {
+      for (const [field, value] of Object.entries(query.filters)) {
+        filterParts.push(
+          `${field}:=${typeof value === 'string' ? `\`${value}\`` : value}`,
+        );
+      }
+    }
+    if (query.rangeFilters) {
+      for (const [field, range] of Object.entries(query.rangeFilters)) {
+        if (range.gte !== undefined) filterParts.push(`${field}:>=${range.gte}`);
+        if (range.lte !== undefined) filterParts.push(`${field}:<=${range.lte}`);
+      }
+    }
+
+    const params = new URLSearchParams();
+    params.set('q', query.q || '*');
+    // Default to searching all text fields; callers can override via
+    // the future `searchFields` knob.
+    params.set('query_by', 'name,description');
+    if (filterParts.length > 0) {
+      params.set('filter_by', filterParts.join(' && '));
+    }
+    if (query.facets && query.facets.length > 0) {
+      params.set('facet_by', query.facets.join(','));
+    }
+    if (query.sort) params.set('sort_by', query.sort);
+    params.set('per_page', String(query.limit ?? 20));
+    params.set('page', String(Math.floor((query.offset ?? 0) / (query.limit ?? 20)) + 1));
+
+    const res = await this.typesenseApi(
+      'GET',
+      `/collections/${collection}/documents/search?${params.toString()}`,
+    );
+
+    const hits = (res.hits ?? []).map((h: any) => ({
+      document: h.document as T,
+      score: h.text_match ?? 1,
+      highlights: h.highlights
+        ? Object.fromEntries(
+            h.highlights.map((hi: any) => [hi.field, hi.snippets ?? []]),
+          )
+        : undefined,
+    }));
+
+    const facets: Record<string, Record<string, number>> = {};
+    for (const fc of res.facet_counts ?? []) {
+      facets[fc.field_name] = Object.fromEntries(
+        (fc.counts ?? []).map((c: any) => [c.value, c.count]),
+      );
+    }
+
+    return {
+      hits,
+      total: res.found ?? hits.length,
+      facets: Object.keys(facets).length > 0 ? facets : undefined,
+      tookMs: res.search_time_ms,
+    };
+  }
+
+  async reindex(
+    collection: string,
+    source: AsyncIterable<SearchableDocument>,
+  ): Promise<number> {
+    // Typesense has no "delete all" endpoint — we delete the collection
+    // and recreate it with a minimal schema, then import. If the caller
+    // already created a proper schema, they should call indexBatch()
+    // themselves instead of reindex().
+    try {
+      await this.typesenseApi('DELETE', `/collections/${collection}`);
+    } catch {
+      // 404 is fine.
+    }
+    await this.typesenseApi('POST', '/collections', {
+      name: collection,
+      fields: [
+        { name: 'id', type: 'string' },
+        { name: '.*', type: 'auto' }, // allow any additional fields
+      ],
+    });
+
+    let count = 0;
+    let batch: SearchableDocument[] = [];
+    for await (const doc of source) {
+      batch.push(doc);
+      if (batch.length >= 1000) {
+        await this.indexBatch(collection, batch);
+        count += batch.length;
+        batch = [];
+      }
+    }
+    if (batch.length > 0) {
+      await this.indexBatch(collection, batch);
+      count += batch.length;
+    }
+    return count;
+  }
+}

--- a/backend/src/modules/search/search-provider.service.ts
+++ b/backend/src/modules/search/search-provider.service.ts
@@ -1,0 +1,94 @@
+/**
+ * SearchProviderService — the pluggable search façade.
+ *
+ * NEW service alongside the existing legacy `SearchService`
+ * (search.service.ts). New code should inject this one. Dispatches
+ * to whichever provider the operator has selected via SEARCH_PROVIDER
+ * in .env (pg-trgm, meilisearch, typesense, none).
+ *
+ * See `./providers/` and `docs/providers/search.md`.
+ *
+ * Migration note: Team@Once's legacy `SearchService` is a universal
+ * content-search across projects / tasks / messages backed by
+ * hand-rolled SQL queries. A follow-up PR will migrate it to
+ * delegate to this pluggable layer so content search respects the
+ * configured SEARCH_PROVIDER.
+ */
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { DatabaseService } from '../database/database.service';
+import {
+  createSearchProvider,
+  SearchProvider,
+  SearchQuery,
+  SearchResult,
+  SearchableDocument,
+} from './providers';
+
+@Injectable()
+export class SearchProviderService implements OnModuleInit {
+  private readonly logger = new Logger(SearchProviderService.name);
+  private provider!: SearchProvider;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly db: DatabaseService,
+  ) {}
+
+  onModuleInit() {
+    // Hand the raw query function to the factory so the pg-trgm
+    // provider can run its own SQL directly against the pool, without
+    // taking a dep on the whole DatabaseService.
+    this.provider = createSearchProvider({
+      config: this.config,
+      pgQuery: async (sql, params) => this.db.query(sql, params),
+    });
+    this.logger.log(
+      `Search provider initialized: ${this.provider.name} (available=${this.provider.isAvailable()})`,
+    );
+  }
+
+  getProviderName(): string {
+    return this.provider?.name ?? 'none';
+  }
+
+  isAvailable(): boolean {
+    return !!this.provider && this.provider.isAvailable();
+  }
+
+  async search<T = SearchableDocument>(
+    collection: string,
+    query: SearchQuery,
+  ): Promise<SearchResult<T>> {
+    return this.provider.search<T>(collection, query);
+  }
+
+  async indexDocument(
+    collection: string,
+    document: SearchableDocument,
+  ): Promise<void> {
+    return this.provider.indexDocument(collection, document);
+  }
+
+  async indexBatch(
+    collection: string,
+    documents: SearchableDocument[],
+  ): Promise<void> {
+    return this.provider.indexBatch(collection, documents);
+  }
+
+  async deleteDocument(collection: string, id: string): Promise<void> {
+    return this.provider.deleteDocument(collection, id);
+  }
+
+  async reindex(
+    collection: string,
+    source: AsyncIterable<SearchableDocument>,
+  ): Promise<number> {
+    return this.provider.reindex(collection, source);
+  }
+
+  getProvider(): SearchProvider {
+    return this.provider;
+  }
+}

--- a/backend/src/modules/search/search.module.ts
+++ b/backend/src/modules/search/search.module.ts
@@ -1,12 +1,30 @@
 import { Module } from '@nestjs/common';
 import { SearchController } from './search.controller';
 import { SearchService } from './search.service';
+import { SearchProviderService } from './search-provider.service';
 import { AuthModule } from '../auth/auth.module';
 
+/**
+ * Search module.
+ *
+ * Exposes two services:
+ *
+ * - `SearchProviderService` (NEW, pluggable)
+ *   Façade over the multi-provider adapter (pg-trgm / meilisearch /
+ *   typesense / none). Pick a provider with `SEARCH_PROVIDER` in .env.
+ *   See `docs/providers/search.md`. New code should inject this.
+ *
+ * - `SearchService` (legacy, hand-rolled Postgres)
+ *   Still exported for backwards compatibility. Implements the
+ *   existing `/api/v1/search/*` endpoints with hybrid keyword +
+ *   semantic search. A follow-up PR will migrate it to delegate to
+ *   `SearchProviderService` so content search respects the configured
+ *   SEARCH_PROVIDER.
+ */
 @Module({
   imports: [AuthModule],
   controllers: [SearchController],
-  providers: [SearchService],
-  exports: [SearchService],
+  providers: [SearchService, SearchProviderService],
+  exports: [SearchService, SearchProviderService],
 })
 export class SearchModule {}


### PR DESCRIPTION
## Summary

Closes #30 (partial). Direct port of vasty-shop PR #31 adapted for Team@Once. Adds the pluggable search provider adapter **alongside** Team@Once's existing legacy `SearchService` without removing it.

## What's in it

**4 real providers + 3 planned stubs**:

- **pg-trgm** *(default)* — Postgres `pg_trgm` + GIN indexes. Zero infra, uses the existing Postgres pool via `DatabaseService.query()`. TABLE_MAP updated for Team@Once tables: `projects`, `project_tasks`, `project_proposals` (6 GIN indexes total).
- **meilisearch** — REST, typo-tolerant
- **typesense** — REST, JSONL batch import
- **none** — disabled stub
- **qdrant** / **weaviate** / **elasticsearch** — planned; logs warning + falls back to none

**`SearchProviderService`** (new) added alongside the existing **`SearchService`** (legacy). Both exported from `SearchModule`. New code should inject `SearchProviderService`. A follow-up PR will migrate `SearchService` to delegate.

## Team@Once deltas vs vasty-shop #31

- Service named `SearchProviderService` (not `SearchService`) to avoid colliding with Team@Once's existing hybrid keyword+semantic content search service
- `TABLE_MAP` replaced with Team@Once's actual tables (projects / project_tasks / project_proposals) — vasty-shop's `products` is gone
- Smoke test updated to use `projects` collection with Team@Once-flavored mock data
- 6 expected GIN indexes instead of vasty's 3

## Verification status (honest)

| Provider | Status |
|---|---|
| **pg-trgm** | written, **smoke-tested** (mock SQL verifies shape, injection rejection, 6 GIN indexes ensured). NOT exercised against real Postgres |
| **meilisearch** / **typesense** | written, **smoke-tested** (mocked HTTP). NOT tested against real services |
| **none** | written, **smoke-tested** |
| **qdrant** / **weaviate** / **elasticsearch** | NOT implemented; planned stubs |

Full TypeScript compile: **0 errors**.

Smoke test: **49/49 assertions pass** on teamatonce.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx ts-node scripts/smoke-test-search-providers.ts` 49/49 pass
- [ ] Manual: seed some projects/tasks, run `curl /api/v1/search/...` with `SEARCH_PROVIDER=pg-trgm`
- [ ] Follow-up: migrate legacy `SearchService` to delegate to `SearchProviderService`

## Out of scope

- Migrating the existing `SearchService` to delegate
- Wiring into project/task/proposal write paths for meilisearch/typesense indexing
- qdrant / weaviate / elasticsearch provider implementations

## Related

- vasty-shop PR #31
- Tracking issue #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)