### PR TITLE
feat(sandbox): pluggable code execution for assessments (sandpack/judge0/piston)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -91,3 +91,30 @@ OPENAI_MODEL=gpt-4o-mini
 QDRANT_HOST=localhost
 QDRANT_PORT=6333
 QDRANT_API_KEY=your_qdrant_api_key
+
+# =====================================================
+# CODE SANDBOX (assessments & lessons)
+# =====================================================
+# Pick a provider. See backend/docs/providers/sandbox.md.
+#
+# Valid values: sandpack | judge0 | piston | none
+#
+# sandpack  — in-browser, zero infra, no anti-cheat
+# judge0    — server-side, 60+ languages, best for graded assessments
+# piston    — server-side, lighter than judge0, public instance available
+
+SANDBOX_PROVIDER=sandpack
+
+# --- Sandpack (default) ---
+SANDPACK_TEMPLATE=react-ts
+
+# --- Judge0 (self-hosted) ---
+# JUDGE0_URL=http://localhost:2358
+# OR Judge0 on RapidAPI:
+# JUDGE0_URL=https://judge0-ce.p.rapidapi.com
+# JUDGE0_API_KEY=
+# JUDGE0_API_HOST=judge0-ce.p.rapidapi.com
+
+# --- Piston ---
+PISTON_URL=https://emkc.org/api/v2/piston
+PISTON_API_KEY=

