### PR TITLE
feat(auth): pluggable SSO registry + magic-link passwordless sign-in

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -91,3 +91,23 @@ OPENAI_MODEL=gpt-4o-mini
 QDRANT_HOST=localhost
 QDRANT_PORT=6333
 QDRANT_API_KEY=your_qdrant_api_key
+
+# =====================================================
+# AUTH / SSO (pluggable)
+# =====================================================
+# Comma-separated list of enabled providers for this deployment.
+# `local` (email + password) is always on; you don't need to list it.
+# See backend/docs/providers/auth-sso.md for per-provider setup.
+#
+# Implemented in PR #46:
+#   local, google, github, magic-link
+#
+# Planned follow-ups (part of issue #31):
+#   gitlab, keycloak, clerk, auth0
+
+AUTH_PROVIDERS=local
+
+# --- Magic Link (passwordless email sign-in) ---
+MAGIC_LINK_TTL_SECONDS=900
+# FRONTEND_URL is already set above in the App section — used to build
+# the click-through link in the email body.

--- a/backend/docs/providers/auth-sso.md
+++ b/backend/docs/providers/auth-sso.md
@@ -1,0 +1,165 @@
+# Auth / SSO providers
+
+Team@Once supports pluggable auth providers controlled by the
+`AUTH_PROVIDERS` env var. The frontend reads `GET /auth/providers` on
+page load and renders login buttons for whichever providers are
+enabled in the deployment.
+
+```
+AUTH_PROVIDERS=local,google,github,magic-link
+```
+
+`local` (email + password) is always enabled — you don't need to list
+it, the registry auto-adds it.
+
+## Implemented in this PR (#31)
+
+| Provider | Status | Env vars |
+|---|---|---|
+| **local** *(baseline)* | ready | (none — uses JWT_SECRET + database) |
+| **google** | ready | `GOOGLE_CLIENT_ID`, `GOOGLE_CLIENT_SECRET`, `GOOGLE_REDIRECT_URL` |
+| **github** | ready | `GITHUB_CLIENT_ID`, `GITHUB_CLIENT_SECRET`, `GITHUB_CALLBACK_URL` |
+| **magic-link** | ready *(NEW)* | `MAGIC_LINK_TTL_SECONDS` (optional, default 900) |
+
+Google and GitHub already existed in Team@Once as passport strategies —
+this PR adds them to the central registry so the frontend can discover
+them without hardcoding. Magic Link is net-new.
+
+## Planned follow-ups
+
+| Provider | Status | Notes |
+|---|---|---|
+| **gitlab** | planned | trivial follow-up — same OAuth2 shape as GitHub |
+| **keycloak** | planned | OIDC compliant, good for self-hosted IAM |
+| **clerk** | planned | managed auth, JWT verification only |
+| **auth0** | planned | managed auth, OIDC |
+
+Listing any of these in `AUTH_PROVIDERS` today logs a warning and
+they're dropped from the enabled list — not silently skipped.
+
+## Frontend endpoint
+
+```
+GET /api/v1/auth/providers
+```
+
+Returns the enabled list the frontend uses to render login buttons:
+
+```json
+{
+  "providers": [
+    { "key": "local", "displayName": "Email & Password", "enabled": true, "implemented": true, "icon": "mail" },
+    { "key": "google", "displayName": "Google", "enabled": true, "implemented": true, "authorizationPath": "/api/v1/auth/oauth/google", "icon": "google" },
+    { "key": "github", "displayName": "GitHub", "enabled": true, "implemented": true, "authorizationPath": "/api/v1/auth/oauth/github", "icon": "github" },
+    { "key": "magic-link", "displayName": "Magic Link", "enabled": true, "implemented": true, "authorizationPath": "/api/v1/auth/magic-link/request", "icon": "link" }
+  ]
+}
+```
+
+The frontend should:
+1. Call this once on login-page mount
+2. Render one button per entry, using `icon` to pick the svg and
+   `displayName` as the label
+3. Clicking an OAuth button navigates to `authorizationPath`
+4. Clicking magic-link opens an email input + calls the request endpoint
+
+## Magic Link setup
+
+Add `magic-link` to `AUTH_PROVIDERS`:
+
+```
+AUTH_PROVIDERS=local,magic-link
+MAGIC_LINK_TTL_SECONDS=900             # optional, default 15 min
+```
+
+No external credentials needed — magic link uses the existing
+`JwtService` for token signing and the existing `EmailService` for
+transport. When the email adapter PR lands, the transport will
+transparently use whichever `EMAIL_PROVIDER` the operator has
+selected (smtp / resend / sendgrid / ses / etc).
+
+### Flow
+
+```
+1. User enters email on login page
+   └─ frontend POSTs /api/v1/auth/magic-link/request { email }
+      └─ backend signs JWT { email, purpose: 'magic-link' }, TTL 15min
+      └─ backend emails user a link:
+           https://app.example.com/auth/magic-link?token=<jwt>
+      └─ returns { success: true } (always, regardless of whether
+         the email is registered — enumeration protection)
+
+2. User clicks the link in their email
+   └─ frontend extracts token from URL
+   └─ frontend POSTs /api/v1/auth/magic-link/verify { token }
+      └─ backend verifies JWT (signature + not expired + purpose
+         matches)
+      └─ backend finds-or-creates user by email
+      └─ backend mints a real access token
+      └─ returns { success: true, user, access_token }
+   └─ frontend stores access_token and redirects to the app
+```
+
+### Security properties
+
+- **Enumeration protection**: `requestMagicLink` returns `{ success: true }`
+  for every valid-format email, whether or not it's registered. Real
+  SMTP failures are logged but not surfaced to the caller.
+- **Purpose isolation**: the JWT payload includes `purpose: 'magic-link'`.
+  `verifyToken` rejects any token without this purpose, so a stolen
+  magic-link token can't be replayed against a different endpoint.
+- **Short TTL**: default 15 minutes, configurable via
+  `MAGIC_LINK_TTL_SECONDS`.
+- **Dev debug token**: in non-production, the request response
+  includes `debugToken` so the e2e test and dev user can complete the
+  flow without waiting on real email delivery. Production builds
+  (`NODE_ENV=production`) never include it.
+
+### Limitations
+
+- **No token revocation**: the JWT is stateless. A leaked token is
+  valid until its `exp` claim. For high-security deployments, add a
+  `used_tokens` table and check it in `verifyToken`.
+- **No rate limiting**: the `/request` endpoint is a potential email
+  spam vector. Add a global rate limiter (per-IP or per-email) before
+  production use.
+
+## Google / GitHub setup
+
+Both providers use the existing passport strategies in
+`backend/src/modules/auth/strategies/`. Wire up credentials in
+`.env`:
+
+```
+GOOGLE_CLIENT_ID=...
+GOOGLE_CLIENT_SECRET=...
+GOOGLE_REDIRECT_URL=http://localhost:3001/api/v1/auth/oauth/google/callback
+
+GITHUB_CLIENT_ID=...
+GITHUB_CLIENT_SECRET=...
+GITHUB_CALLBACK_URL=http://localhost:3001/api/v1/auth/oauth/github/callback
+```
+
+Then add `google` and/or `github` to `AUTH_PROVIDERS` so the registry
+exposes them via `/auth/providers`. Without the list entry, the
+OAuth routes still work but the frontend won't render the buttons.
+
+## Adding a new provider
+
+1. (OAuth) Implement a new passport strategy in
+   `backend/src/modules/auth/strategies/<name>.strategy.ts` — copy
+   `github.strategy.ts` and swap the URLs
+2. (OIDC / JWT-verify) Write a new service in
+   `backend/src/modules/auth/sso/<name>.service.ts`
+3. Flip the provider's `implemented: false` → `true` in
+   `PROVIDER_CATALOG` in `sso-registry.service.ts`
+4. Document env vars here and in `.env.example`
+5. Add smoke-test coverage in
+   `backend/scripts/smoke-test-auth-sso.ts`
+
+## Admin settings UI (future)
+
+The `SsoRegistryService.getCatalog()` method returns the full list of
+providers with their `enabled` + `implemented` flags. A future admin
+integrations page can render this to let operators toggle providers
+at runtime (writing to a `.env.runtime` overlay).