--- a/backend/docs/providers/sandbox.md
+++ b/backend/docs/providers/sandbox.md
@@ -1,0 +1,144 @@
+# Code sandbox providers
+
+Team@Once runs user-submitted code for lesson exercises and graded
+assessments. Pick a provider by setting `SANDBOX_PROVIDER` in your
+`.env`.
+
+```
+SANDBOX_PROVIDER=sandpack   # browser-only default (no infra)
+```
+
+## Comparison
+
+| Provider | Runs on | Infra | Languages | Anti-cheat | Best for |
+|---|---|---|---|---|---|
+| **sandpack** *(default)* | user's browser | none | JS/TS/React/Vue/Svelte/Solid | ❌ | lesson previews, UI exercises |
+| **judge0** | your server | docker or RapidAPI | 60+ | ✅ | graded assessments |
+| **piston** | your server (or emkc.org) | docker or none (public rate-limited) | 40+ | ✅ | lighter alternative to Judge0 |
+| **stackblitz** | user's browser | none | Node.js in WebContainers | ❌ | [planned #36] |
+| **codesandbox** | codesandbox.io | managed | containers | partial | [planned #36] |
+| **none** *(default if unset)* | — | — | — | — | code features disabled |
+
+## Which should I pick?
+
+- **"I just want to show students some React code"** → `sandpack` (zero infra, in-browser)
+- **Graded assessments with real scoring** → `judge0` (server-side, 60 languages, full judge feature set)
+- **Lightweight polyglot execution without running Judge0** → `piston` (simpler API, public instance for dev)
+- **Node.js exercises** → `sandpack` with `template=node`, or wait for `stackblitz` WebContainers (planned)
+- **Not using sandboxes yet** → leave `SANDBOX_PROVIDER` unset
+
+## Per-provider setup
+
+### sandpack (default, frontend-only)
+
+```
+SANDBOX_PROVIDER=sandpack
+SANDPACK_TEMPLATE=react-ts     # optional
+```
+
+**Valid templates**: `vanilla`, `vanilla-ts`, `react`, `react-ts`, `vue`, `vue-ts`, `angular`, `svelte`, `solid`, `node`, `nextjs`, `vite-react`, `vite-react-ts`, etc. See <https://sandpack.codesandbox.io/docs> for the full list.
+
+The backend provider is metadata-only — it returns `{ provider: 'sandpack', template }` from `/api/v1/sandbox/config`. The frontend imports `@codesandbox/sandpack-react` and renders `<Sandpack template={template}>` directly. Execution happens entirely in the user's browser via Web Workers + a bundled JS interpreter.
+
+**Calling `POST /sandbox/execute` with sandpack throws** `SandboxProviderNotSupportedError`. This is deliberate: if you need server-side execution, you need a server-side provider. Silent no-op would hide broken assessment wiring.
+
+### judge0
+
+Two deployment modes:
+
+**Self-hosted (recommended, free)**:
+```bash
+# One-time: docker-compose up from https://github.com/judge0/judge0
+docker compose -f judge0-docker-compose.yml up -d
+```
+
+```
+SANDBOX_PROVIDER=judge0
+JUDGE0_URL=http://localhost:2358
+```
+
+**RapidAPI-hosted (paid, managed)**:
+```
+SANDBOX_PROVIDER=judge0
+JUDGE0_URL=https://judge0-ce.p.rapidapi.com
+JUDGE0_API_KEY=...
+JUDGE0_API_HOST=judge0-ce.p.rapidapi.com
+```
+
+**Supported languages (whitelist in `judge0.provider.ts`)**:
+
+| Language | id |
+|---|---|
+| javascript / typescript | 63 / 74 |
+| python / python3 | 71 |
+| java | 62 |
+| c / cpp (c++) | 50 / 54 |
+| csharp (c#) | 51 |
+| go | 60 |
+| rust | 73 |
+| ruby | 72 |
+| php | 68 |
+| kotlin / swift | 78 / 83 |
+| r / bash | 80 / 46 |
+| sql | 82 |
+
+Add more by editing `JUDGE0_LANGUAGES` in the provider file — or a follow-up PR can fetch `/languages` dynamically on startup.
+
+**Execution**: `POST /submissions?base64_encoded=true&wait=true` with base64-encoded source + stdin. The provider decodes the base64-encoded response fields back to plain text.
+
+**Anti-cheat**: Judge0 runs code in a sandboxed environment you control. Time + memory limits are enforced by the sandbox, not the user's browser. Code can't make outbound network calls. This is the right choice for real graded assessments where students might try to cheat.
+
+### piston
+
+```
+SANDBOX_PROVIDER=piston
+PISTON_URL=https://emkc.org/api/v2/piston    # public, rate-limited
+# or self-host:
+# PISTON_URL=http://localhost:2000
+PISTON_API_KEY=                               # optional, for paid tiers
+```
+
+Piston is simpler than Judge0 (single `/execute` endpoint, no submission queue) and lighter-weight to run. Supports ~40 languages.
+
+**Language aliases**: the provider normalizes `js` → `javascript`, `py` → `python`, `cpp` → `c++`, etc. Use whichever alias is most ergonomic.
+
+**Signal handling**: Piston uses `signal: "SIGKILL"` for time-limit kills and `SIGXCPU` for CPU-time-limit kills. The provider maps these to `timeLimitExceeded` / `memoryLimitExceeded` in the unified result.
+
+**Public instance rate limits**: the public Piston at `emkc.org` limits to ~5 requests/second per IP. For production traffic, self-host.
+
+### stackblitz / codesandbox (planned)
+
+Not yet implemented. Selecting either logs a warning and falls back to `none`. Follow-up PRs will:
+- `stackblitz`: integrate StackBlitz WebContainers for full Node.js in the browser
+- `codesandbox`: use the CodeSandbox Devboxes API for managed containers
+
+### none (default if unset)
+
+Every execute() call throws `SandboxProviderNotConfiguredError`. The startup log tells the operator which env var to set.
+
+## Endpoints
+
+```
+GET  /api/v1/sandbox/config         — frontend bootstrap (public)
+GET  /api/v1/sandbox/languages      — list supported languages (public)
+POST /api/v1/sandbox/execute        — run code (JWT required)
+     Body: { language, source, stdin?, timeLimitSeconds?, memoryLimitKb?, commandLineArgs? }
+     Returns: { stdout, stderr, exitCode, timeLimitExceeded, memoryLimitExceeded, durationMs, provider }
+```
+
+The `/execute` endpoint is JWT-protected because real code execution costs compute — unauthenticated abuse would be expensive. For public lesson previews using `sandpack`, the frontend renders `<Sandpack>` directly and never calls this endpoint.
+
+Input validation:
+- `source` max 64KB (hard limit in the controller)
+- `timeLimitSeconds` defaults to 5, enforced by the provider
+- `memoryLimitKb` defaults to 128MB, enforced by the provider
+
+## Adding a new provider
+
+1. Implement `SandboxProvider` in
+   `backend/src/modules/sandbox/providers/<name>.provider.ts`
+2. Add a case to `createSandboxProvider()` in `providers/index.ts`
+3. Document env vars in this file and in `.env.example`
+4. Add smoke-test coverage in
+   `backend/scripts/smoke-test-sandbox-providers.ts` — mock `fetch`
+   and verify URL, headers, payload translation, response parsing

--- a/backend/scripts/smoke-test-sandbox-providers.ts
+++ b/backend/scripts/smoke-test-sandbox-providers.ts
@@ -1,0 +1,449 @@
+/**
+ * Smoke test for the multi-provider sandbox factory.
+ *
+ * - sandpack: metadata-only, no network; verifies config + throws
+ *   on execute()
+ * - judge0 / piston: mock fetch to verify URL, auth headers,
+ *   base64 encoding, payload shape, and response translation
+ * - none: throws
+ *
+ * Run with: npx ts-node scripts/smoke-test-sandbox-providers.ts
+ */
+import { ConfigService } from '@nestjs/config';
+import {
+  createSandboxProvider,
+  SandboxProviderNotConfiguredError,
+  SandboxProviderNotSupportedError,
+} from '../src/modules/sandbox/providers';
+
+function fakeConfig(env: Record<string, string>): ConfigService {
+  return {
+    get: <T>(key: string, def?: T) => (env[key] as any) ?? def,
+  } as unknown as ConfigService;
+}
+
+type FetchCall = {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: any;
+};
+const fetchCalls: FetchCall[] = [];
+const realFetch = global.fetch;
+function installMockFetch(
+  responder: (url: string, init: any) => { status: number; body: any },
+) {
+  global.fetch = (async (url: any, init: any = {}) => {
+    const headers: Record<string, string> = {};
+    if (init.headers) {
+      for (const [k, v] of Object.entries(init.headers)) {
+        headers[k] = String(v);
+      }
+    }
+    fetchCalls.push({
+      url: String(url),
+      method: init.method ?? 'GET',
+      headers,
+      body: init.body ? JSON.parse(init.body) : null,
+    });
+    const { status, body } = responder(String(url), init);
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as any;
+}
+function restoreFetch() {
+  global.fetch = realFetch;
+}
+
+async function expectThrow(
+  label: string,
+  fn: () => Promise<unknown>,
+  matcher: (e: Error) => boolean,
+): Promise<boolean> {
+  try {
+    await fn();
+    console.log(`  ❌ ${label}: expected throw, got success`);
+    return false;
+  } catch (e) {
+    if (matcher(e as Error)) {
+      console.log(`  ✅ ${label}: threw as expected`);
+      return true;
+    }
+    console.log(`  ❌ ${label}: wrong error: ${(e as Error).message}`);
+    return false;
+  }
+}
+
+async function main(): Promise<void> {
+  let pass = 0;
+  let fail = 0;
+  const ok = (b: boolean, msg?: string) => {
+    if (b) pass++;
+    else {
+      fail++;
+      if (msg) console.log(`  ⚠️  ${msg}`);
+    }
+  };
+  console.log('=== Sandbox provider factory smoke test ===\n');
+
+  // 1. none default
+  console.log('1. no SANDBOX_PROVIDER → none');
+  {
+    const p = createSandboxProvider(fakeConfig({}));
+    ok(p.name === 'none');
+    ok(p.isAvailable() === false);
+    ok(
+      await expectThrow(
+        'execute fails loudly',
+        () =>
+          p.execute({ language: 'python', source: 'print(1)' }),
+        (e) => e instanceof SandboxProviderNotConfiguredError,
+      ),
+    );
+    const config = p.getFrontendConfig();
+    ok(config.provider === 'none');
+    ok((config.extra as any)?.disabled === true);
+  }
+
+  // 2. sandpack metadata + listLanguages
+  console.log('\n2. sandpack metadata');
+  {
+    const p = createSandboxProvider(
+      fakeConfig({ SANDBOX_PROVIDER: 'sandpack' }),
+    );
+    ok(p.name === 'sandpack');
+    ok(p.isAvailable() === true);
+    const config = p.getFrontendConfig();
+    ok(config.template === 'react-ts');
+    const langs = await p.listLanguages();
+    ok(langs.length >= 10);
+    ok(langs.some((l) => l.id === 'react-ts'));
+    ok(langs.some((l) => l.id === 'vanilla'));
+    console.log(`  ✅ sandpack: ${langs.length} templates, default=${config.template}`);
+  }
+
+  // 3. sandpack execute() throws NotSupported
+  console.log('\n3. sandpack execute() throws NotSupported (browser-only)');
+  {
+    const p = createSandboxProvider(
+      fakeConfig({ SANDBOX_PROVIDER: 'sandpack' }),
+    );
+    ok(
+      await expectThrow(
+        'sandpack execute throws',
+        () => p.execute({ language: 'javascript', source: 'console.log(1)' }),
+        (e) => e instanceof SandboxProviderNotSupportedError,
+      ),
+    );
+  }
+
+  // 4. sandpack custom template from env
+  console.log('\n4. sandpack with SANDPACK_TEMPLATE=vue-ts');
+  {
+    const p = createSandboxProvider(
+      fakeConfig({
+        SANDBOX_PROVIDER: 'sandpack',
+        SANDPACK_TEMPLATE: 'vue-ts',
+      }),
+    );
+    ok(p.getFrontendConfig().template === 'vue-ts');
+    console.log(`  ✅ custom template applied`);
+  }
+
+  // 5. judge0 without URL → unavailable
+  console.log('\n5. judge0 without JUDGE0_URL → unavailable');
+  {
+    const p = createSandboxProvider(fakeConfig({ SANDBOX_PROVIDER: 'judge0' }));
+    ok(p.name === 'judge0');
+    ok(p.isAvailable() === false);
+    ok(
+      await expectThrow(
+        'execute throws NotConfigured',
+        () => p.execute({ language: 'python', source: 'print(1)' }),
+        (e) => e instanceof SandboxProviderNotConfiguredError,
+      ),
+    );
+  }
+
+  // 6. judge0 happy path — verifies base64 encoding + status parsing
+  console.log('\n6. judge0 execute (mocked)');
+  {
+    // Judge0 responds with base64-encoded output fields
+    const stdoutB64 = Buffer.from('hello\n', 'utf-8').toString('base64');
+    const stderrB64 = '';
+
+    installMockFetch((url) => {
+      if (url.includes('/submissions') && url.includes('wait=true')) {
+        return {
+          status: 201,
+          body: {
+            stdout: stdoutB64,
+            stderr: stderrB64,
+            compile_output: null,
+            exit_code: 0,
+            time: '0.012',
+            memory: 1024,
+            status: { id: 3, description: 'Accepted' },
+          },
+        };
+      }
+      return { status: 404, body: {} };
+    });
+    try {
+      const p = createSandboxProvider(
+        fakeConfig({
+          SANDBOX_PROVIDER: 'judge0',
+          JUDGE0_URL: 'http://localhost:2358',
+        }),
+      );
+      ok(p.isAvailable() === true);
+      const result = await p.execute({
+        language: 'python',
+        source: 'print("hello")',
+        stdin: '',
+        timeLimitSeconds: 3,
+      });
+      ok(result.stdout === 'hello\n');
+      ok(result.exitCode === 0);
+      ok(result.timeLimitExceeded === false);
+      ok(result.memoryKb === 1024);
+      ok(result.durationMs === 12);
+      ok(result.provider === 'judge0');
+      console.log(
+        `  ✅ judge0 decoded stdout: "${result.stdout.trim()}" (exit=${result.exitCode}, ${result.durationMs}ms)`,
+      );
+
+      const call = fetchCalls[fetchCalls.length - 1];
+      ok(
+        call.url ===
+          'http://localhost:2358/submissions?base64_encoded=true&wait=true',
+      );
+      // Verify base64 encoding of the source
+      const expectedSource = Buffer.from('print("hello")', 'utf-8').toString(
+        'base64',
+      );
+      ok(call.body.source_code === expectedSource);
+      ok(call.body.language_id === 71); // python
+      ok(call.body.cpu_time_limit === 3);
+      console.log(`  ✅ source base64-encoded + python language_id=71`);
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
+  // 7. judge0 time-limit-exceeded status
+  console.log('\n7. judge0 time limit exceeded (status=5)');
+  {
+    installMockFetch(() => ({
+      status: 201,
+      body: {
+        stdout: null,
+        stderr: null,
+        exit_code: null,
+        status: { id: 5, description: 'Time Limit Exceeded' },
+      },
+    }));
+    try {
+      const p = createSandboxProvider(
+        fakeConfig({
+          SANDBOX_PROVIDER: 'judge0',
+          JUDGE0_URL: 'http://localhost:2358',
+        }),
+      );
+      const result = await p.execute({
+        language: 'python',
+        source: 'while True: pass',
+      });
+      ok(result.timeLimitExceeded === true);
+      ok(result.exitCode === null);
+      console.log(`  ✅ TLE correctly flagged`);
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
+  // 8. judge0 RapidAPI headers
+  console.log('\n8. judge0 with RapidAPI credentials → X-RapidAPI-* headers');
+  {
+    installMockFetch(() => ({
+      status: 201,
+      body: {
+        stdout: Buffer.from('ok', 'utf-8').toString('base64'),
+        status: { id: 3 },
+        exit_code: 0,
+      },
+    }));
+    try {
+      const p = createSandboxProvider(
+        fakeConfig({
+          SANDBOX_PROVIDER: 'judge0',
+          JUDGE0_URL: 'https://judge0-ce.p.rapidapi.com',
+          JUDGE0_API_KEY: 'rapid-key',
+          JUDGE0_API_HOST: 'judge0-ce.p.rapidapi.com',
+        }),
+      );
+      await p.execute({ language: 'javascript', source: 'console.log(1)' });
+      const call = fetchCalls[fetchCalls.length - 1];
+      ok(call.headers['X-RapidAPI-Key'] === 'rapid-key');
+      ok(call.headers['X-RapidAPI-Host'] === 'judge0-ce.p.rapidapi.com');
+      console.log(`  ✅ RapidAPI headers attached`);
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
+  // 9. judge0 unknown language → throws
+  console.log('\n9. judge0 unknown language → throws');
+  {
+    const p = createSandboxProvider(
+      fakeConfig({
+        SANDBOX_PROVIDER: 'judge0',
+        JUDGE0_URL: 'http://localhost:2358',
+      }),
+    );
+    ok(
+      await expectThrow(
+        'unknown language rejected',
+        () => p.execute({ language: 'brainfuck', source: '+++' }),
+        (e) => /does not know language/.test(e.message),
+      ),
+    );
+  }
+
+  // 10. piston is always available
+  console.log('\n10. piston defaults to public instance');
+  {
+    const p = createSandboxProvider(fakeConfig({ SANDBOX_PROVIDER: 'piston' }));
+    ok(p.name === 'piston');
+    ok(p.isAvailable() === true);
+    console.log(`  ✅ piston available without config`);
+  }
+
+  // 11. piston happy path
+  console.log('\n11. piston execute (mocked)');
+  {
+    installMockFetch((url) => {
+      if (url.includes('/execute')) {
+        return {
+          status: 200,
+          body: {
+            language: 'python',
+            version: '3.10.0',
+            run: {
+              stdout: 'hello\n',
+              stderr: '',
+              code: 0,
+              signal: null,
+              output: 'hello\n',
+            },
+          },
+        };
+      }
+      return { status: 404, body: {} };
+    });
+    try {
+      const p = createSandboxProvider(fakeConfig({ SANDBOX_PROVIDER: 'piston' }));
+      const result = await p.execute({
+        language: 'python',
+        source: 'print("hello")',
+      });
+      ok(result.stdout === 'hello\n');
+      ok(result.exitCode === 0);
+      ok(result.provider === 'piston');
+
+      const call = fetchCalls[fetchCalls.length - 1];
+      ok(call.url === 'https://emkc.org/api/v2/piston/execute');
+      ok(call.body.language === 'python');
+      ok(call.body.version === '*');
+      ok(call.body.files[0].content === 'print("hello")');
+      console.log(`  ✅ piston execute correct`);
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
+  // 12. piston signal=SIGKILL → timeLimitExceeded
+  console.log('\n12. piston signal=SIGKILL → timeLimitExceeded');
+  {
+    installMockFetch(() => ({
+      status: 200,
+      body: {
+        run: {
+          stdout: '',
+          stderr: '',
+          code: null,
+          signal: 'SIGKILL',
+          output: '',
+        },
+      },
+    }));
+    try {
+      const p = createSandboxProvider(fakeConfig({ SANDBOX_PROVIDER: 'piston' }));
+      const result = await p.execute({
+        language: 'python',
+        source: 'while True: pass',
+      });
+      ok(result.timeLimitExceeded === true);
+      ok(result.exitCode === null);
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
+  // 13. piston language aliases
+  console.log('\n13. piston normalizes aliases (js → javascript)');
+  {
+    installMockFetch(() => ({
+      status: 200,
+      body: {
+        run: { stdout: '', stderr: '', code: 0, signal: null, output: '' },
+      },
+    }));
+    try {
+      const p = createSandboxProvider(fakeConfig({ SANDBOX_PROVIDER: 'piston' }));
+      await p.execute({ language: 'js', source: 'console.log(1)' });
+      const call = fetchCalls[fetchCalls.length - 1];
+      ok(call.body.language === 'javascript');
+      console.log(`  ✅ js → javascript alias`);
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
+  // 14. planned stubs fall back to none
+  console.log('\n14. stackblitz / codesandbox planned stubs → none');
+  {
+    ok(
+      createSandboxProvider(fakeConfig({ SANDBOX_PROVIDER: 'stackblitz' }))
+        .name === 'none',
+    );
+    ok(
+      createSandboxProvider(fakeConfig({ SANDBOX_PROVIDER: 'codesandbox' }))
+        .name === 'none',
+    );
+    console.log(`  ✅ planned stubs fall back to none with warning`);
+  }
+
+  // 15. unknown value
+  console.log('\n15. unknown SANDBOX_PROVIDER → none (fallback)');
+  {
+    const p = createSandboxProvider(fakeConfig({ SANDBOX_PROVIDER: 'foobar' }));
+    ok(p.name === 'none');
+  }
+
+  console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+  process.exit(fail > 0 ? 1 : 0);
+}
+
+main().catch((e) => {
+  console.error('Smoke test crashed:', e);
+  process.exit(1);
+});

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -27,6 +27,7 @@ import { SearchModule } from './modules/search/search.module';
 import { AchievementsModule } from './modules/achievements/achievements.module';
 import { DatabaseModule } from './modules/database/database.module';
 import { StorageModule } from './modules/storage/storage.module';
+import { SandboxModule } from './modules/sandbox/sandbox.module';
 import { AdminModule } from './modules/admin/admin.module';
 import { InstructorsModule } from './modules/instructors/instructors.module';
 import { EscrowModule } from './modules/escrow/escrow.module';
@@ -85,6 +86,7 @@ import { QueueModule } from './modules/queue/queue.module';
     AchievementsModule,
     DatabaseModule,
     StorageModule,
+    SandboxModule,
     AdminModule,
     InstructorsModule,
     EscrowModule,

--- a/backend/src/modules/sandbox/dto/execute.dto.ts
+++ b/backend/src/modules/sandbox/dto/execute.dto.ts
@@ -1,0 +1,76 @@
+import {
+  ArrayMaxSize,
+  IsArray,
+  IsInt,
+  IsOptional,
+  IsString,
+  Max,
+  MaxLength,
+  Min,
+  MinLength,
+} from 'class-validator';
+
+/**
+ * DTO for POST /api/v1/sandbox/execute.
+ *
+ * Upper bounds on timeLimitSeconds / memoryLimitKb / source length
+ * exist so that an authenticated user can't submit a pathologically
+ * large request to burn real compute at the judge0/piston provider.
+ * The controller's JwtAuthGuard gates *who* can call this endpoint;
+ * this DTO gates *how big* any single call can be.
+ */
+export class ExecuteDto {
+  /**
+   * Language id: "javascript", "python", "cpp", "rust", etc.
+   * Small regex-able string to keep random garbage out of provider
+   * payloads.
+   */
+  @IsString()
+  @MinLength(1)
+  @MaxLength(32)
+  language!: string;
+
+  /** Source code to run. Max 64KB. */
+  @IsString()
+  @MinLength(1)
+  @MaxLength(65536)
+  source!: string;
+
+  /** Optional stdin. Max 32KB. */
+  @IsOptional()
+  @IsString()
+  @MaxLength(32768)
+  stdin?: string;
+
+  /**
+   * Max runtime in seconds. 1..15 — tight upper bound so a compromised
+   * account can't submit `timeLimitSeconds: 99999` to DoS the provider.
+   */
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(15)
+  timeLimitSeconds?: number;
+
+  /**
+   * Max memory in KB. 16384 (16 MB)..512000 (500 MB).
+   * Anything larger is usually a sign of abuse or a misuse.
+   */
+  @IsOptional()
+  @IsInt()
+  @Min(16_384)
+  @Max(512_000)
+  memoryLimitKb?: number;
+
+  /**
+   * Optional command-line args. Capped at 32 args of 256 chars each
+   * so a caller can't stuff megabytes into argv and bypass the
+   * `source` cap.
+   */
+  @IsOptional()
+  @IsArray()
+  @ArrayMaxSize(32)
+  @IsString({ each: true })
+  @MaxLength(256, { each: true })
+  commandLineArgs?: string[];
+}

--- a/backend/src/modules/sandbox/providers/index.ts
+++ b/backend/src/modules/sandbox/providers/index.ts
@@ -1,0 +1,77 @@
+/**
+ * Sandbox provider factory.
+ *
+ * Reads SANDBOX_PROVIDER from config and returns the matching provider.
+ *
+ * Shipped in this PR:
+ *   sandpack  — DEFAULT. Client-side only, metadata provider
+ *   judge0    — server-side execution via Judge0
+ *   piston    — server-side execution via Piston
+ *   none      — disabled
+ *
+ * Planned follow-ups (tracked in issue #36):
+ *   stackblitz   — StackBlitz WebContainers
+ *   codesandbox  — CodeSandbox Devboxes API
+ */
+import { ConfigService } from '@nestjs/config';
+import { Logger } from '@nestjs/common';
+import { SandboxProvider } from './sandbox-provider.interface';
+import { SandpackProvider } from './sandpack.provider';
+import { Judge0Provider } from './judge0.provider';
+import { PistonProvider } from './piston.provider';
+import { NoneSandboxProvider } from './none.provider';
+
+const log = new Logger('SandboxProviderFactory');
+
+export function createSandboxProvider(config: ConfigService): SandboxProvider {
+  const choice = (config.get<string>('SANDBOX_PROVIDER') || 'none')
+    .toLowerCase()
+    .trim();
+
+  switch (choice) {
+    case 'sandpack': {
+      const p = new SandpackProvider(config);
+      log.log(
+        `Selected sandbox provider: sandpack (available=${p.isAvailable()})`,
+      );
+      return p;
+    }
+    case 'judge0': {
+      const p = new Judge0Provider(config);
+      log.log(
+        `Selected sandbox provider: judge0 (available=${p.isAvailable()})`,
+      );
+      return p;
+    }
+    case 'piston': {
+      const p = new PistonProvider(config);
+      log.log(
+        `Selected sandbox provider: piston (available=${p.isAvailable()})`,
+      );
+      return p;
+    }
+    case 'stackblitz':
+    case 'stackblitz-webcontainers':
+    case 'codesandbox':
+    case 'codesandbox-devboxes': {
+      log.warn(
+        `SANDBOX_PROVIDER="${choice}" is planned but not yet implemented (see issue #36). Falling back to "none". Implemented providers: sandpack, judge0, piston.`,
+      );
+      return new NoneSandboxProvider();
+    }
+    case 'none':
+    case '':
+      return new NoneSandboxProvider();
+    default:
+      log.warn(
+        `Unknown SANDBOX_PROVIDER="${choice}". Falling back to "none". Valid values: sandpack, judge0, piston, none.`,
+      );
+      return new NoneSandboxProvider();
+  }
+}
+
+export * from './sandbox-provider.interface';
+export { SandpackProvider } from './sandpack.provider';
+export { Judge0Provider } from './judge0.provider';
+export { PistonProvider } from './piston.provider';
+export { NoneSandboxProvider } from './none.provider';

--- a/backend/src/modules/sandbox/providers/judge0.provider.ts
+++ b/backend/src/modules/sandbox/providers/judge0.provider.ts
@@ -1,0 +1,216 @@
+/**
+ * Judge0 sandbox provider (server-side code execution).
+ *
+ *   SANDBOX_PROVIDER=judge0
+ *   JUDGE0_URL=https://judge0-ce.p.rapidapi.com
+ *   JUDGE0_API_KEY=...                    # only for RapidAPI-hosted
+ *   JUDGE0_API_HOST=judge0-ce.p.rapidapi.com  # only for RapidAPI-hosted
+ *
+ * Judge0 (https://judge0.com) is a polyglot online judge supporting
+ * 60+ languages. Two ways to use it:
+ *
+ *   1. Self-hosted (free, docker-compose):
+ *        JUDGE0_URL=http://localhost:2358
+ *        (no API key or host header needed)
+ *
+ *   2. RapidAPI-hosted (paid, managed):
+ *        JUDGE0_URL=https://judge0-ce.p.rapidapi.com
+ *        JUDGE0_API_KEY=<your rapidapi key>
+ *        JUDGE0_API_HOST=judge0-ce.p.rapidapi.com
+ *
+ * The provider POSTs code + stdin to /submissions?base64_encoded=true&wait=true
+ * and receives the execution result synchronously. For longer-running
+ * jobs, use base64_encoded=true without wait=true and poll — that's
+ * a follow-up.
+ *
+ * This is the recommended provider for GRADED assessments because:
+ *  1. Code runs on YOUR infrastructure, not the student's browser
+ *  2. stdin is fed in securely (can't be tampered with)
+ *  3. Time/memory limits are enforced by the sandbox
+ *  4. 60+ languages cover practically any curriculum
+ */
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  ExecuteInput,
+  ExecuteResult,
+  FrontendSandboxConfig,
+  LanguageInfo,
+  SandboxProvider,
+  SandboxProviderNotConfiguredError,
+} from './sandbox-provider.interface';
+
+/** Judge0 language id map. Only the top 20-ish — the provider
+ * validates against this set so typos fail fast instead of reaching
+ * the API. A follow-up can load this dynamically from /languages. */
+const JUDGE0_LANGUAGES: Record<string, { id: number; name: string }> = {
+  javascript: { id: 63, name: 'JavaScript (Node.js 12.14.0)' },
+  typescript: { id: 74, name: 'TypeScript (3.7.4)' },
+  python: { id: 71, name: 'Python (3.8.1)' },
+  'python3': { id: 71, name: 'Python (3.8.1)' },
+  java: { id: 62, name: 'Java (OpenJDK 13.0.1)' },
+  c: { id: 50, name: 'C (GCC 9.2.0)' },
+  cpp: { id: 54, name: 'C++ (GCC 9.2.0)' },
+  'c++': { id: 54, name: 'C++ (GCC 9.2.0)' },
+  csharp: { id: 51, name: 'C# (Mono 6.6.0.161)' },
+  'c#': { id: 51, name: 'C# (Mono 6.6.0.161)' },
+  go: { id: 60, name: 'Go (1.13.5)' },
+  rust: { id: 73, name: 'Rust (1.40.0)' },
+  ruby: { id: 72, name: 'Ruby (2.7.0)' },
+  php: { id: 68, name: 'PHP (7.4.1)' },
+  kotlin: { id: 78, name: 'Kotlin (1.3.70)' },
+  swift: { id: 83, name: 'Swift (5.2.3)' },
+  r: { id: 80, name: 'R (4.0.0)' },
+  bash: { id: 46, name: 'Bash (5.0.0)' },
+  sql: { id: 82, name: 'SQL (SQLite 3.27.2)' },
+};
+
+export class Judge0Provider implements SandboxProvider {
+  readonly name = 'judge0' as const;
+  private readonly logger = new Logger('Judge0Provider');
+
+  private readonly baseUrl: string;
+  private readonly apiKey: string;
+  private readonly apiHost: string;
+
+  constructor(config: ConfigService) {
+    this.baseUrl = (config.get<string>('JUDGE0_URL', '') || '').replace(/\/+$/, '');
+    this.apiKey = config.get<string>('JUDGE0_API_KEY', '');
+    this.apiHost = config.get<string>('JUDGE0_API_HOST', '');
+
+    if (this.isAvailable()) {
+      this.logger.log(
+        `Judge0 provider configured (${this.baseUrl}${this.apiKey ? ', RapidAPI' : ', self-hosted'})`,
+      );
+    } else {
+      this.logger.warn(
+        'Judge0 provider selected but JUDGE0_URL missing',
+      );
+    }
+  }
+
+  isAvailable(): boolean {
+    return !!this.baseUrl;
+  }
+
+  private async judge0Api(
+    method: 'GET' | 'POST',
+    path: string,
+    body?: any,
+  ): Promise<any> {
+    if (!this.isAvailable()) {
+      throw new SandboxProviderNotConfiguredError('judge0', ['JUDGE0_URL']);
+    }
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    if (this.apiKey) headers['X-RapidAPI-Key'] = this.apiKey;
+    if (this.apiHost) headers['X-RapidAPI-Host'] = this.apiHost;
+
+    const res = await fetch(`${this.baseUrl}${path}`, {
+      method,
+      headers,
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    const json = (await res.json()) as any;
+    if (!res.ok) {
+      throw new Error(
+        `Judge0 API ${method} ${path} failed: ${res.status} ${JSON.stringify(json)}`,
+      );
+    }
+    return json;
+  }
+
+  /**
+   * Base64-encode a string for Judge0's base64_encoded=true mode.
+   * Keeps binary-safe transmission of Unicode source / stdin.
+   */
+  private b64(s: string): string {
+    return Buffer.from(s, 'utf-8').toString('base64');
+  }
+
+  private b64Decode(s: string | null | undefined): string {
+    if (!s) return '';
+    try {
+      return Buffer.from(s, 'base64').toString('utf-8');
+    } catch {
+      return s;
+    }
+  }
+
+  private resolveLanguageId(language: string): number {
+    const key = language.toLowerCase().trim();
+    const entry = JUDGE0_LANGUAGES[key];
+    if (!entry) {
+      throw new Error(
+        `Judge0 provider does not know language "${language}". Known: ${Object.keys(JUDGE0_LANGUAGES).join(', ')}. Add to JUDGE0_LANGUAGES or fetch /languages dynamically.`,
+      );
+    }
+    return entry.id;
+  }
+
+  async execute(input: ExecuteInput): Promise<ExecuteResult> {
+    const languageId = this.resolveLanguageId(input.language);
+    const started = Date.now();
+
+    const res = (await this.judge0Api(
+      'POST',
+      '/submissions?base64_encoded=true&wait=true',
+      {
+        language_id: languageId,
+        source_code: this.b64(input.source),
+        stdin: input.stdin ? this.b64(input.stdin) : '',
+        cpu_time_limit: input.timeLimitSeconds ?? 5,
+        memory_limit: input.memoryLimitKb ?? 128_000,
+        command_line_arguments: input.commandLineArgs?.join(' '),
+      },
+    )) as {
+      stdout?: string;
+      stderr?: string;
+      compile_output?: string;
+      exit_code?: number | null;
+      time?: string;
+      memory?: number;
+      status?: { id: number; description: string };
+    };
+
+    // Judge0 status ids:
+    //   1: queued, 2: processing, 3: accepted, 4: wrong answer
+    //   5: time limit exceeded, 6: compilation error, 7-12: runtime errors
+    //   13: internal error, 14: exec format error
+    const statusId = res.status?.id ?? 0;
+
+    return {
+      stdout: this.b64Decode(res.stdout),
+      stderr: this.b64Decode(res.stderr),
+      compileOutput: this.b64Decode(res.compile_output),
+      exitCode: res.exit_code ?? null,
+      timeLimitExceeded: statusId === 5,
+      memoryLimitExceeded: false, // Judge0 lumps this into status=5
+      durationMs: res.time
+        ? Math.round(parseFloat(res.time) * 1000)
+        : Date.now() - started,
+      memoryKb: res.memory,
+      provider: 'judge0',
+    };
+  }
+
+  async listLanguages(): Promise<LanguageInfo[]> {
+    return Object.entries(JUDGE0_LANGUAGES).map(([id, meta]) => ({
+      id,
+      name: meta.name,
+    }));
+  }
+
+  getFrontendConfig(): FrontendSandboxConfig {
+    return {
+      provider: 'judge0',
+      extra: {
+        // Frontend should POST to our internal /sandbox/execute
+        // endpoint (which calls this provider) rather than hitting
+        // Judge0 directly.
+        executeEndpoint: '/api/v1/sandbox/execute',
+      },
+    };
+  }
+}

--- a/backend/src/modules/sandbox/providers/none.provider.ts
+++ b/backend/src/modules/sandbox/providers/none.provider.ts
@@ -1,0 +1,53 @@
+/**
+ * "None" sandbox provider — code execution disabled.
+ *
+ * The default if SANDBOX_PROVIDER is unset. Every method throws
+ * SandboxProviderNotConfiguredError so assessment / lesson flows
+ * fail loudly instead of silently returning empty output (which
+ * would mask broken wiring during development).
+ */
+import { Logger } from '@nestjs/common';
+import {
+  ExecuteInput,
+  ExecuteResult,
+  FrontendSandboxConfig,
+  LanguageInfo,
+  SandboxProvider,
+  SandboxProviderNotConfiguredError,
+} from './sandbox-provider.interface';
+
+export class NoneSandboxProvider implements SandboxProvider {
+  readonly name = 'none' as const;
+  private readonly logger = new Logger('NoneSandboxProvider');
+
+  constructor() {
+    this.logger.log(
+      'Code sandbox is DISABLED (SANDBOX_PROVIDER not set). To enable, set SANDBOX_PROVIDER to one of: sandpack, judge0, piston. See docs/providers/sandbox.md.',
+    );
+  }
+
+  isAvailable(): boolean {
+    return false;
+  }
+
+  private fail(op: string): never {
+    throw new SandboxProviderNotConfiguredError('none', [
+      `SANDBOX_PROVIDER (currently unset) - cannot ${op}`,
+    ]);
+  }
+
+  async execute(_input: ExecuteInput): Promise<ExecuteResult> {
+    return this.fail('execute');
+  }
+
+  async listLanguages(): Promise<LanguageInfo[]> {
+    return [];
+  }
+
+  getFrontendConfig(): FrontendSandboxConfig {
+    return {
+      provider: 'none',
+      extra: { disabled: true },
+    };
+  }
+}

--- a/backend/src/modules/sandbox/providers/piston.provider.ts
+++ b/backend/src/modules/sandbox/providers/piston.provider.ts
@@ -1,0 +1,185 @@
+/**
+ * Piston sandbox provider.
+ *
+ *   SANDBOX_PROVIDER=piston
+ *   PISTON_URL=https://emkc.org/api/v2/piston   # public instance (default)
+ *   PISTON_API_KEY=                             # optional, for paid tiers
+ *
+ * Piston (https://github.com/engineer-man/piston) is an open-source
+ * polyglot code runner from engineer-man. Free public instance at
+ * emkc.org/api/v2/piston (rate-limited) or self-host for unlimited.
+ *
+ * Simpler API than Judge0 (single POST /execute endpoint, no
+ * submission polling). Supports 40+ languages. Lighter-weight if
+ * you don't need Judge0's full judge feature set.
+ *
+ * Use for: lesson exercises and medium-grade assessments where you
+ * need real server-side execution but don't need the full Judge0
+ * submission-queue + grading UX.
+ */
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  ExecuteInput,
+  ExecuteResult,
+  FrontendSandboxConfig,
+  LanguageInfo,
+  SandboxProvider,
+  SandboxProviderNotConfiguredError,
+} from './sandbox-provider.interface';
+
+/**
+ * Piston language aliases. Piston uses language names like
+ * "javascript" / "python3" / "c++" directly, so the map is lighter
+ * than Judge0's numeric id lookup. Still useful for normalization
+ * (e.g. accepting "python" as "python3").
+ */
+const PISTON_LANGUAGE_ALIASES: Record<string, string> = {
+  js: 'javascript',
+  ts: 'typescript',
+  py: 'python',
+  python3: 'python',
+  cpp: 'c++',
+  'c++': 'c++',
+  rs: 'rust',
+  go: 'go',
+  java: 'java',
+  rb: 'ruby',
+  kt: 'kotlin',
+  sh: 'bash',
+};
+
+/** Known languages exposed via listLanguages(). Not authoritative —
+ * a follow-up can fetch /runtimes for the live list. */
+const PISTON_KNOWN_LANGUAGES: LanguageInfo[] = [
+  { id: 'javascript', name: 'JavaScript (Node.js)' },
+  { id: 'typescript', name: 'TypeScript' },
+  { id: 'python', name: 'Python 3' },
+  { id: 'java', name: 'Java' },
+  { id: 'c', name: 'C' },
+  { id: 'c++', name: 'C++' },
+  { id: 'go', name: 'Go' },
+  { id: 'rust', name: 'Rust' },
+  { id: 'ruby', name: 'Ruby' },
+  { id: 'php', name: 'PHP' },
+  { id: 'bash', name: 'Bash' },
+  { id: 'kotlin', name: 'Kotlin' },
+  { id: 'swift', name: 'Swift' },
+  { id: 'haskell', name: 'Haskell' },
+  { id: 'elixir', name: 'Elixir' },
+];
+
+export class PistonProvider implements SandboxProvider {
+  readonly name = 'piston' as const;
+  private readonly logger = new Logger('PistonProvider');
+
+  private readonly baseUrl: string;
+  private readonly apiKey: string;
+
+  constructor(config: ConfigService) {
+    this.baseUrl = (
+      config.get<string>('PISTON_URL', 'https://emkc.org/api/v2/piston') ||
+      'https://emkc.org/api/v2/piston'
+    ).replace(/\/+$/, '');
+    this.apiKey = config.get<string>('PISTON_API_KEY', '');
+
+    this.logger.log(
+      `Piston provider configured (${this.baseUrl}${this.apiKey ? ', authenticated' : ''})`,
+    );
+  }
+
+  isAvailable(): boolean {
+    // Always available — the public instance needs no auth.
+    return true;
+  }
+
+  private async pistonApi(path: string, body: any): Promise<any> {
+    const headers: Record<string, string> = {
+      'Content-Type': 'application/json',
+    };
+    if (this.apiKey) headers['Authorization'] = `Bearer ${this.apiKey}`;
+
+    const res = await fetch(`${this.baseUrl}${path}`, {
+      method: 'POST',
+      headers,
+      body: JSON.stringify(body),
+    });
+    const json = (await res.json()) as any;
+    if (!res.ok) {
+      throw new Error(
+        `Piston API ${path} failed: ${res.status} ${JSON.stringify(json)}`,
+      );
+    }
+    return json;
+  }
+
+  private normalizeLanguage(language: string): string {
+    const key = language.toLowerCase().trim();
+    return PISTON_LANGUAGE_ALIASES[key] ?? key;
+  }
+
+  async execute(input: ExecuteInput): Promise<ExecuteResult> {
+    const language = this.normalizeLanguage(input.language);
+    const started = Date.now();
+
+    // Piston's /execute shape:
+    //   { language, version: "*", files: [{ content }], stdin, args,
+    //     compile_timeout: ms, run_timeout: ms, compile_memory_limit,
+    //     run_memory_limit }
+    const res = (await this.pistonApi('/execute', {
+      language,
+      version: '*',
+      files: [{ content: input.source }],
+      stdin: input.stdin ?? '',
+      args: input.commandLineArgs ?? [],
+      run_timeout: (input.timeLimitSeconds ?? 5) * 1000,
+      run_memory_limit: input.memoryLimitKb ?? 128_000,
+      compile_timeout: 10_000,
+      compile_memory_limit: 128_000,
+    })) as {
+      language: string;
+      version: string;
+      run: {
+        stdout: string;
+        stderr: string;
+        code: number | null;
+        signal: string | null;
+        output: string;
+      };
+      compile?: {
+        stdout: string;
+        stderr: string;
+        code: number | null;
+        output: string;
+      };
+    };
+
+    // Piston uses `signal: "SIGKILL"` for timeout/memory kills.
+    const killedBySignal =
+      res.run.signal === 'SIGKILL' || res.run.signal === 'SIGXCPU';
+
+    return {
+      stdout: res.run.stdout,
+      stderr: res.run.stderr,
+      compileOutput: res.compile?.output,
+      exitCode: res.run.code,
+      timeLimitExceeded: killedBySignal && res.run.signal === 'SIGKILL',
+      memoryLimitExceeded: killedBySignal && res.run.signal === 'SIGXCPU',
+      durationMs: Date.now() - started,
+      provider: 'piston',
+    };
+  }
+
+  async listLanguages(): Promise<LanguageInfo[]> {
+    return PISTON_KNOWN_LANGUAGES;
+  }
+
+  getFrontendConfig(): FrontendSandboxConfig {
+    return {
+      provider: 'piston',
+      extra: {
+        executeEndpoint: '/api/v1/sandbox/execute',
+      },
+    };
+  }
+}

--- a/backend/src/modules/sandbox/providers/sandbox-provider.interface.ts
+++ b/backend/src/modules/sandbox/providers/sandbox-provider.interface.ts
@@ -1,0 +1,151 @@
+/**
+ * Common interface that every code sandbox / execution provider
+ * implements.
+ *
+ * Pick a provider by setting SANDBOX_PROVIDER in your .env to one of:
+ *
+ *   sandpack    - CodeSandbox Sandpack. In-browser Web Worker runtime.
+ *                 No server-side execution. The provider just returns
+ *                 frontend config so the <Sandpack> React component
+ *                 can bootstrap. Zero infra, zero cost. Perfect for
+ *                 JS/TS/React lesson exercises where grading is
+ *                 presentation-only (show output, no anti-cheat).
+ *                 The default.
+ *
+ *   judge0      - Judge0 (https://judge0.com). Real server-side
+ *                 polyglot code execution across 60+ languages. Can
+ *                 be self-hosted (docker) or consumed via RapidAPI.
+ *                 Enables anti-cheat grading because source + stdin
+ *                 run on your infra, not the user's browser.
+ *
+ *   piston      - Piston (https://github.com/engineer-man/piston).
+ *                 Open-source polyglot runner from engineer-man.
+ *                 Public instance at emkc.org/api/v2/piston
+ *                 (rate-limited) or self-host. Lighter-weight than
+ *                 Judge0, fewer languages.
+ *
+ *   stackblitz  - StackBlitz WebContainers. Full Node.js in the
+ *                 browser. [PLANNED follow-up]
+ *
+ *   codesandbox - CodeSandbox Devboxes API. Managed containers.
+ *                 [PLANNED follow-up]
+ *
+ *   none        - Code execution disabled. Every method throws.
+ *                 The default if SANDBOX_PROVIDER is unset.
+ *
+ * Adding a new provider: implement this interface, register it in
+ * providers/index.ts, document the env vars in docs/providers/sandbox.md.
+ */
+
+export interface ExecuteInput {
+  /** Language id: "javascript", "python", "cpp", "rust", etc. */
+  language: string;
+  /** Source code to run. */
+  source: string;
+  /** stdin fed to the program. */
+  stdin?: string;
+  /** Max runtime in seconds. Default 5. */
+  timeLimitSeconds?: number;
+  /** Max memory in KB. Default 128000 (128 MB). */
+  memoryLimitKb?: number;
+  /** Command-line arguments. */
+  commandLineArgs?: string[];
+}
+
+export interface ExecuteResult {
+  /** Combined stdout from the program. */
+  stdout: string;
+  /** Combined stderr. */
+  stderr: string;
+  /** Compilation output (empty for interpreted languages). */
+  compileOutput?: string;
+  /** Process exit code. null if killed by timeout / memory. */
+  exitCode: number | null;
+  /** True if the program exceeded the time limit. */
+  timeLimitExceeded: boolean;
+  /** True if the program exceeded the memory limit. */
+  memoryLimitExceeded: boolean;
+  /** Wall-clock runtime in milliseconds. */
+  durationMs?: number;
+  /** Peak memory in KB. */
+  memoryKb?: number;
+  /** Provider name. */
+  provider: string;
+}
+
+export interface LanguageInfo {
+  /** Canonical id used in ExecuteInput.language. */
+  id: string;
+  /** Human-readable name ("JavaScript (Node.js 20)"). */
+  name: string;
+  /** Language version string ("20.10.0") if the provider reports it. */
+  version?: string;
+}
+
+export interface FrontendSandboxConfig {
+  /** Provider name for the <Sandbox> React component to pick the right UI. */
+  provider: string;
+  /** For sandpack: default template ("react-ts", "vanilla", "node"). */
+  template?: string;
+  /** For stackblitz: project type. */
+  stackblitzProject?: string;
+  /** Any extra config the frontend needs. */
+  extra?: Record<string, any>;
+}
+
+/**
+ * Common interface implemented by every sandbox provider. Methods a
+ * provider can't support should throw SandboxProviderNotSupportedError
+ * — never silently no-op.
+ */
+export interface SandboxProvider {
+  /** Stable provider name for logging / clients. */
+  readonly name:
+    | 'sandpack'
+    | 'judge0'
+    | 'piston'
+    | 'stackblitz'
+    | 'codesandbox'
+    | 'none';
+
+  /** True if the provider has the credentials/infra it needs. */
+  isAvailable(): boolean;
+
+  /**
+   * Execute a code submission server-side. For in-browser providers
+   * (sandpack, stackblitz) this throws SandboxProviderNotSupportedError
+   * — execution happens in the user's browser, graded presentationally.
+   */
+  execute(input: ExecuteInput): Promise<ExecuteResult>;
+
+  /** List languages this provider can execute. */
+  listLanguages(): Promise<LanguageInfo[]>;
+
+  /** Frontend-safe bootstrap config for the <Sandbox> component. */
+  getFrontendConfig(): FrontendSandboxConfig;
+}
+
+/**
+ * Thrown when a provider is asked to do something it can't support
+ * (e.g. execute() on sandpack).
+ */
+export class SandboxProviderNotSupportedError extends Error {
+  constructor(provider: string, operation: string) {
+    super(
+      `Operation "${operation}" is not supported by the "${provider}" sandbox provider. See docs/providers/sandbox.md.`,
+    );
+    this.name = 'SandboxProviderNotSupportedError';
+  }
+}
+
+/**
+ * Thrown when a provider is selected but its credentials are missing.
+ */
+export class SandboxProviderNotConfiguredError extends Error {
+  constructor(provider: string, missingVars: string[]) {
+    super(
+      `Sandbox provider "${provider}" is selected but the following env vars are missing: ${missingVars.join(', ')}. See docs/providers/sandbox.md.`,
+    );
+    this.name = 'SandboxProviderNotConfiguredError';
+  }
+}

--- a/backend/src/modules/sandbox/providers/sandpack.provider.ts
+++ b/backend/src/modules/sandbox/providers/sandpack.provider.ts
@@ -1,0 +1,95 @@
+/**
+ * Sandpack sandbox provider (frontend-only execution).
+ *
+ *   SANDBOX_PROVIDER=sandpack    (default)
+ *
+ * CodeSandbox Sandpack is an in-browser code runtime built on Web
+ * Workers + a bundled JS interpreter. The "provider" here is
+ * metadata-only — actual execution happens client-side in the
+ * user's browser, so there's no backend API call.
+ *
+ * Optional env vars:
+ *   SANDPACK_TEMPLATE=react-ts    (default)
+ *      Valid values: vanilla, vanilla-ts, react, react-ts, vue,
+ *      vue-ts, angular, svelte, solid, node, nextjs, vite-react,
+ *      vite-react-ts, etc. See https://sandpack.codesandbox.io/docs
+ *
+ * Use this for JS/TS/React lesson exercises where grading is
+ * presentation-only (show the output in an iframe, no anti-cheat
+ * grading). For graded assessments with real scoring, use judge0
+ * or piston instead — those execute server-side where the student
+ * can't tamper with the runtime.
+ *
+ * The frontend loads the @codesandbox/sandpack-react package and
+ * renders a <Sandpack template={...}> component. The provider's
+ * only job is to tell it which template to use.
+ */
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  ExecuteInput,
+  ExecuteResult,
+  FrontendSandboxConfig,
+  LanguageInfo,
+  SandboxProvider,
+  SandboxProviderNotSupportedError,
+} from './sandbox-provider.interface';
+
+export class SandpackProvider implements SandboxProvider {
+  readonly name = 'sandpack' as const;
+  private readonly logger = new Logger('SandpackProvider');
+
+  private readonly template: string;
+
+  constructor(config: ConfigService) {
+    this.template = config.get<string>('SANDPACK_TEMPLATE', 'react-ts');
+    this.logger.log(
+      `Sandpack provider configured (template=${this.template}) — execution is client-side only`,
+    );
+  }
+
+  isAvailable(): boolean {
+    // Always available — no backend config needed, everything is
+    // rendered + executed in the browser.
+    return true;
+  }
+
+  async execute(_input: ExecuteInput): Promise<ExecuteResult> {
+    // Sandpack runs in the user's browser — the backend has no
+    // access to the runtime. Throwing here instead of silently
+    // no-op'ing forces the caller to realize they need a
+    // server-side provider (judge0/piston) for graded assessments.
+    throw new SandboxProviderNotSupportedError(
+      'sandpack',
+      'execute (Sandpack runs in the browser — use judge0 or piston for server-side execution, or grade presentationally via the Sandpack iframe output)',
+    );
+  }
+
+  async listLanguages(): Promise<LanguageInfo[]> {
+    // Sandpack's supported languages are really "templates" — what
+    // JS bundler config to ship to the browser. Expose the common
+    // set so callers can surface them in a picker UI.
+    return [
+      { id: 'vanilla', name: 'Vanilla JavaScript' },
+      { id: 'vanilla-ts', name: 'Vanilla TypeScript' },
+      { id: 'react', name: 'React' },
+      { id: 'react-ts', name: 'React + TypeScript' },
+      { id: 'vue', name: 'Vue' },
+      { id: 'vue-ts', name: 'Vue + TypeScript' },
+      { id: 'angular', name: 'Angular' },
+      { id: 'svelte', name: 'Svelte' },
+      { id: 'solid', name: 'Solid' },
+      { id: 'node', name: 'Node.js' },
+      { id: 'nextjs', name: 'Next.js' },
+      { id: 'vite-react', name: 'Vite + React' },
+      { id: 'vite-react-ts', name: 'Vite + React + TypeScript' },
+    ];
+  }
+
+  getFrontendConfig(): FrontendSandboxConfig {
+    return {
+      provider: 'sandpack',
+      template: this.template,
+    };
+  }
+}

--- a/backend/src/modules/sandbox/sandbox.controller.ts
+++ b/backend/src/modules/sandbox/sandbox.controller.ts
@@ -4,12 +4,11 @@ import {
   Get,
   Post,
   UseGuards,
-  BadRequestException,
 } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
 import { SandboxService } from './sandbox.service';
 import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
-import { ExecuteInput } from './providers';
+import { ExecuteDto } from './dto/execute.dto';
 
 /**
  * Sandbox endpoints.
@@ -52,16 +51,16 @@ export class SandboxController {
     description:
       'Sandpack-style providers throw NotSupported here because they run in the browser.',
   })
-  async execute(@Body() input: ExecuteInput) {
-    if (!input?.language || !input?.source) {
-      throw new BadRequestException('language and source are required');
-    }
-    if (typeof input.source !== 'string' || input.source.length === 0) {
-      throw new BadRequestException('source must be a non-empty string');
-    }
-    if (input.source.length > 65536) {
-      throw new BadRequestException('source too large (max 64KB)');
-    }
+  async execute(@Body() input: ExecuteDto) {
+    // Input shape + upper-bound validation is handled by the global
+    // ValidationPipe via class-validator decorators on ExecuteDto.
+    // That enforces:
+    //   - language / source are non-empty strings
+    //   - source ≤ 64KB
+    //   - stdin ≤ 32KB
+    //   - timeLimitSeconds ∈ [1, 15]
+    //   - memoryLimitKb ∈ [16MB, 500MB]
+    //   - commandLineArgs ≤ 32 entries × 256 chars
     return this.sandbox.execute(input);
   }
 }

--- a/backend/src/modules/sandbox/sandbox.controller.ts
+++ b/backend/src/modules/sandbox/sandbox.controller.ts
@@ -1,0 +1,67 @@
+import {
+  Body,
+  Controller,
+  Get,
+  Post,
+  UseGuards,
+  BadRequestException,
+} from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
+import { SandboxService } from './sandbox.service';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { ExecuteInput } from './providers';
+
+/**
+ * Sandbox endpoints.
+ *
+ *   GET  /api/v1/sandbox/config                   — frontend bootstrap (public)
+ *   GET  /api/v1/sandbox/languages                — list supported languages
+ *   POST /api/v1/sandbox/execute  (auth required) — run code server-side
+ *
+ * `execute` is JWT-protected because it costs real compute and
+ * would be abused by unauthenticated callers. For public lesson
+ * previews that use sandpack (browser-only execution), the
+ * frontend renders a <Sandpack> component directly and never
+ * calls this endpoint.
+ */
+@ApiTags('sandbox')
+@Controller('sandbox')
+export class SandboxController {
+  constructor(private readonly sandbox: SandboxService) {}
+
+  @Get('config')
+  @ApiOperation({ summary: 'Frontend sandbox bootstrap config' })
+  getConfig() {
+    return this.sandbox.getFrontendConfig();
+  }
+
+  @Get('languages')
+  @ApiOperation({ summary: 'List languages supported by the active provider' })
+  async listLanguages() {
+    return {
+      provider: this.sandbox.getProviderName(),
+      languages: await this.sandbox.listLanguages(),
+    };
+  }
+
+  @Post('execute')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Execute code server-side (judge0 / piston)',
+    description:
+      'Sandpack-style providers throw NotSupported here because they run in the browser.',
+  })
+  async execute(@Body() input: ExecuteInput) {
+    if (!input?.language || !input?.source) {
+      throw new BadRequestException('language and source are required');
+    }
+    if (typeof input.source !== 'string' || input.source.length === 0) {
+      throw new BadRequestException('source must be a non-empty string');
+    }
+    if (input.source.length > 65536) {
+      throw new BadRequestException('source too large (max 64KB)');
+    }
+    return this.sandbox.execute(input);
+  }
+}

--- a/backend/src/modules/sandbox/sandbox.module.ts
+++ b/backend/src/modules/sandbox/sandbox.module.ts
@@ -1,0 +1,19 @@
+import { Module } from '@nestjs/common';
+import { SandboxService } from './sandbox.service';
+import { SandboxController } from './sandbox.controller';
+import { AuthModule } from '../auth/auth.module';
+
+/**
+ * Sandbox module — pluggable code execution for assessments and
+ * lesson exercises.
+ *
+ * Pick a provider via SANDBOX_PROVIDER in your .env. See
+ * `docs/providers/sandbox.md` for the full comparison.
+ */
+@Module({
+  imports: [AuthModule], // JwtAuthGuard on /execute
+  controllers: [SandboxController],
+  providers: [SandboxService],
+  exports: [SandboxService],
+})
+export class SandboxModule {}

--- a/backend/src/modules/sandbox/sandbox.service.ts
+++ b/backend/src/modules/sandbox/sandbox.service.ts
@@ -1,0 +1,60 @@
+/**
+ * SandboxService — code execution façade.
+ *
+ * Assessment grading, lesson exercises, and any other feature that
+ * needs to run user-submitted code should inject this service.
+ *
+ * Switching providers (sandpack → judge0 → piston) is just a matter
+ * of changing `SANDBOX_PROVIDER` in .env.
+ *
+ * See `./providers/` and `docs/providers/sandbox.md`.
+ */
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  createSandboxProvider,
+  ExecuteInput,
+  ExecuteResult,
+  FrontendSandboxConfig,
+  LanguageInfo,
+  SandboxProvider,
+} from './providers';
+
+@Injectable()
+export class SandboxService implements OnModuleInit {
+  private readonly logger = new Logger(SandboxService.name);
+  private provider!: SandboxProvider;
+
+  constructor(private readonly config: ConfigService) {}
+
+  onModuleInit() {
+    this.provider = createSandboxProvider(this.config);
+    this.logger.log(
+      `Sandbox provider initialized: ${this.provider.name} (available=${this.provider.isAvailable()})`,
+    );
+  }
+
+  getProviderName(): string {
+    return this.provider?.name ?? 'none';
+  }
+
+  isAvailable(): boolean {
+    return !!this.provider && this.provider.isAvailable();
+  }
+
+  async execute(input: ExecuteInput): Promise<ExecuteResult> {
+    return this.provider.execute(input);
+  }
+
+  async listLanguages(): Promise<LanguageInfo[]> {
+    return this.provider.listLanguages();
+  }
+
+  getFrontendConfig(): FrontendSandboxConfig {
+    return this.provider.getFrontendConfig();
+  }
+
+  getProvider(): SandboxProvider {
+    return this.provider;
+  }
+}


### PR DESCRIPTION
## Summary

Closes #36. Adds a first-class code sandbox module for running user-submitted code in assessments and lesson exercises. Covers both browser-only (Sandpack) and server-side (Judge0, Piston) execution.

## What's in it

**4 real providers + 2 planned stubs + none**:

- **sandpack** *(default)* — in-browser Web Worker runtime, zero infra, 13 supported templates (React/TS/Vue/Svelte/Solid/Node/Vite/Next/...). Metadata-only provider — `execute()` throws `NotSupported` because the runtime is in the user's browser, not the server. Perfect for lesson previews with presentational grading.
- **judge0** — server-side polyglot execution, 60+ languages, 19 whitelisted in the provider with numeric id mapping. Two modes: self-hosted (docker) or RapidAPI-managed. Base64 source + stdin round-trip for Unicode safety. Status id 5 → `timeLimitExceeded`. **Right choice for graded assessments** — code runs on your infra with enforceable limits.
- **piston** — lightweight open-source runner from engineer-man. Single `/execute` endpoint. Public instance at `emkc.org` (rate-limited) or self-host. Language aliases (`js` → `javascript`). `SIGKILL` → `timeLimitExceeded`, `SIGXCPU` → `memoryLimitExceeded`.
- **stackblitz** / **codesandbox** — planned stubs, fall back to `none` with warning.
- **none** — disabled stub, throws loudly.

## Key design decisions

- **Sandpack throws on `execute()`** instead of silently no-op'ing. Forces the caller to realize they need a server-side provider for graded assessments. Silent no-op would hide broken scoring.
- **Judge0 base64 round-trip**: `base64_encoded=true&wait=true` — source and stdin encoded on the way in, stdout/stderr/compile_output decoded on the way out. Unicode-safe. Callers pass plain UTF-8.
- **Judge0 language whitelist**: unknown languages throw early with a list of valid names instead of hitting the API with a wrong id. Follow-up can fetch `/languages` dynamically.
- **Piston signal mapping**: `SIGKILL` → `timeLimitExceeded`, `SIGXCPU` → `memoryLimitExceeded`, `signal=null` with `code=0` → success.
- **`/sandbox/execute` is JWT-protected** because server-side execution costs real compute. Source length capped at 64KB in the controller. Lesson previews using Sandpack don't hit this endpoint — the frontend renders `<Sandpack>` directly.

## Endpoints

```
GET  /api/v1/sandbox/config    — frontend bootstrap (public)
GET  /api/v1/sandbox/languages — list supported languages (public)
POST /api/v1/sandbox/execute   — run code (JWT required)
```

## Verification status (honest)

| Provider | Status |
|---|---|
| **sandpack** | written, **smoke-tested** (metadata + throws on execute) |
| **judge0** | written, **smoke-tested** (mocked fetch + base64 round-trip + TLE status id=5 + RapidAPI headers + unknown-language rejection). NOT tested against real Judge0 |
| **piston** | written, **smoke-tested** (mocked fetch + SIGKILL mapping + alias normalization). NOT tested against real Piston |
| **none** | written, **smoke-tested** (throws as expected) |
| **stackblitz** / **codesandbox** | NOT implemented, planned stubs with warning fallback |

Full TypeScript compile: **0 errors**.

Smoke test (`backend/scripts/smoke-test-sandbox-providers.ts`): **47/47 assertions pass**. 15 scenarios.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx ts-node scripts/smoke-test-sandbox-providers.ts` 47/47 pass
- [ ] Manual: boot with `SANDBOX_PROVIDER=sandpack`, `curl /api/v1/sandbox/config` returns the react-ts template
- [ ] Manual: spin up local Judge0 via docker-compose, set `JUDGE0_URL=http://localhost:2358`, `POST /sandbox/execute` with Python code
- [ ] Manual: Piston against `emkc.org` public instance
- [ ] Follow-up PR: wire `SandboxService` into the existing assessments module

## Out of scope

- `stackblitz` / `codesandbox` provider implementations
- Wiring `SandboxService` into the existing assessments module
- Dynamic Judge0 `/languages` fetch on startup
- Per-user rate limiting beyond JWT
- Frontend `<Sandbox>` component that reads `/sandbox/config`

## Related

- Tracking issue #38 (pluggable providers meta)

🤖 Generated with [Claude Code](https://claude.com/claude-code)