--- a/backend/scripts/smoke-test-auth-sso.ts
+++ b/backend/scripts/smoke-test-auth-sso.ts
@@ -1,0 +1,307 @@
+/**
+ * Smoke test for the SSO registry + magic-link flow.
+ *
+ * - SsoRegistryService: direct construction with a fake
+ *   ConfigService, verifies which providers end up enabled given
+ *   various AUTH_PROVIDERS values
+ * - MagicLinkService: sign → verify round-trip with a fake JwtService
+ *   and a mocked EmailService that captures outbound sends
+ *
+ * No network calls, no real JWT library, no real email delivery.
+ *
+ * Run with: npx ts-node scripts/smoke-test-auth-sso.ts
+ */
+import { ConfigService } from '@nestjs/config';
+import { SsoRegistryService } from '../src/modules/auth/sso/sso-registry.service';
+import { MagicLinkService } from '../src/modules/auth/sso/magic-link.service';
+
+function fakeConfig(env: Record<string, string>): ConfigService {
+  return {
+    get: <T>(key: string, def?: T) => (env[key] as any) ?? def,
+  } as unknown as ConfigService;
+}
+
+// ---------------------------------------------------------------
+// Fake JwtService — signs "fake-<base64(payload)>" and verifies it
+// by reversing the encoding. Good enough to exercise the
+// MagicLinkService's sign/verify logic without pulling in the real
+// JWT library's secret config.
+// ---------------------------------------------------------------
+class FakeJwtService {
+  private expired: Set<string> = new Set();
+
+  sign(payload: any, options?: any): string {
+    const json = JSON.stringify(payload);
+    const encoded = Buffer.from(json).toString('base64');
+    const exp = options?.expiresIn
+      ? Date.now() + options.expiresIn * 1000
+      : Date.now() + 7 * 24 * 60 * 60 * 1000;
+    return `fake-${encoded}-${exp}`;
+  }
+
+  verify<T = any>(token: string): T {
+    const m = /^fake-(.+?)-(\d+)$/.exec(token);
+    if (!m) throw new Error('malformed token');
+    const exp = parseInt(m[2], 10);
+    if (Date.now() > exp) throw new Error('expired');
+    if (this.expired.has(token)) throw new Error('expired');
+    const json = Buffer.from(m[1], 'base64').toString('utf-8');
+    return JSON.parse(json) as T;
+  }
+
+  forceExpire(token: string) {
+    this.expired.add(token);
+  }
+}
+
+// ---------------------------------------------------------------
+// Fake EmailService that captures outbound mail.
+// ---------------------------------------------------------------
+class FakeEmailService {
+  public sentEmails: Array<{
+    to: string | string[];
+    subject: string;
+    html: string;
+    text?: string;
+  }> = [];
+
+  public throwOnNext = false;
+
+  async sendEmail(
+    to: string | string[],
+    subject: string,
+    html: string,
+    text?: string,
+  ): Promise<void> {
+    if (this.throwOnNext) {
+      this.throwOnNext = false;
+      throw new Error('SMTP unreachable');
+    }
+    this.sentEmails.push({ to, subject, html, text });
+  }
+}
+
+async function main(): Promise<void> {
+  let pass = 0;
+  let fail = 0;
+  const ok = (b: boolean, msg?: string) => {
+    if (b) pass++;
+    else {
+      fail++;
+      if (msg) console.log(`  ⚠️  ${msg}`);
+    }
+  };
+  console.log('=== Auth / SSO smoke test ===\n');
+
+  // 1. Registry: no AUTH_PROVIDERS env → only local enabled
+  console.log('1. no AUTH_PROVIDERS → only local enabled (baseline)');
+  {
+    const reg = new SsoRegistryService(fakeConfig({}));
+    reg.onModuleInit();
+    const enabled = reg.getEnabled();
+    ok(enabled.length === 1);
+    ok(enabled[0].key === 'local');
+    ok(reg.isEnabled('local') === true);
+    ok(reg.isEnabled('google') === false);
+    console.log(`  ✅ only local enabled by default`);
+  }
+
+  // 2. Registry: AUTH_PROVIDERS=local,google,github,magic-link
+  console.log('\n2. AUTH_PROVIDERS=local,google,github,magic-link');
+  {
+    const reg = new SsoRegistryService(
+      fakeConfig({ AUTH_PROVIDERS: 'local,google,github,magic-link' }),
+    );
+    reg.onModuleInit();
+    const enabled = reg.getEnabled();
+    ok(enabled.length === 4);
+    ok(reg.isEnabled('google') === true);
+    ok(reg.isEnabled('github') === true);
+    ok(reg.isEnabled('magic-link') === true);
+    ok(reg.isEnabled('local') === true);
+    console.log(`  ✅ 4 providers enabled`);
+  }
+
+  // 3. Registry: planned provider (keycloak) → warn + skip
+  console.log('\n3. AUTH_PROVIDERS=local,keycloak → keycloak skipped');
+  {
+    const reg = new SsoRegistryService(
+      fakeConfig({ AUTH_PROVIDERS: 'local,keycloak' }),
+    );
+    reg.onModuleInit();
+    ok(reg.isEnabled('keycloak') === false);
+    ok(reg.isEnabled('local') === true);
+    ok(reg.getEnabled().length === 1);
+    console.log(`  ✅ planned provider skipped with warning`);
+  }
+
+  // 4. Registry: unknown provider → warn + skip
+  console.log('\n4. AUTH_PROVIDERS=local,foobar → foobar ignored');
+  {
+    const reg = new SsoRegistryService(
+      fakeConfig({ AUTH_PROVIDERS: 'local,foobar' }),
+    );
+    reg.onModuleInit();
+    ok(reg.getEnabled().length === 1);
+    ok(reg.getEnabled()[0].key === 'local');
+    console.log(`  ✅ unknown provider silently dropped`);
+  }
+
+  // 5. Registry: `local` is implicit even if omitted
+  console.log('\n5. AUTH_PROVIDERS=google,github → local still implicit');
+  {
+    const reg = new SsoRegistryService(
+      fakeConfig({ AUTH_PROVIDERS: 'google,github' }),
+    );
+    reg.onModuleInit();
+    ok(reg.isEnabled('local') === true);
+    ok(reg.getEnabled().length === 3); // local + google + github
+    console.log(`  ✅ local auto-added even when omitted`);
+  }
+
+  // 6. Registry: getCatalog returns full list with enabled flag
+  console.log('\n6. registry.getCatalog() shows all 8 providers');
+  {
+    const reg = new SsoRegistryService(
+      fakeConfig({ AUTH_PROVIDERS: 'google' }),
+    );
+    reg.onModuleInit();
+    const catalog = reg.getCatalog();
+    ok(catalog.length === 8); // local, google, github, gitlab, magic-link, keycloak, clerk, auth0
+    const google = catalog.find((p) => p.key === 'google');
+    ok(google?.enabled === true);
+    ok(google?.implemented === true);
+    const gitlab = catalog.find((p) => p.key === 'gitlab');
+    ok(gitlab?.enabled === false);
+    ok(gitlab?.implemented === false);
+    console.log(`  ✅ catalog covers all 8 providers with flags`);
+  }
+
+  // 7. MagicLink: sign + verify round-trip
+  console.log('\n7. MagicLink sign + verify round-trip');
+  {
+    const jwt = new FakeJwtService();
+    const email = new FakeEmailService();
+    const svc = new MagicLinkService(
+      fakeConfig({ NODE_ENV: 'development', FRONTEND_URL: 'https://app.example.com' }),
+      jwt as any,
+      email as any,
+    );
+    const result = await svc.requestMagicLink('Alice@Example.Com  ');
+    ok(result.success === true);
+    ok(typeof result.debugToken === 'string');
+    console.log(`  ✅ requestMagicLink returned debug token (dev mode)`);
+
+    // Email was sent
+    ok(email.sentEmails.length === 1);
+    ok(email.sentEmails[0].to === 'alice@example.com');
+    ok(email.sentEmails[0].subject.includes('sign-in'));
+    ok(email.sentEmails[0].html.includes('https://app.example.com/auth/magic-link?token='));
+    ok(email.sentEmails[0].text?.includes('https://app.example.com/auth/magic-link?token=') === true);
+    console.log(`  ✅ email captured with expected body`);
+
+    // Verify the token
+    const verifiedEmail = svc.verifyToken(result.debugToken!);
+    ok(verifiedEmail === 'alice@example.com');
+    console.log(`  ✅ verify returned normalized email`);
+  }
+
+  // 8. MagicLink: production mode hides debugToken
+  console.log('\n8. MagicLink production mode → no debugToken');
+  {
+    const jwt = new FakeJwtService();
+    const email = new FakeEmailService();
+    const svc = new MagicLinkService(
+      fakeConfig({ NODE_ENV: 'production' }),
+      jwt as any,
+      email as any,
+    );
+    const result = await svc.requestMagicLink('bob@example.com');
+    ok(result.success === true);
+    ok(result.debugToken === undefined);
+    console.log(`  ✅ debugToken omitted in production`);
+  }
+
+  // 9. MagicLink: verify rejects tampered token
+  console.log('\n9. MagicLink verify rejects tampered token');
+  {
+    const jwt = new FakeJwtService();
+    const email = new FakeEmailService();
+    const svc = new MagicLinkService(
+      fakeConfig({ NODE_ENV: 'development' }),
+      jwt as any,
+      email as any,
+    );
+    try {
+      svc.verifyToken('not-a-real-token');
+      ok(false, 'expected throw');
+    } catch (e: any) {
+      ok(/invalid or expired/i.test(e.message));
+      console.log(`  ✅ tampered token rejected: "${e.message.slice(0, 60)}..."`);
+    }
+  }
+
+  // 10. MagicLink: verify rejects wrong purpose
+  console.log('\n10. MagicLink verify rejects wrong-purpose token');
+  {
+    const jwt = new FakeJwtService();
+    const wrongPurposeToken = jwt.sign({ sub: 'a@b.com', email: 'a@b.com', purpose: 'reset' }, { expiresIn: 900 });
+    const svc = new MagicLinkService(
+      fakeConfig({ NODE_ENV: 'development' }),
+      jwt as any,
+      new FakeEmailService() as any,
+    );
+    try {
+      svc.verifyToken(wrongPurposeToken);
+      ok(false);
+    } catch (e: any) {
+      ok(/purpose/i.test(e.message));
+      console.log(`  ✅ wrong purpose rejected`);
+    }
+  }
+
+  // 11. MagicLink: email send failure doesn't throw (enumeration protection)
+  console.log('\n11. MagicLink request swallows email send failure');
+  {
+    const jwt = new FakeJwtService();
+    const email = new FakeEmailService();
+    email.throwOnNext = true;
+    const svc = new MagicLinkService(
+      fakeConfig({ NODE_ENV: 'development' }),
+      jwt as any,
+      email as any,
+    );
+    const result = await svc.requestMagicLink('unreachable@example.com');
+    // Still returns success
+    ok(result.success === true);
+    ok(typeof result.debugToken === 'string');
+    // Email was not captured
+    ok(email.sentEmails.length === 0);
+    console.log(`  ✅ SMTP failure didn't throw; token still issued`);
+  }
+
+  // 12. MagicLink: invalid email syntax throws
+  console.log('\n12. MagicLink rejects invalid email');
+  {
+    const svc = new MagicLinkService(
+      fakeConfig({ NODE_ENV: 'development' }),
+      new FakeJwtService() as any,
+      new FakeEmailService() as any,
+    );
+    try {
+      await svc.requestMagicLink('not-an-email');
+      ok(false);
+    } catch (e: any) {
+      ok(/invalid email/i.test(e.message));
+      console.log(`  ✅ invalid email rejected`);
+    }
+  }
+
+  console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+  process.exit(fail > 0 ? 1 : 0);
+}
+
+main().catch((e) => {
+  console.error('Smoke test crashed:', e);
+  process.exit(1);
+});

--- a/backend/src/modules/auth/auth.module.ts
+++ b/backend/src/modules/auth/auth.module.ts
@@ -4,7 +4,29 @@ import { AuthService } from './auth.service';
 import { JwtModule, JwtService } from '@nestjs/jwt';
 import { ConfigModule, ConfigService } from '@nestjs/config';
 import { JwtAuthGuard } from './guards/jwt-auth.guard';
+import { SsoController } from './sso/sso.controller';
+import { SsoRegistryService } from './sso/sso-registry.service';
+import { MagicLinkService } from './sso/magic-link.service';
+import { EmailService } from '../../services/email.service';
 
+/**
+ * Auth module.
+ *
+ * Existing:
+ * - AuthController + AuthService — local email/password + OAuth flows
+ * - JwtAuthGuard — standard JWT middleware
+ * - Passport strategies under ./strategies/ for Google + GitHub
+ *
+ * NEW (pluggable SSO layer — see issue #31):
+ * - SsoRegistryService — reads AUTH_PROVIDERS from .env and returns
+ *   the active list to the frontend
+ * - MagicLinkService — email-based passwordless sign-in
+ * - SsoController — exposes /auth/providers + /auth/magic-link/*
+ *
+ * EmailService is imported from ../../services/email.service — it's
+ * the existing centralized email service. Once the email adapter
+ * PR lands, this import can be swapped for the pluggable façade.
+ */
 @Module({
   imports: [
     ConfigModule,
@@ -19,11 +41,14 @@ import { JwtAuthGuard } from './guards/jwt-auth.guard';
       inject: [ConfigService],
     }),
   ],
-  controllers: [AuthController],
+  controllers: [AuthController, SsoController],
   providers: [
     AuthService,
     JwtAuthGuard,
+    SsoRegistryService,
+    MagicLinkService,
+    EmailService,
   ],
-  exports: [AuthService, JwtModule, JwtAuthGuard],
+  exports: [AuthService, JwtModule, JwtAuthGuard, SsoRegistryService],
 })
 export class AuthModule {}

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -629,6 +629,61 @@ export class AuthService {
   }
 
   /**
+   * Find-or-create a user by email and return a signed access token.
+   * Used by the magic-link flow: the email was already proven to
+   * belong to the caller (they clicked a link sent to that address),
+   * so we trust it as identity without a password.
+   *
+   * Idempotent — calling this repeatedly with the same email returns
+   * the same user and a fresh token each time.
+   */
+  async authenticateViaMagicLink(
+    email: string,
+  ): Promise<{
+    success: true;
+    user: { id: string; email: string; name: string; role: string };
+    access_token: string;
+  }> {
+    const normalized = email.toLowerCase().trim();
+
+    const existingUsers = await /* TODO: use AuthService */ this.db.client.auth.searchUsers(normalized);
+    let user: any;
+
+    if (existingUsers?.users?.length) {
+      user = existingUsers.users[0];
+      this.logger.log(`Magic link sign-in for existing user: ${user.id}`);
+    } else {
+      // Create a new user with a random password — they'll never
+      // use it because they'll always come in via magic link.
+      const randomPassword =
+        Math.random().toString(36).slice(-16) +
+        Math.random().toString(36).slice(-16);
+      const registered = await /* TODO: use AuthService */ this.db.signUp(
+        normalized,
+        randomPassword,
+        normalized.split('@')[0],
+        { magic_link_auth: true, primary_provider: 'magic-link' },
+        'client',
+      );
+      user = registered.user;
+      this.logger.log(`Magic link sign-in created new user: ${user.id}`);
+    }
+
+    const token = this.generateToken(user);
+
+    return {
+      success: true,
+      user: {
+        id: user.id,
+        email: user.email,
+        name: user.name || normalized.split('@')[0],
+        role: user.role || 'client',
+      },
+      access_token: token,
+    };
+  }
+
+  /**
    * Unlink social account from user
    */
   async unlinkSocialAccount(userId: string, dto: UnlinkSocialAccountDto): Promise<{ success: boolean; message: string }> {

--- a/backend/src/modules/auth/auth.service.ts
+++ b/backend/src/modules/auth/auth.service.ts
@@ -1,6 +1,7 @@
 import { Injectable, UnauthorizedException, BadRequestException, ConflictException, NotFoundException, Logger } from '@nestjs/common';
 import { JwtService } from '@nestjs/jwt';
 import { ConfigService } from '@nestjs/config';
+import * as crypto from 'crypto';
 import { DatabaseService } from '../database/database.service';
 import { RegisterDto, LoginDto } from './dto/auth.dto';
 import {
@@ -565,8 +566,11 @@ export class AuthService {
 
         const registerResponse = await /* TODO: use AuthService */ this.db.signUp(
           profile.email,
-          // Generate random password for social auth users
-          Math.random().toString(36).slice(-16) + Math.random().toString(36).slice(-16),
+          // Random 256-bit password for social-auth users. They
+          // never see it (SSO log-in only) but it must be
+          // crypto-strong: Math.random is predictable and not
+          // suitable for anything security-sensitive.
+          crypto.randomBytes(32).toString('hex'),
           profile.name || profile.email.split('@')[0],
           {
             avatar_url: profile.avatarUrl,
@@ -655,9 +659,9 @@ export class AuthService {
     } else {
       // Create a new user with a random password — they'll never
       // use it because they'll always come in via magic link.
-      const randomPassword =
-        Math.random().toString(36).slice(-16) +
-        Math.random().toString(36).slice(-16);
+      // Must be crypto-strong: Math.random is predictable and
+      // not suitable for anything security-sensitive.
+      const randomPassword = crypto.randomBytes(32).toString('hex');
       const registered = await /* TODO: use AuthService */ this.db.signUp(
         normalized,
         randomPassword,

--- a/backend/src/modules/auth/sso/magic-link.service.ts
+++ b/backend/src/modules/auth/sso/magic-link.service.ts
@@ -1,0 +1,171 @@
+/**
+ * MagicLinkService — passwordless email sign-in.
+ *
+ * Flow:
+ *   1. User submits their email at /login → frontend POSTs to
+ *      `/api/v1/auth/magic-link/request { email }`
+ *   2. Backend signs a short-lived JWT containing { email, purpose:
+ *      'magic-link' }, TTL 15 minutes
+ *   3. Backend emails the user a link like
+ *      `${FRONTEND_URL}/auth/magic-link?token=<jwt>`
+ *   4. User clicks the link → frontend POSTs to
+ *      `/api/v1/auth/magic-link/verify { token }`
+ *   5. Backend verifies the JWT, looks up (or creates) the user,
+ *      returns a real access token + refresh token
+ *
+ * Uses the existing EmailService for SMTP transport and the
+ * existing JwtService for token signing — no new deps.
+ *
+ * Enable by adding 'magic-link' to AUTH_PROVIDERS in .env:
+ *
+ *   AUTH_PROVIDERS=local,google,magic-link
+ *
+ * Optional env vars:
+ *   MAGIC_LINK_TTL_SECONDS=900       (default 15 min)
+ *   MAGIC_LINK_FROM_EMAIL=...        (defaults to EMAIL_FROM)
+ *   FRONTEND_URL=http://localhost:5173 (used to build the link)
+ */
+import { Injectable, Logger, BadRequestException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { JwtService } from '@nestjs/jwt';
+import { EmailService } from '../../../services/email.service';
+
+export interface MagicLinkTokenPayload {
+  sub: string; // email (subject)
+  email: string;
+  purpose: 'magic-link';
+}
+
+export interface RequestMagicLinkResult {
+  /** Always true — we don't leak whether the email exists in the
+   * user table. The frontend shows a generic "check your inbox"
+   * message regardless of whether the email is registered. */
+  success: true;
+  /** Debug-only: the signed token. NEVER returned in production —
+   * this field is only populated when NODE_ENV !== 'production' so
+   * the e2e test and the dev user can debug the flow without waiting
+   * on real email delivery. */
+  debugToken?: string;
+}
+
+@Injectable()
+export class MagicLinkService {
+  private readonly logger = new Logger(MagicLinkService.name);
+
+  private readonly ttlSeconds: number;
+  private readonly frontendUrl: string;
+  private readonly isProduction: boolean;
+
+  constructor(
+    private readonly config: ConfigService,
+    private readonly jwtService: JwtService,
+    private readonly emailService: EmailService,
+  ) {
+    this.ttlSeconds = parseInt(
+      config.get<string>('MAGIC_LINK_TTL_SECONDS', '900') || '900',
+      10,
+    );
+    this.frontendUrl = config.get<string>('FRONTEND_URL', 'http://localhost:5173');
+    this.isProduction =
+      (config.get<string>('NODE_ENV') || 'development').toLowerCase() === 'production';
+  }
+
+  /**
+   * Sign a magic-link JWT for `email`. The JWT uses the same secret
+   * as the regular access token (JwtService is preconfigured), but
+   * embeds `purpose: 'magic-link'` so the verify step can reject a
+   * stolen token being used at a different endpoint.
+   */
+  private signToken(email: string): string {
+    const payload: MagicLinkTokenPayload = {
+      sub: email,
+      email,
+      purpose: 'magic-link',
+    };
+    return this.jwtService.sign(payload, {
+      expiresIn: this.ttlSeconds,
+    });
+  }
+
+  /**
+   * Verify and decode a magic-link token. Returns the email if valid
+   * (correct signature, not expired, purpose === 'magic-link').
+   * Throws BadRequestException on any failure.
+   */
+  verifyToken(token: string): string {
+    let payload: MagicLinkTokenPayload;
+    try {
+      payload = this.jwtService.verify<MagicLinkTokenPayload>(token);
+    } catch (e: any) {
+      throw new BadRequestException(
+        `Magic link token is invalid or expired: ${e.message}`,
+      );
+    }
+    if (payload.purpose !== 'magic-link') {
+      throw new BadRequestException('Token purpose mismatch');
+    }
+    if (!payload.email || !payload.email.includes('@')) {
+      throw new BadRequestException('Token missing valid email');
+    }
+    return payload.email.toLowerCase().trim();
+  }
+
+  /**
+   * Issue a magic link email. Returns `{ success: true }` regardless
+   * of whether the email is registered (to prevent enumeration
+   * attacks). In non-production, also returns `debugToken` so the
+   * e2e test + dev user can complete the flow without waiting on
+   * real email delivery.
+   */
+  async requestMagicLink(email: string): Promise<RequestMagicLinkResult> {
+    const normalized = email.toLowerCase().trim();
+    if (!normalized.includes('@')) {
+      throw new BadRequestException('Invalid email');
+    }
+
+    const token = this.signToken(normalized);
+    const link = `${this.frontendUrl.replace(/\/+$/, '')}/auth/magic-link?token=${encodeURIComponent(token)}`;
+
+    const html = this.buildHtml(link);
+    const text = `Click to sign in: ${link}\n\nThis link will expire in ${Math.round(this.ttlSeconds / 60)} minutes.\n\nIf you didn't request this, you can safely ignore this email.`;
+
+    try {
+      await this.emailService.sendEmail(
+        normalized,
+        'Your Team@Once sign-in link',
+        html,
+        text,
+      );
+      this.logger.log(`Magic link sent to ${normalized}`);
+    } catch (e: any) {
+      // Log the failure but don't surface it to the caller —
+      // prevents email-existence enumeration. The dev can see
+      // the failure in the logs.
+      this.logger.error(
+        `Failed to send magic link to ${normalized}: ${e.message}`,
+      );
+    }
+
+    return {
+      success: true,
+      debugToken: this.isProduction ? undefined : token,
+    };
+  }
+
+  private buildHtml(link: string): string {
+    return `<!doctype html>
+<html>
+  <body style="font-family:system-ui,sans-serif;max-width:600px;margin:40px auto;padding:0 20px;color:#1a1a1a;">
+    <h2 style="color:#2563eb;">Sign in to Team@Once</h2>
+    <p>Click the button below to sign in. This link will expire in ${Math.round(this.ttlSeconds / 60)} minutes and can only be used once.</p>
+    <p style="text-align:center;margin:32px 0;">
+      <a href="${link}" style="display:inline-block;background:#2563eb;color:#fff;padding:12px 32px;border-radius:6px;text-decoration:none;font-weight:600;">Sign in</a>
+    </p>
+    <p style="color:#666;font-size:14px;">If the button doesn't work, copy and paste this link into your browser:</p>
+    <p style="word-break:break-all;color:#2563eb;font-size:14px;">${link}</p>
+    <hr style="border:0;border-top:1px solid #eee;margin:32px 0;" />
+    <p style="color:#999;font-size:12px;">If you didn't request this sign-in link, you can safely ignore this email.</p>
+  </body>
+</html>`;
+  }
+}

--- a/backend/src/modules/auth/sso/magic-link.service.ts
+++ b/backend/src/modules/auth/sso/magic-link.service.ts
@@ -157,7 +157,7 @@ export class MagicLinkService {
 <html>
   <body style="font-family:system-ui,sans-serif;max-width:600px;margin:40px auto;padding:0 20px;color:#1a1a1a;">
     <h2 style="color:#2563eb;">Sign in to Team@Once</h2>
-    <p>Click the button below to sign in. This link will expire in ${Math.round(this.ttlSeconds / 60)} minutes and can only be used once.</p>
+    <p>Click the button below to sign in. This link will expire in ${Math.round(this.ttlSeconds / 60)} minutes.</p>
     <p style="text-align:center;margin:32px 0;">
       <a href="${link}" style="display:inline-block;background:#2563eb;color:#fff;padding:12px 32px;border-radius:6px;text-decoration:none;font-weight:600;">Sign in</a>
     </p>

--- a/backend/src/modules/auth/sso/sso-registry.service.ts
+++ b/backend/src/modules/auth/sso/sso-registry.service.ts
@@ -1,0 +1,191 @@
+/**
+ * SsoRegistryService — single source of truth for which SSO / auth
+ * providers are enabled in this deployment.
+ *
+ * Reads `AUTH_PROVIDERS` from .env as a comma-separated list, e.g.:
+ *
+ *   AUTH_PROVIDERS=local,google,github,magic-link
+ *
+ * Valid values:
+ *
+ *   local       - Email + password (always enabled — acts as the
+ *                 baseline even if omitted from AUTH_PROVIDERS)
+ *   google      - Google OAuth2 (existing `GoogleStrategy`)
+ *   github      - GitHub OAuth2 (existing `GitHubStrategy`)
+ *   gitlab      - GitLab OAuth2 [planned follow-up]
+ *   magic-link  - Email-based passwordless sign-in via MagicLinkStrategy
+ *                 (this PR)
+ *   keycloak    - OIDC against a self-hosted Keycloak [planned]
+ *   clerk       - Clerk-hosted auth (JWT verification) [planned]
+ *   auth0       - Auth0-hosted auth (JWT verification) [planned]
+ *
+ * The frontend calls `GET /api/v1/auth/providers` at page load time
+ * to discover which providers to render as login buttons. Unknown
+ * values in AUTH_PROVIDERS are logged and ignored — never silently
+ * dropped.
+ */
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+
+export type AuthProviderKey =
+  | 'local'
+  | 'google'
+  | 'github'
+  | 'gitlab'
+  | 'magic-link'
+  | 'keycloak'
+  | 'clerk'
+  | 'auth0';
+
+export interface AuthProviderInfo {
+  /** Stable provider key. */
+  key: AuthProviderKey;
+  /** Display name for login buttons. */
+  displayName: string;
+  /** Whether the provider is enabled in this deployment. */
+  enabled: boolean;
+  /** Whether the provider's adapter is actually implemented vs planned. */
+  implemented: boolean;
+  /** Authorization URL for OAuth providers (absent for local/magic-link). */
+  authorizationPath?: string;
+  /** Icon identifier the frontend can use for branded buttons. */
+  icon?: string;
+}
+
+/**
+ * Static metadata about each provider. Kept separate from runtime
+ * enablement so new-provider PRs only need to edit this table.
+ */
+const PROVIDER_CATALOG: Record<
+  AuthProviderKey,
+  Omit<AuthProviderInfo, 'enabled'>
+> = {
+  local: {
+    key: 'local',
+    displayName: 'Email & Password',
+    implemented: true,
+    icon: 'mail',
+  },
+  google: {
+    key: 'google',
+    displayName: 'Google',
+    implemented: true, // existing GoogleStrategy
+    authorizationPath: '/api/v1/auth/oauth/google',
+    icon: 'google',
+  },
+  github: {
+    key: 'github',
+    displayName: 'GitHub',
+    implemented: true, // existing GitHubStrategy
+    authorizationPath: '/api/v1/auth/oauth/github',
+    icon: 'github',
+  },
+  gitlab: {
+    key: 'gitlab',
+    displayName: 'GitLab',
+    implemented: false, // planned follow-up
+    authorizationPath: '/api/v1/auth/oauth/gitlab',
+    icon: 'gitlab',
+  },
+  'magic-link': {
+    key: 'magic-link',
+    displayName: 'Magic Link',
+    implemented: true, // this PR
+    authorizationPath: '/api/v1/auth/magic-link/request',
+    icon: 'link',
+  },
+  keycloak: {
+    key: 'keycloak',
+    displayName: 'Keycloak',
+    implemented: false, // planned
+    authorizationPath: '/api/v1/auth/oidc/keycloak',
+    icon: 'shield',
+  },
+  clerk: {
+    key: 'clerk',
+    displayName: 'Clerk',
+    implemented: false, // planned
+    icon: 'shield',
+  },
+  auth0: {
+    key: 'auth0',
+    displayName: 'Auth0',
+    implemented: false, // planned
+    authorizationPath: '/api/v1/auth/oidc/auth0',
+    icon: 'shield',
+  },
+};
+
+@Injectable()
+export class SsoRegistryService implements OnModuleInit {
+  private readonly logger = new Logger(SsoRegistryService.name);
+
+  /** Final resolved list of enabled providers for this deployment. */
+  private enabled: AuthProviderInfo[] = [];
+
+  constructor(private readonly config: ConfigService) {}
+
+  onModuleInit() {
+    const raw = this.config.get<string>('AUTH_PROVIDERS', '') || '';
+    const requested = raw
+      .split(',')
+      .map((s) => s.trim().toLowerCase())
+      .filter(Boolean);
+
+    // `local` is always enabled — email/password is the baseline.
+    const enabledKeys = new Set<AuthProviderKey>(['local']);
+
+    for (const r of requested) {
+      if (!(r in PROVIDER_CATALOG)) {
+        this.logger.warn(
+          `Unknown auth provider "${r}" in AUTH_PROVIDERS — ignoring. Valid values: ${Object.keys(PROVIDER_CATALOG).join(', ')}`,
+        );
+        continue;
+      }
+      const key = r as AuthProviderKey;
+      if (!PROVIDER_CATALOG[key].implemented) {
+        this.logger.warn(
+          `Auth provider "${r}" is listed in AUTH_PROVIDERS but its adapter is not yet implemented (see issue #31). Skipping. The frontend's /auth/providers response will NOT include it.`,
+        );
+        continue;
+      }
+      enabledKeys.add(key);
+    }
+
+    this.enabled = Array.from(enabledKeys).map((key) => ({
+      ...PROVIDER_CATALOG[key],
+      enabled: true,
+    }));
+
+    this.logger.log(
+      `SSO registry initialized: ${this.enabled.map((p) => p.key).join(', ')}`,
+    );
+  }
+
+  /**
+   * The full list of enabled providers. Used by the
+   * /api/v1/auth/providers endpoint.
+   */
+  getEnabled(): AuthProviderInfo[] {
+    return [...this.enabled];
+  }
+
+  /**
+   * Is a given provider enabled in this deployment?
+   */
+  isEnabled(key: AuthProviderKey): boolean {
+    return this.enabled.some((p) => p.key === key);
+  }
+
+  /**
+   * Catalog entry for a provider (metadata only — says nothing about
+   * runtime enablement). Used internally by the controller/endpoint
+   * layer and by the admin settings UI.
+   */
+  getCatalog(): Array<AuthProviderInfo> {
+    return Object.values(PROVIDER_CATALOG).map((p) => ({
+      ...p,
+      enabled: this.enabled.some((e) => e.key === p.key),
+    }));
+  }
+}

--- a/backend/src/modules/auth/sso/sso.controller.ts
+++ b/backend/src/modules/auth/sso/sso.controller.ts
@@ -1,0 +1,83 @@
+/**
+ * SSO public endpoints.
+ *
+ *   GET  /api/v1/auth/providers
+ *     Returns the list of enabled auth providers for this
+ *     deployment. The frontend calls this once on page load to
+ *     render the login buttons (Google / GitHub / Magic Link /
+ *     Email + Password). Deliberately unauthenticated.
+ *
+ *   POST /api/v1/auth/magic-link/request { email }
+ *     Issues a magic-link sign-in email. Returns { success: true }
+ *     regardless of whether the email exists (enumeration
+ *     protection). In non-production, also returns { debugToken }
+ *     so the dev + e2e test can complete the flow without waiting
+ *     on real email delivery.
+ *
+ *   POST /api/v1/auth/magic-link/verify { token }
+ *     Verifies the magic-link token, finds or creates the user,
+ *     returns a real access token. Frontend redirects to the app
+ *     after this.
+ */
+import {
+  Body,
+  Controller,
+  Get,
+  Post,
+  BadRequestException,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation } from '@nestjs/swagger';
+import { SsoRegistryService } from './sso-registry.service';
+import { MagicLinkService } from './magic-link.service';
+import { AuthService } from '../auth.service';
+
+@ApiTags('auth')
+@Controller('auth')
+export class SsoController {
+  constructor(
+    private readonly registry: SsoRegistryService,
+    private readonly magicLink: MagicLinkService,
+    private readonly authService: AuthService,
+  ) {}
+
+  @Get('providers')
+  @ApiOperation({
+    summary: 'List enabled SSO / auth providers for the frontend to render',
+  })
+  listProviders() {
+    return {
+      providers: this.registry.getEnabled(),
+    };
+  }
+
+  @Post('magic-link/request')
+  @ApiOperation({ summary: 'Email a magic sign-in link to the user' })
+  async requestMagicLink(@Body() body: { email?: string }) {
+    if (!this.registry.isEnabled('magic-link')) {
+      throw new BadRequestException(
+        'Magic link auth is not enabled in this deployment. Add "magic-link" to AUTH_PROVIDERS.',
+      );
+    }
+    if (!body?.email) {
+      throw new BadRequestException('email is required');
+    }
+    return this.magicLink.requestMagicLink(body.email);
+  }
+
+  @Post('magic-link/verify')
+  @ApiOperation({
+    summary: 'Verify a magic-link token and return an access token',
+  })
+  async verifyMagicLink(@Body() body: { token?: string }) {
+    if (!this.registry.isEnabled('magic-link')) {
+      throw new BadRequestException(
+        'Magic link auth is not enabled in this deployment.',
+      );
+    }
+    if (!body?.token) {
+      throw new BadRequestException('token is required');
+    }
+    const email = this.magicLink.verifyToken(body.token);
+    return this.authService.authenticateViaMagicLink(email);
+  }
+}


### PR DESCRIPTION
## Summary

Closes #31. Adds a pluggable auth/SSO layer alongside Team@Once's existing email/password auth + Google/GitHub OAuth strategies. Frontend can now render login buttons dynamically based on what's enabled in the deployment.

## What's in it

### 1. `SsoRegistryService`

Single source of truth for which auth providers are enabled. Reads `AUTH_PROVIDERS` from `.env` as a comma list:

```
AUTH_PROVIDERS=local,google,github,magic-link
```

`local` is always implicitly enabled — you don't need to list it.

### 2. `MagicLinkService` (NEW — the main new capability)

Email-based passwordless sign-in. Uses the existing `JwtService` for token signing (15-min TTL) and the existing `EmailService` for transport — **no new dependencies**.

**Flow**:
1. User enters email → `POST /auth/magic-link/request` → JWT signed with `{ email, purpose: 'magic-link' }`, emailed as a link
2. User clicks link → `POST /auth/magic-link/verify { token }` → JWT verified → find-or-create user → real access token returned

### 3. `SsoController`

Three new public endpoints:
- `GET /api/v1/auth/providers` — frontend bootstrap, returns enabled provider list
- `POST /api/v1/auth/magic-link/request { email }` — issue a sign-in link
- `POST /api/v1/auth/magic-link/verify { token }` — complete sign-in

### 4. `AuthService.authenticateViaMagicLink(email)`

New public method reusing the same find-or-create + JWT-minting pattern as the existing OAuth social-auth flow.

## Provider catalog

| Provider | Status | Notes |
|---|---|---|
| **local** *(baseline)* | ready | always enabled |
| **google** | ready | existing `GoogleStrategy`, now discoverable via `/auth/providers` |
| **github** | ready | existing `GitHubStrategy`, same |
| **magic-link** | ready *(NEW)* | this PR |
| **gitlab** | planned | follow-up — trivial, same shape as github |
| **keycloak** | planned | OIDC |
| **clerk** | planned | JWT verification |
| **auth0** | planned | OIDC |

Listing any planned provider in `AUTH_PROVIDERS` today logs a warning and drops it from the enabled list.

## Key design decisions

- **Enumeration protection**: `requestMagicLink` returns `{ success: true }` for every valid-format email regardless of registration status. Real SMTP failures are logged but not surfaced.
- **Purpose isolation**: magic-link JWTs carry `purpose: 'magic-link'`. `verifyToken` rejects any token without it — a stolen magic-link JWT can't be replayed against a password-reset endpoint.
- **Dev debug token**: in non-production, `requestMagicLink` response includes `debugToken` so e2e tests + dev users can complete the flow without waiting on real email. Production builds never include it.
- **Email normalization**: lowercase + trim before signing. `"Alice@Example.COM"` === `"alice@example.com"`.

## Verification status (honest)

| Piece | Status |
|---|---|
| **SsoRegistryService** | written, **smoke-tested** (6 scenarios: default, full, planned-skip, unknown-drop, implicit local, catalog) |
| **MagicLinkService** | written, **smoke-tested** (6 scenarios: sign+verify round-trip, prod mode, tamper, purpose, SMTP failure, invalid email) |
| **SsoController** | written, tsc clean, **NOT runtime-tested** |
| **AuthService.authenticateViaMagicLink** | written, tsc clean, **NOT tested** with real DB + JWT |
| **Google / GitHub** | pre-existing strategies; added to registry metadata only |

Full TypeScript compile: **0 errors**.

Smoke test (`backend/scripts/smoke-test-auth-sso.ts`): **37/37 assertions pass**. Uses fake `JwtService` + fake `EmailService`.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx ts-node scripts/smoke-test-auth-sso.ts` 37/37 pass
- [ ] Manual: boot backend with `AUTH_PROVIDERS=local,magic-link`, `curl /auth/providers` shows 2, `curl /auth/magic-link/request { email }` triggers email via Mailtrap, verify link works
- [ ] Manual: test with real SMTP
- [ ] Frontend PR: render login buttons from `/auth/providers`, add magic-link email input + verify callback route

## Out of scope (follow-ups)

- gitlab / keycloak / clerk / auth0 provider implementations
- Rate limiting on `/auth/magic-link/request` (spam vector)
- Token revocation via a `used_tokens` table (for high-security deployments)
- Admin settings UI for runtime provider enablement
- Migrating `MagicLinkService`'s email dep to the pluggable `EmailService` façade once the email adapter PR #42 merges

## Related

- Tracking issue #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)