### PR TITLE
feat(payments): pluggable payment gateway adapter — first-pass (stripe/paypal/bkash)

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -108,8 +108,8 @@ QDRANT_API_KEY=your_qdrant_api_key
 
 PAYMENT_PROVIDER=none
 
-# STRIPE_SECRET_KEY is already set in the Stripe section above.
-STRIPE_WEBHOOK_SECRET=whsec_...
+# STRIPE_SECRET_KEY and STRIPE_WEBHOOK_SECRET are set in the Stripe
+# section above. Don't redeclare them here.
 
 # --- PayPal ---
 PAYPAL_CLIENT_ID=

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -115,6 +115,10 @@ PAYMENT_PROVIDER=none
 PAYPAL_CLIENT_ID=
 PAYPAL_CLIENT_SECRET=
 PAYPAL_MODE=sandbox
+# Required for webhook verification. Get it from
+# https://developer.paypal.com/dashboard/webhooks — parseWebhook
+# throws until this is set, to prevent forged notifications.
+PAYPAL_WEBHOOK_ID=
 
 # --- bKash (Bangladesh mobile wallet) ---
 BKASH_BASE_URL=https://tokenized.sandbox.bka.sh/v1.2.0-beta

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -91,3 +91,34 @@ OPENAI_MODEL=gpt-4o-mini
 QDRANT_HOST=localhost
 QDRANT_PORT=6333
 QDRANT_API_KEY=your_qdrant_api_key
+
+# =====================================================
+# PAYMENT GATEWAY (pluggable)
+# =====================================================
+# Pick a provider. See backend/docs/providers/payments.md.
+#
+# Valid values: stripe | paypal | bkash | none
+#
+# Team@Once's escrow/milestone model is Stripe-centric today;
+# stripe is the recommended production choice. PayPal and bKash
+# are available for marketplaces that need them.
+#
+# Planned follow-ups (part of #35):
+#   razorpay, paystack, mollie, mpesa, lemonsqueezy
+
+PAYMENT_PROVIDER=none
+
+# STRIPE_SECRET_KEY is already set in the Stripe section above.
+STRIPE_WEBHOOK_SECRET=whsec_...
+
+# --- PayPal ---
+PAYPAL_CLIENT_ID=
+PAYPAL_CLIENT_SECRET=
+PAYPAL_MODE=sandbox
+
+# --- bKash (Bangladesh mobile wallet) ---
+BKASH_BASE_URL=https://tokenized.sandbox.bka.sh/v1.2.0-beta
+BKASH_APP_KEY=
+BKASH_APP_SECRET=
+BKASH_USERNAME=
+BKASH_PASSWORD=

--- a/backend/scripts/smoke-test-payment-providers.ts
+++ b/backend/scripts/smoke-test-payment-providers.ts
@@ -347,6 +347,44 @@ async function main(): Promise<void> {
         (e) => /signature mismatch/i.test(e.message),
       ),
     );
+
+    // Fail-closed: if webhookSecret is set, a missing signature
+    // header must throw instead of silently parsing the payload.
+    ok(
+      await expectThrow(
+        'missing signature header throws (fail-closed)',
+        () => p.parseWebhook(payload, undefined),
+        (e) => /signature missing/i.test(e.message),
+      ),
+    );
+
+    // Length-mismatch signatures must NOT bubble as RangeError
+    // from timingSafeEqual; they should be rejected cleanly.
+    ok(
+      await expectThrow(
+        'length-mismatch signature rejects cleanly',
+        () => p.parseWebhook(payload, `t=${timestamp},v1=deadbeef`),
+        (e) =>
+          /signature mismatch/i.test(e.message) &&
+          !/ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH/i.test(e.message),
+      ),
+    );
+
+    // Replay protection: a signed payload with a 10-minute-old
+    // timestamp must be rejected (tolerance window is 5 min).
+    const staleTs = Math.floor(Date.now() / 1000) - 600;
+    const staleSigned = `${staleTs}.${payload}`;
+    const staleV1 = crypto
+      .createHmac('sha256', 'whsec_test_secret')
+      .update(staleSigned)
+      .digest('hex');
+    ok(
+      await expectThrow(
+        'stale timestamp rejected (replay protection)',
+        () => p.parseWebhook(payload, `t=${staleTs},v1=${staleV1}`),
+        (e) => /tolerance/i.test(e.message),
+      ),
+    );
   }
 
   // 7. paypal without creds → unavailable

--- a/backend/scripts/smoke-test-payment-providers.ts
+++ b/backend/scripts/smoke-test-payment-providers.ts
@@ -469,6 +469,214 @@ async function main(): Promise<void> {
     }
   }
 
+  // 8b. paypal zero-decimal currencies format without the /100 step
+  console.log('\n8b. paypal JPY amounts format as integer (zero-decimal)');
+  {
+    installMockFetch((url) => {
+      if (url.endsWith('/v1/oauth2/token')) {
+        return { status: 200, body: { access_token: 't', expires_in: 3600 } };
+      }
+      if (url.endsWith('/v2/checkout/orders')) {
+        return {
+          status: 201,
+          body: {
+            id: 'JPY-ORDER',
+            links: [{ rel: 'approve', href: 'https://x' }],
+          },
+        };
+      }
+      return { status: 404, body: {} };
+    });
+    try {
+      const p = createPaymentProvider(
+        fakeConfig({
+          PAYMENT_PROVIDER: 'paypal',
+          PAYPAL_CLIENT_ID: 'cid',
+          PAYPAL_CLIENT_SECRET: 'csec',
+        }),
+      );
+      await p.createCheckout({
+        orderReference: 'jp-1',
+        currency: 'JPY',
+        totalAmount: 1000, // 1000 yen, NOT 10 yen
+        lineItems: [
+          { productId: 'noodles', description: 'noodles', quantity: 1, unitAmount: 1000 },
+        ],
+        customer: {
+          email: 't@example.com',
+          name: 'Alice',
+          line1: '1',
+          city: 'Tokyo',
+          postalCode: '100',
+          country: 'JP',
+        },
+        successUrl: 'https://x',
+        cancelUrl: 'https://x',
+      });
+      const orderCall = fetchCalls.find((c) =>
+        c.url.endsWith('/v2/checkout/orders'),
+      );
+      ok(orderCall!.body.purchase_units[0].amount.value === '1000');
+      ok(
+        orderCall!.body.purchase_units[0].items[0].unit_amount.value === '1000',
+      );
+      console.log(`  ✅ JPY amount 1000 → "1000" (not "10.00")`);
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
+  // 8c. paypal webhook without PAYPAL_WEBHOOK_ID → fail-closed
+  console.log('\n8c. paypal webhook refuses to run without PAYPAL_WEBHOOK_ID');
+  {
+    const p = createPaymentProvider(
+      fakeConfig({
+        PAYMENT_PROVIDER: 'paypal',
+        PAYPAL_CLIENT_ID: 'cid',
+        PAYPAL_CLIENT_SECRET: 'csec',
+        // PAYPAL_WEBHOOK_ID deliberately unset
+      }),
+    );
+    ok(
+      await expectThrow(
+        'missing PAYPAL_WEBHOOK_ID throws',
+        () => p.parseWebhook('{}', '{}'),
+        (e) => /PAYPAL_WEBHOOK_ID/.test(e.message),
+      ),
+    );
+  }
+
+  // 8d. paypal webhook with missing transmission headers → fail-closed
+  console.log('\n8d. paypal webhook rejects incomplete header bundle');
+  {
+    const p = createPaymentProvider(
+      fakeConfig({
+        PAYMENT_PROVIDER: 'paypal',
+        PAYPAL_CLIENT_ID: 'cid',
+        PAYPAL_CLIENT_SECRET: 'csec',
+        PAYPAL_WEBHOOK_ID: 'wh-123',
+      }),
+    );
+    ok(
+      await expectThrow(
+        'missing signature bundle throws',
+        () => p.parseWebhook('{}', undefined),
+        (e) => /bundle missing/.test(e.message),
+      ),
+    );
+    ok(
+      await expectThrow(
+        'incomplete headers throw',
+        () =>
+          p.parseWebhook(
+            '{}',
+            JSON.stringify({ 'paypal-transmission-id': 'x' }),
+          ),
+        (e) => /headers missing/.test(e.message),
+      ),
+    );
+  }
+
+  // 8e. paypal webhook happy path calls verify endpoint
+  console.log('\n8e. paypal webhook calls verify endpoint + returns event');
+  {
+    installMockFetch((url) => {
+      if (url.endsWith('/v1/oauth2/token')) {
+        return { status: 200, body: { access_token: 't', expires_in: 3600 } };
+      }
+      if (url.includes('/v1/notifications/verify-webhook-signature')) {
+        return { status: 200, body: { verification_status: 'SUCCESS' } };
+      }
+      return { status: 404, body: {} };
+    });
+    try {
+      const p = createPaymentProvider(
+        fakeConfig({
+          PAYMENT_PROVIDER: 'paypal',
+          PAYPAL_CLIENT_ID: 'cid',
+          PAYPAL_CLIENT_SECRET: 'csec',
+          PAYPAL_WEBHOOK_ID: 'wh-happy',
+        }),
+      );
+      const body = JSON.stringify({
+        event_type: 'PAYMENT.CAPTURE.COMPLETED',
+        resource: {
+          id: 'CAP-1',
+          amount: { value: '20.00', currency_code: 'USD' },
+          custom_id: 'ord-8e',
+        },
+      });
+      const headers = JSON.stringify({
+        'paypal-transmission-id': 'tid',
+        'paypal-transmission-time': '2026-01-01T00:00:00Z',
+        'paypal-transmission-sig': 'sig',
+        'paypal-cert-url': 'https://api.sandbox.paypal.com/v1/x',
+        'paypal-auth-algo': 'SHA256withRSA',
+      });
+      const event = await p.parseWebhook(body, headers);
+      ok(event !== null);
+      ok(event!.kind === 'payment.succeeded');
+      ok(event!.paymentId === 'CAP-1');
+      ok(event!.amount === 2000); // USD, 2-decimal
+      const verifyCall = fetchCalls.find((c) =>
+        c.url.includes('/v1/notifications/verify-webhook-signature'),
+      );
+      ok(!!verifyCall);
+      ok(verifyCall!.body.webhook_id === 'wh-happy');
+      ok(verifyCall!.body.auth_algo === 'SHA256withRSA');
+      console.log(`  ✅ verify endpoint called + event returned`);
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
+  // 8f. paypal webhook rejects when verify_status != SUCCESS
+  console.log('\n8f. paypal webhook rejects verify_status != SUCCESS');
+  {
+    installMockFetch((url) => {
+      if (url.endsWith('/v1/oauth2/token')) {
+        return { status: 200, body: { access_token: 't', expires_in: 3600 } };
+      }
+      if (url.includes('/v1/notifications/verify-webhook-signature')) {
+        return { status: 200, body: { verification_status: 'FAILURE' } };
+      }
+      return { status: 404, body: {} };
+    });
+    try {
+      const p = createPaymentProvider(
+        fakeConfig({
+          PAYMENT_PROVIDER: 'paypal',
+          PAYPAL_CLIENT_ID: 'cid',
+          PAYPAL_CLIENT_SECRET: 'csec',
+          PAYPAL_WEBHOOK_ID: 'wh-bad',
+        }),
+      );
+      const headers = JSON.stringify({
+        'paypal-transmission-id': 'tid',
+        'paypal-transmission-time': 't',
+        'paypal-transmission-sig': 's',
+        'paypal-cert-url': 'u',
+        'paypal-auth-algo': 'a',
+      });
+      ok(
+        await expectThrow(
+          'FAILURE verification rejects',
+          () =>
+            p.parseWebhook(
+              '{"event_type":"PAYMENT.CAPTURE.COMPLETED","resource":{}}',
+              headers,
+            ),
+          (e) => /verification_status=FAILURE/.test(e.message),
+        ),
+      );
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
   // 9. bkash without creds → unavailable
   console.log('\n9. bkash without creds → unavailable');
   {

--- a/backend/scripts/smoke-test-payment-providers.ts
+++ b/backend/scripts/smoke-test-payment-providers.ts
@@ -772,6 +772,80 @@ async function main(): Promise<void> {
     }
   }
 
+  // 10b. bkash capturePayment captures trxID, refund uses it
+  console.log(
+    '\n10b. bkash capturePayment caches trxID; refund sends trxID ≠ paymentID',
+  );
+  {
+    installMockFetch((url) => {
+      if (url.includes('/tokenized/checkout/token/grant')) {
+        return {
+          status: 200,
+          body: {
+            id_token: 'bkash-tok',
+            expires_in: 3600,
+            statusCode: '0000',
+          },
+        };
+      }
+      if (url.includes('/tokenized/checkout/execute')) {
+        return {
+          status: 200,
+          body: {
+            paymentID: 'TR0011PAYMENT',
+            trxID: 'CAPTUREDTRX999',
+            transactionStatus: 'Completed',
+            amount: '500.00',
+            statusCode: '0000',
+          },
+        };
+      }
+      if (url.includes('/tokenized/checkout/payment/refund')) {
+        return {
+          status: 200,
+          body: {
+            refundTrxID: 'REFUND-1',
+            amount: '500.00',
+            transactionStatus: 'Completed',
+            statusCode: '0000',
+          },
+        };
+      }
+      return { status: 404, body: {} };
+    });
+    try {
+      const p = createPaymentProvider(
+        fakeConfig({
+          PAYMENT_PROVIDER: 'bkash',
+          BKASH_APP_KEY: 'appkey',
+          BKASH_APP_SECRET: 'appsecret',
+          BKASH_USERNAME: 'user',
+          BKASH_PASSWORD: 'pass',
+        }),
+      );
+      // Step 1: capturePayment is part of the interface and works.
+      const info = await p.capturePayment('TR0011PAYMENT');
+      ok(info.status === 'succeeded');
+      ok(info.provider === 'bkash');
+
+      // Step 2: refund uses the cached trxID, not the paymentID.
+      await p.refund({ paymentId: 'TR0011PAYMENT', amount: 50000 });
+      const refundCall = fetchCalls.find((c) =>
+        c.url.includes('/tokenized/checkout/payment/refund'),
+      );
+      ok(!!refundCall);
+      ok(refundCall!.body.paymentID === 'TR0011PAYMENT');
+      ok(refundCall!.body.trxID === 'CAPTUREDTRX999');
+      ok(refundCall!.body.trxID !== refundCall!.body.paymentID);
+      console.log(
+        `  ✅ capturePayment ok, refund uses trxID (${refundCall!.body.trxID}) ≠ paymentID`,
+      );
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
   // 11. Planned providers fall back to none
   console.log('\n11. razorpay / mollie / etc fall back to none');
   {

--- a/backend/scripts/smoke-test-payment-providers.ts
+++ b/backend/scripts/smoke-test-payment-providers.ts
@@ -1,0 +1,565 @@
+/**
+ * Smoke test for the multi-provider payment factory.
+ *
+ * Mocks `fetch` to verify URL + auth + payload shape per provider.
+ * Also verifies Stripe webhook HMAC-SHA256 signature flow with real
+ * crypto. No real API calls.
+ *
+ * Run with: npx ts-node scripts/smoke-test-payment-providers.ts
+ */
+import * as crypto from 'crypto';
+import { ConfigService } from '@nestjs/config';
+import {
+  createPaymentProvider,
+  PaymentProviderNotConfiguredError,
+} from '../src/modules/payment/providers';
+
+function fakeConfig(env: Record<string, string>): ConfigService {
+  return {
+    get: <T>(key: string, def?: T) => (env[key] as any) ?? def,
+  } as unknown as ConfigService;
+}
+
+type FetchCall = {
+  url: string;
+  method: string;
+  headers: Record<string, string>;
+  body: any;
+  rawBody: string | null;
+};
+const fetchCalls: FetchCall[] = [];
+const realFetch = global.fetch;
+function installMockFetch(
+  responder: (url: string, init: any) => { status: number; body: any },
+) {
+  global.fetch = (async (url: any, init: any = {}) => {
+    const headers: Record<string, string> = {};
+    if (init.headers) {
+      for (const [k, v] of Object.entries(init.headers)) {
+        headers[k] = String(v);
+      }
+    }
+    const rawBody = typeof init.body === 'string' ? init.body : null;
+    let parsedBody: any = null;
+    if (rawBody) {
+      try {
+        parsedBody = JSON.parse(rawBody);
+      } catch {
+        // Form-urlencoded body
+        parsedBody = Object.fromEntries(new URLSearchParams(rawBody));
+      }
+    }
+    fetchCalls.push({
+      url: String(url),
+      method: init.method ?? 'GET',
+      headers,
+      body: parsedBody,
+      rawBody,
+    });
+    const { status, body } = responder(String(url), init);
+    return new Response(JSON.stringify(body), {
+      status,
+      headers: { 'Content-Type': 'application/json' },
+    });
+  }) as any;
+}
+function restoreFetch() {
+  global.fetch = realFetch;
+}
+
+async function expectThrow(
+  label: string,
+  fn: () => Promise<unknown>,
+  matcher: (e: Error) => boolean,
+): Promise<boolean> {
+  try {
+    await fn();
+    console.log(`  ❌ ${label}: expected throw, got success`);
+    return false;
+  } catch (e) {
+    if (matcher(e as Error)) {
+      console.log(`  ✅ ${label}: threw as expected`);
+      return true;
+    }
+    console.log(`  ❌ ${label}: wrong error: ${(e as Error).message}`);
+    return false;
+  }
+}
+
+async function main(): Promise<void> {
+  let pass = 0;
+  let fail = 0;
+  const ok = (b: boolean, msg?: string) => {
+    if (b) pass++;
+    else {
+      fail++;
+      if (msg) console.log(`  ⚠️  ${msg}`);
+    }
+  };
+  console.log('=== Payment provider factory smoke test ===\n');
+
+  const customer = {
+    name: 'Alice',
+    email: 'alice@example.com',
+    phone: '+8801711111111',
+    country: 'BD',
+  };
+  const lineItems = [
+    { productId: 'p1', description: 'Widget', unitAmount: 1000, quantity: 2 },
+  ];
+
+  // 1. none default
+  console.log('1. no PAYMENT_PROVIDER → none');
+  {
+    const p = createPaymentProvider(fakeConfig({}));
+    ok(p.name === 'none');
+    ok(p.isAvailable() === false);
+    ok(
+      await expectThrow(
+        'createCheckout fails loudly',
+        () =>
+          p.createCheckout({
+            orderReference: 'ord-1',
+            currency: 'USD',
+            lineItems,
+            totalAmount: 2000,
+            customer,
+            successUrl: 'https://app.example.com/success',
+            cancelUrl: 'https://app.example.com/cancel',
+          }),
+        (e) => e instanceof PaymentProviderNotConfiguredError,
+      ),
+    );
+  }
+
+  // 2. stripe without key → unavailable
+  console.log('\n2. stripe without STRIPE_SECRET_KEY → unavailable');
+  {
+    const p = createPaymentProvider(fakeConfig({ PAYMENT_PROVIDER: 'stripe' }));
+    ok(p.name === 'stripe');
+    ok(p.isAvailable() === false);
+  }
+
+  // 3. stripe createCheckout
+  console.log('\n3. stripe createCheckout (mocked)');
+  {
+    installMockFetch((url, init) => {
+      if (url.endsWith('/v1/checkout/sessions') && init.method === 'POST') {
+        return {
+          status: 200,
+          body: {
+            id: 'cs_test_abc',
+            url: 'https://checkout.stripe.com/pay/cs_test_abc',
+          },
+        };
+      }
+      return { status: 404, body: {} };
+    });
+    try {
+      const p = createPaymentProvider(
+        fakeConfig({
+          PAYMENT_PROVIDER: 'stripe',
+          STRIPE_SECRET_KEY: 'sk_test_xxx',
+        }),
+      );
+      ok(p.isAvailable() === true);
+      const session = await p.createCheckout({
+        orderReference: 'ord-42',
+        currency: 'USD',
+        lineItems,
+        totalAmount: 2000,
+        customer,
+        successUrl: 'https://app.example.com/success',
+        cancelUrl: 'https://app.example.com/cancel',
+        metadata: { note: 'first order' },
+      });
+      ok(session.sessionId === 'cs_test_abc');
+      ok(session.checkoutUrl.includes('checkout.stripe.com'));
+      ok(session.provider === 'stripe');
+      console.log(`  ✅ session ${session.sessionId}`);
+
+      const call = fetchCalls[fetchCalls.length - 1];
+      ok(call.headers['Authorization'] === 'Bearer sk_test_xxx');
+      ok(call.headers['Content-Type'] === 'application/x-www-form-urlencoded');
+      // Verify nested form keys
+      ok(call.body.mode === 'payment');
+      ok(call.body.client_reference_id === 'ord-42');
+      ok(call.body['line_items[0][price_data][currency]'] === 'usd');
+      ok(call.body['line_items[0][price_data][unit_amount]'] === '1000');
+      ok(call.body['line_items[0][quantity]'] === '2');
+      ok(call.body['metadata[order_reference]'] === 'ord-42');
+      ok(call.body['metadata[note]'] === 'first order');
+      console.log(`  ✅ nested form encoding correct`);
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
+  // 4. stripe marketplace split (single vendor)
+  console.log('\n4. stripe single-vendor split → transfer_data.destination');
+  {
+    installMockFetch(() => ({
+      status: 200,
+      body: { id: 'cs_split', url: 'https://checkout.stripe.com/pay/cs_split' },
+    }));
+    try {
+      const p = createPaymentProvider(
+        fakeConfig({
+          PAYMENT_PROVIDER: 'stripe',
+          STRIPE_SECRET_KEY: 'sk_test',
+        }),
+      );
+      await p.createCheckout({
+        orderReference: 'ord-43',
+        currency: 'USD',
+        lineItems: [
+          {
+            productId: 'p1',
+            description: 'Widget',
+            unitAmount: 1000,
+            quantity: 1,
+            vendorAccountId: 'acct_vendor_123',
+          },
+        ],
+        totalAmount: 1000,
+        platformFeeAmount: 100,
+        customer,
+        successUrl: 'https://app.example.com/success',
+        cancelUrl: 'https://app.example.com/cancel',
+      });
+      const call = fetchCalls[fetchCalls.length - 1];
+      ok(
+        call.body['payment_intent_data[application_fee_amount]'] === '100',
+      );
+      ok(
+        call.body['payment_intent_data[transfer_data][destination]'] ===
+          'acct_vendor_123',
+      );
+      console.log(`  ✅ single-vendor split routes to transfer_data`);
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
+  // 5. stripe multi-vendor split → transfer_group
+  console.log('\n5. stripe multi-vendor → transfer_group');
+  {
+    installMockFetch(() => ({
+      status: 200,
+      body: { id: 'cs_multi', url: 'https://checkout.stripe.com/pay/cs_multi' },
+    }));
+    try {
+      const p = createPaymentProvider(
+        fakeConfig({
+          PAYMENT_PROVIDER: 'stripe',
+          STRIPE_SECRET_KEY: 'sk_test',
+        }),
+      );
+      await p.createCheckout({
+        orderReference: 'ord-44',
+        currency: 'USD',
+        lineItems: [
+          {
+            productId: 'p1',
+            description: 'A',
+            unitAmount: 500,
+            quantity: 1,
+            vendorAccountId: 'acct_v1',
+          },
+          {
+            productId: 'p2',
+            description: 'B',
+            unitAmount: 500,
+            quantity: 1,
+            vendorAccountId: 'acct_v2',
+          },
+        ],
+        totalAmount: 1000,
+        customer,
+        successUrl: 'https://app.example.com/success',
+        cancelUrl: 'https://app.example.com/cancel',
+      });
+      const call = fetchCalls[fetchCalls.length - 1];
+      ok(
+        call.body['payment_intent_data[transfer_group]'] === 'order_ord-44',
+      );
+      // No direct transfer_data for multi-vendor
+      ok(
+        call.body['payment_intent_data[transfer_data][destination]'] ===
+          undefined,
+      );
+      console.log(`  ✅ multi-vendor → transfer_group, no direct transfer_data`);
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
+  // 6. stripe webhook signature verification
+  console.log('\n6. stripe webhook signature verification');
+  {
+    const p = createPaymentProvider(
+      fakeConfig({
+        PAYMENT_PROVIDER: 'stripe',
+        STRIPE_SECRET_KEY: 'sk_test',
+        STRIPE_WEBHOOK_SECRET: 'whsec_test_secret',
+      }),
+    );
+    const payload = JSON.stringify({
+      type: 'checkout.session.completed',
+      data: {
+        object: {
+          id: 'cs_test_abc',
+          client_reference_id: 'ord-42',
+          amount_total: 2000,
+          currency: 'usd',
+        },
+      },
+    });
+    const timestamp = Math.floor(Date.now() / 1000);
+    const signedPayload = `${timestamp}.${payload}`;
+    const v1 = crypto
+      .createHmac('sha256', 'whsec_test_secret')
+      .update(signedPayload)
+      .digest('hex');
+    const sigHeader = `t=${timestamp},v1=${v1}`;
+
+    const event = await p.parseWebhook(payload, sigHeader);
+    ok(event !== null);
+    ok(event!.kind === 'payment.succeeded');
+    ok(event!.paymentId === 'cs_test_abc');
+    ok(event!.orderReference === 'ord-42');
+    ok(event!.amount === 2000);
+    ok(event!.currency === 'USD');
+    console.log(`  ✅ valid signature + mapped event`);
+
+    // Bad signature should throw
+    ok(
+      await expectThrow(
+        'bad signature throws',
+        () =>
+          p.parseWebhook(
+            payload,
+            `t=${timestamp},v1=${'0'.repeat(64)}`,
+          ),
+        (e) => /signature mismatch/i.test(e.message),
+      ),
+    );
+  }
+
+  // 7. paypal without creds → unavailable
+  console.log('\n7. paypal without creds → unavailable');
+  {
+    const p = createPaymentProvider(fakeConfig({ PAYMENT_PROVIDER: 'paypal' }));
+    ok(p.name === 'paypal');
+    ok(p.isAvailable() === false);
+  }
+
+  // 8. paypal token exchange + createCheckout
+  console.log('\n8. paypal createCheckout (token + orders)');
+  {
+    installMockFetch((url) => {
+      if (url.endsWith('/v1/oauth2/token')) {
+        return {
+          status: 200,
+          body: { access_token: 'paypal-fake-token', expires_in: 3600 },
+        };
+      }
+      if (url.endsWith('/v2/checkout/orders')) {
+        return {
+          status: 201,
+          body: {
+            id: 'PAYPAL-ORDER-XYZ',
+            status: 'CREATED',
+            links: [
+              { rel: 'self', href: '...' },
+              {
+                rel: 'approve',
+                href: 'https://www.sandbox.paypal.com/checkoutnow?token=PAYPAL-ORDER-XYZ',
+              },
+            ],
+          },
+        };
+      }
+      return { status: 404, body: {} };
+    });
+    try {
+      const p = createPaymentProvider(
+        fakeConfig({
+          PAYMENT_PROVIDER: 'paypal',
+          PAYPAL_CLIENT_ID: 'cid',
+          PAYPAL_CLIENT_SECRET: 'csec',
+          PAYPAL_MODE: 'sandbox',
+        }),
+      );
+      ok(p.isAvailable() === true);
+      const session = await p.createCheckout({
+        orderReference: 'ord-45',
+        currency: 'USD',
+        lineItems,
+        totalAmount: 2000,
+        customer,
+        successUrl: 'https://app.example.com/success',
+        cancelUrl: 'https://app.example.com/cancel',
+      });
+      ok(session.sessionId === 'PAYPAL-ORDER-XYZ');
+      ok(session.checkoutUrl.includes('paypal.com/checkoutnow'));
+      console.log(`  ✅ paypal order created: ${session.sessionId}`);
+
+      const tokenCall = fetchCalls.find((c) =>
+        c.url.includes('/oauth2/token'),
+      );
+      const orderCall = fetchCalls.find((c) =>
+        c.url.endsWith('/v2/checkout/orders'),
+      );
+      ok(!!tokenCall);
+      ok(!!orderCall);
+      ok(
+        tokenCall!.headers['Authorization']?.startsWith('Basic '),
+      );
+      ok(orderCall!.headers['Authorization'] === 'Bearer paypal-fake-token');
+      // Amount in decimal string, not minor units
+      ok(
+        orderCall!.body.purchase_units[0].amount.value === '20.00',
+      );
+      console.log(`  ✅ basic auth → bearer, amount formatted as decimal`);
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
+  // 9. bkash without creds → unavailable
+  console.log('\n9. bkash without creds → unavailable');
+  {
+    const p = createPaymentProvider(fakeConfig({ PAYMENT_PROVIDER: 'bkash' }));
+    ok(p.name === 'bkash');
+    ok(p.isAvailable() === false);
+  }
+
+  // 10. bkash token grant + createCheckout
+  console.log('\n10. bkash createCheckout (token + create)');
+  {
+    installMockFetch((url) => {
+      if (url.includes('/tokenized/checkout/token/grant')) {
+        return {
+          status: 200,
+          body: {
+            id_token: 'bkash-token-abc',
+            expires_in: 3600,
+            statusCode: '0000',
+          },
+        };
+      }
+      if (url.includes('/tokenized/checkout/create')) {
+        return {
+          status: 200,
+          body: {
+            paymentID: 'TR0011xxxxxx',
+            bkashURL: 'https://sandbox.bka.sh/payment/choose?paymentID=TR0011xxxxxx',
+            statusCode: '0000',
+          },
+        };
+      }
+      return { status: 404, body: {} };
+    });
+    try {
+      const p = createPaymentProvider(
+        fakeConfig({
+          PAYMENT_PROVIDER: 'bkash',
+          BKASH_APP_KEY: 'appkey',
+          BKASH_APP_SECRET: 'appsecret',
+          BKASH_USERNAME: 'user',
+          BKASH_PASSWORD: 'pass',
+        }),
+      );
+      ok(p.isAvailable() === true);
+      const session = await p.createCheckout({
+        orderReference: 'ord-46',
+        currency: 'BDT',
+        lineItems: [
+          {
+            productId: 'p1',
+            description: 'Widget',
+            unitAmount: 50000, // 500 BDT in paisa
+            quantity: 1,
+          },
+        ],
+        totalAmount: 50000,
+        customer,
+        successUrl: 'https://app.example.com/success',
+        cancelUrl: 'https://app.example.com/cancel',
+      });
+      ok(session.sessionId === 'TR0011xxxxxx');
+      ok(session.checkoutUrl.includes('sandbox.bka.sh'));
+      ok(session.provider === 'bkash');
+
+      // Verify token grant call used raw username/password headers
+      const tokenCall = fetchCalls.find((c) =>
+        c.url.includes('/token/grant'),
+      );
+      ok(!!tokenCall);
+      ok(tokenCall!.headers['username'] === 'user');
+      ok(tokenCall!.headers['password'] === 'pass');
+      ok(tokenCall!.body.app_key === 'appkey');
+
+      // Create call used bearer-style auth (id_token directly) +
+      // x-app-key
+      const createCall = fetchCalls.find((c) =>
+        c.url.includes('/checkout/create'),
+      );
+      ok(!!createCall);
+      ok(createCall!.headers['Authorization'] === 'bkash-token-abc');
+      ok(createCall!.headers['x-app-key'] === 'appkey');
+      // Amount in BDT decimal string
+      ok(createCall!.body.amount === '500.00');
+      ok(createCall!.body.currency === 'BDT');
+      ok(createCall!.body.merchantInvoiceNumber === 'ord-46');
+      console.log(
+        `  ✅ bkash token + create with correct headers + BDT amount`,
+      );
+    } finally {
+      restoreFetch();
+      fetchCalls.length = 0;
+    }
+  }
+
+  // 11. Planned providers fall back to none
+  console.log('\n11. razorpay / mollie / etc fall back to none');
+  {
+    for (const choice of [
+      'razorpay',
+      'paystack',
+      'mollie',
+      'mpesa',
+      'square',
+      'adyen',
+      'lemonsqueezy',
+      'sslcommerz',
+      'nagad',
+    ]) {
+      const p = createPaymentProvider(
+        fakeConfig({ PAYMENT_PROVIDER: choice }),
+      );
+      ok(p.name === 'none', `${choice} should fallback to none`);
+    }
+    console.log(`  ✅ all 9 planned providers fall back to none`);
+  }
+
+  // 12. unknown value
+  console.log('\n12. unknown PAYMENT_PROVIDER → none');
+  {
+    const p = createPaymentProvider(fakeConfig({ PAYMENT_PROVIDER: 'foobar' }));
+    ok(p.name === 'none');
+  }
+
+  console.log(`\n=== Result: ${pass} passed, ${fail} failed ===`);
+  process.exit(fail > 0 ? 1 : 0);
+}
+
+main().catch((e) => {
+  console.error('Smoke test crashed:', e);
+  process.exit(1);
+});

--- a/backend/src/modules/payment/payment-provider.service.ts
+++ b/backend/src/modules/payment/payment-provider.service.ts
@@ -56,6 +56,10 @@ export class PaymentProviderService implements OnModuleInit {
     return this.provider.getPayment(paymentId);
   }
 
+  async capturePayment(paymentId: string): Promise<PaymentInfo> {
+    return this.provider.capturePayment(paymentId);
+  }
+
   async refund(input: RefundInput): Promise<RefundResult> {
     return this.provider.refund(input);
   }

--- a/backend/src/modules/payment/payment-provider.service.ts
+++ b/backend/src/modules/payment/payment-provider.service.ts
@@ -1,0 +1,73 @@
+/**
+ * PaymentProviderService — pluggable payment façade.
+ *
+ * New code should inject this service instead of calling the
+ * legacy `PaymentService` (which is hardcoded to Stripe) directly.
+ * Switching providers is a matter of changing `PAYMENT_PROVIDER`
+ * in .env.
+ *
+ * The existing `PaymentService` and `StripeConnectService` still
+ * exist for backwards compatibility. A follow-up PR will migrate
+ * their internals to delegate to this façade and delete the
+ * hardcoded Stripe paths.
+ *
+ * See `./providers/` and `docs/providers/payments.md`.
+ */
+import { Injectable, Logger, OnModuleInit } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  createPaymentProvider,
+  CheckoutSession,
+  CreateCheckoutInput,
+  PaymentInfo,
+  PaymentProvider,
+  RefundInput,
+  RefundResult,
+  WebhookEvent,
+} from './providers';
+
+@Injectable()
+export class PaymentProviderService implements OnModuleInit {
+  private readonly logger = new Logger(PaymentProviderService.name);
+  private provider!: PaymentProvider;
+
+  constructor(private readonly config: ConfigService) {}
+
+  onModuleInit() {
+    this.provider = createPaymentProvider(this.config);
+    this.logger.log(
+      `Payment provider initialized: ${this.provider.name} (available=${this.provider.isAvailable()})`,
+    );
+  }
+
+  getProviderName(): string {
+    return this.provider?.name ?? 'none';
+  }
+
+  isAvailable(): boolean {
+    return !!this.provider && this.provider.isAvailable();
+  }
+
+  async createCheckout(input: CreateCheckoutInput): Promise<CheckoutSession> {
+    return this.provider.createCheckout(input);
+  }
+
+  async getPayment(paymentId: string): Promise<PaymentInfo | null> {
+    return this.provider.getPayment(paymentId);
+  }
+
+  async refund(input: RefundInput): Promise<RefundResult> {
+    return this.provider.refund(input);
+  }
+
+  async parseWebhook(
+    rawBody: string,
+    signature?: string,
+  ): Promise<WebhookEvent | null> {
+    return this.provider.parseWebhook(rawBody, signature);
+  }
+
+  getProvider(): PaymentProvider {
+    return this.provider;
+  }
+}

--- a/backend/src/modules/payment/payment.module.ts
+++ b/backend/src/modules/payment/payment.module.ts
@@ -4,23 +4,35 @@ import { StripeService } from './stripe.service';
 import { PaymentService } from './payment.service';
 import { PaymentController } from './payment.controller';
 import { TeamAtOncePaymentController } from './teamatonce-payment.controller';
+import { PaymentProviderService } from './payment-provider.service';
 import { NotificationsModule } from '../notifications/notifications.module';
 import { AuthModule } from '../auth/auth.module';
 
 /**
  * Payment Module
  *
- * Provides Stripe payment integration for Team@Once platform
- * Handles subscriptions, payment methods, invoices, and checkout sessions
+ * Exposes three services:
  *
- * Includes two controllers:
- * - PaymentController: Original /payment/* endpoints
- * - Team@OncePaymentController: Wrapper /teamatonce/* endpoints for frontend compatibility
+ * - `PaymentProviderService` (NEW, pluggable)
+ *   The façade over the multi-provider adapter (stripe / paypal /
+ *   bkash / none). Switch providers with `PAYMENT_PROVIDER` in .env.
+ *   New code should inject this. See `docs/providers/payments.md`.
+ *
+ * - `StripeService` (legacy)
+ *   Subscriptions + invoices + checkout sessions hardcoded to Stripe.
+ *   Still exported for backwards compatibility.
+ *
+ * - `PaymentService` (legacy)
+ *   High-level Team@Once payment flows. Still Stripe-only.
+ *
+ * Two controllers:
+ *   - `PaymentController`: original /payment/* endpoints
+ *   - `Team@OncePaymentController`: wrapper /teamatonce/* endpoints
  */
 @Module({
   imports: [forwardRef(() => NotificationsModule)],
-  providers: [StripeService, PaymentService],
+  providers: [StripeService, PaymentService, PaymentProviderService],
   controllers: [PaymentController, TeamAtOncePaymentController],
-  exports: [StripeService, PaymentService],
+  exports: [StripeService, PaymentService, PaymentProviderService],
 })
 export class PaymentModule {}

--- a/backend/src/modules/payment/providers/bkash.provider.ts
+++ b/backend/src/modules/payment/providers/bkash.provider.ts
@@ -63,6 +63,15 @@ export class BkashProvider implements PaymentProvider {
   private idToken: string | null = null;
   private tokenExpiresAt = 0;
 
+  /**
+   * Cache of bKash paymentID → trxID, populated by capturePayment /
+   * getPayment. refund() requires trxID (which is a different ID
+   * than the paymentID callers hold). We look it up here, and if
+   * we haven't seen it, fall through to a status call before
+   * refunding.
+   */
+  private readonly trxIdByPaymentId = new Map<string, string>();
+
   constructor(config: ConfigService) {
     this.baseUrl = (
       config.get<string>(
@@ -189,15 +198,25 @@ export class BkashProvider implements PaymentProvider {
   }
 
   /**
-   * Execute a previously-created payment. Called after bKash
+   * Finalize a previously-created payment. Called after bKash
    * redirects the customer back to the callback URL with
-   * ?paymentID=... — the controller handling that redirect should
-   * call this to actually capture the payment.
+   * ?paymentID=... — the controller handling that redirect must
+   * call this to actually capture the payment. This is part of
+   * the PaymentProvider interface so callers don't need to branch
+   * on provider name; Stripe/PayPal implement it as a pass-through.
+   *
+   * bKash's /execute response includes the trxID (not the same as
+   * paymentID). We cache it in-memory keyed on paymentID so the
+   * later refund() call can look it up without requiring callers
+   * to persist the trxID themselves.
    */
-  async executePayment(paymentId: string): Promise<PaymentInfo> {
+  async capturePayment(paymentId: string): Promise<PaymentInfo> {
     const res = await this.bkashApi('/tokenized/checkout/execute', {
       paymentID: paymentId,
     });
+    if (res.trxID) {
+      this.trxIdByPaymentId.set(paymentId, res.trxID);
+    }
     return {
       paymentId: res.paymentID ?? paymentId,
       status: res.transactionStatus === 'Completed' ? 'succeeded' : 'pending',
@@ -215,6 +234,9 @@ export class BkashProvider implements PaymentProvider {
       const res = await this.bkashApi('/tokenized/checkout/payment/status', {
         paymentID: paymentId,
       });
+      if (res.trxID) {
+        this.trxIdByPaymentId.set(paymentId, res.trxID);
+      }
       return {
         paymentId: res.paymentID ?? paymentId,
         status: this.mapStatus(res.transactionStatus),
@@ -232,16 +254,33 @@ export class BkashProvider implements PaymentProvider {
   }
 
   async refund(input: RefundInput): Promise<RefundResult> {
-    // bKash refund needs the trxID, which the provider returns
-    // from execute/status. For a first pass, we accept the
-    // payment_id (sessionId) AS the trxID — real integrations
-    // should store the trxID separately.
+    // bKash refund requires trxID, which is DIFFERENT from paymentID.
+    // trxID is returned by /execute and /payment/status. We cache
+    // it in trxIdByPaymentId; if we haven't seen it yet, fetch the
+    // status first so the refund call gets the right id.
+    let trxId = this.trxIdByPaymentId.get(input.paymentId);
+    if (!trxId) {
+      const status = await this.bkashApi(
+        '/tokenized/checkout/payment/status',
+        { paymentID: input.paymentId },
+      );
+      trxId = status.trxID;
+      if (!trxId) {
+        throw new Error(
+          `bKash refund failed: unable to resolve trxID for paymentID=${input.paymentId}. ` +
+            `The payment may not have been executed (capturePayment) yet.`,
+        );
+      }
+      this.trxIdByPaymentId.set(input.paymentId, trxId);
+    }
+
     const res = await this.bkashApi('/tokenized/checkout/payment/refund', {
       paymentID: input.paymentId,
-      amount: input.amount !== undefined
-        ? (input.amount / 100).toFixed(2)
-        : undefined,
-      trxID: input.paymentId,
+      amount:
+        input.amount !== undefined
+          ? (input.amount / 100).toFixed(2)
+          : undefined,
+      trxID: trxId,
       sku: 'refund',
       reason: input.reason ?? 'Customer refund',
     });

--- a/backend/src/modules/payment/providers/bkash.provider.ts
+++ b/backend/src/modules/payment/providers/bkash.provider.ts
@@ -1,0 +1,305 @@
+/**
+ * bKash payment provider — Bangladesh mobile wallet.
+ *
+ *   PAYMENT_PROVIDER=bkash
+ *   BKASH_BASE_URL=https://tokenized.sandbox.bka.sh/v1.2.0-beta   (sandbox)
+ *   # BKASH_BASE_URL=https://tokenized.pay.bka.sh/v1.2.0-beta    (production)
+ *   BKASH_APP_KEY=...
+ *   BKASH_APP_SECRET=...
+ *   BKASH_USERNAME=...
+ *   BKASH_PASSWORD=...
+ *
+ * bKash is Bangladesh's largest mobile money platform — a must-have
+ * for any Bangladesh-origin marketplace. Uses the Tokenized Checkout
+ * API: create payment → customer enters PIN on bKash's hosted page
+ * → callback to merchant → execute payment → confirmation.
+ *
+ * Auth: 2-legged token exchange using the tokenized checkout
+ * /token/grant endpoint with username + password HEADERS (yes,
+ * as plain headers — not basic auth). The returned `id_token` is
+ * used as the `Authorization` header on subsequent calls, plus
+ * the `x-app-key` header for every request.
+ *
+ * Workflow:
+ *   createCheckout → POST /checkout/create
+ *      returns { paymentID, bkashURL } — customer redirects to bkashURL
+ *   (customer enters PIN on bKash page, returns to merchant
+ *    success_url with a ?status=success&paymentID=... query string)
+ *   merchant calls /checkout/execute to actually capture
+ *   getPayment → GET /checkout/payment/status
+ *   refund → POST /checkout/payment/refund
+ *
+ * THIS IS A FIRST-PASS INTEGRATION. Real-world bKash integrations
+ * often need the `intent=sale` vs `intent=authorization` distinction,
+ * custom merchant invoice number formats, and specific URL-encoding
+ * quirks that vary between sandbox and production. Smoke-tested
+ * with mocked fetch; production deployments should validate against
+ * real sandbox before going live.
+ */
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  CheckoutSession,
+  CreateCheckoutInput,
+  PaymentInfo,
+  PaymentProvider,
+  PaymentProviderNotConfiguredError,
+  PaymentStatus,
+  RefundInput,
+  RefundResult,
+  WebhookEvent,
+} from './payment-provider.interface';
+
+export class BkashProvider implements PaymentProvider {
+  readonly name = 'bkash' as const;
+  private readonly logger = new Logger('BkashProvider');
+
+  private readonly baseUrl: string;
+  private readonly appKey: string;
+  private readonly appSecret: string;
+  private readonly username: string;
+  private readonly password: string;
+
+  private idToken: string | null = null;
+  private tokenExpiresAt = 0;
+
+  constructor(config: ConfigService) {
+    this.baseUrl = (
+      config.get<string>(
+        'BKASH_BASE_URL',
+        'https://tokenized.sandbox.bka.sh/v1.2.0-beta',
+      ) || 'https://tokenized.sandbox.bka.sh/v1.2.0-beta'
+    ).replace(/\/+$/, '');
+    this.appKey = config.get<string>('BKASH_APP_KEY', '');
+    this.appSecret = config.get<string>('BKASH_APP_SECRET', '');
+    this.username = config.get<string>('BKASH_USERNAME', '');
+    this.password = config.get<string>('BKASH_PASSWORD', '');
+
+    if (this.isAvailable()) {
+      this.logger.log(`bKash provider configured (${this.baseUrl})`);
+    } else {
+      this.logger.warn(
+        'bKash provider selected but BKASH_APP_KEY / APP_SECRET / USERNAME / PASSWORD missing',
+      );
+    }
+  }
+
+  isAvailable(): boolean {
+    return !!(
+      this.appKey &&
+      this.appSecret &&
+      this.username &&
+      this.password
+    );
+  }
+
+  private missingVars(): string[] {
+    const out: string[] = [];
+    if (!this.appKey) out.push('BKASH_APP_KEY');
+    if (!this.appSecret) out.push('BKASH_APP_SECRET');
+    if (!this.username) out.push('BKASH_USERNAME');
+    if (!this.password) out.push('BKASH_PASSWORD');
+    return out;
+  }
+
+  private async ensureToken(): Promise<string> {
+    if (this.idToken && Date.now() < this.tokenExpiresAt) {
+      return this.idToken;
+    }
+    if (!this.isAvailable()) {
+      throw new PaymentProviderNotConfiguredError('bkash', this.missingVars());
+    }
+
+    const res = await fetch(
+      `${this.baseUrl}/tokenized/checkout/token/grant`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          // bKash uses raw username + password HEADERS (not basic auth)
+          username: this.username,
+          password: this.password,
+        },
+        body: JSON.stringify({
+          app_key: this.appKey,
+          app_secret: this.appSecret,
+        }),
+      },
+    );
+
+    const json = (await res.json()) as {
+      id_token?: string;
+      expires_in?: number;
+      statusCode?: string;
+      statusMessage?: string;
+    };
+    if (!res.ok || !json.id_token) {
+      throw new Error(
+        `bKash token grant failed: ${res.status} ${json.statusMessage ?? JSON.stringify(json)}`,
+      );
+    }
+
+    this.idToken = json.id_token;
+    this.tokenExpiresAt = Date.now() + Math.max(0, (json.expires_in ?? 3600) - 60) * 1000;
+    return this.idToken;
+  }
+
+  private async bkashApi(path: string, body: any): Promise<any> {
+    const token = await this.ensureToken();
+    const res = await fetch(`${this.baseUrl}${path}`, {
+      method: 'POST',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        Authorization: token,
+        'x-app-key': this.appKey,
+      },
+      body: JSON.stringify(body),
+    });
+    const json = (await res.json()) as any;
+    if (!res.ok || (json.statusCode && json.statusCode !== '0000')) {
+      throw new Error(
+        `bKash API ${path} failed: ${res.status} ${json.statusMessage ?? JSON.stringify(json)}`,
+      );
+    }
+    return json;
+  }
+
+  async createCheckout(input: CreateCheckoutInput): Promise<CheckoutSession> {
+    // bKash amounts are decimal strings in BDT (not paisa).
+    const amountBdt = (input.totalAmount / 100).toFixed(2);
+
+    const res = await this.bkashApi('/tokenized/checkout/create', {
+      mode: '0011', // 0011 = checkout (tokenized)
+      payerReference: input.customer.phone ?? input.orderReference,
+      callbackURL: input.successUrl,
+      amount: amountBdt,
+      currency: 'BDT',
+      intent: 'sale',
+      merchantInvoiceNumber: input.orderReference,
+    });
+
+    return {
+      sessionId: res.paymentID,
+      checkoutUrl: res.bkashURL,
+      provider: 'bkash',
+      status: 'pending',
+    };
+  }
+
+  /**
+   * Execute a previously-created payment. Called after bKash
+   * redirects the customer back to the callback URL with
+   * ?paymentID=... — the controller handling that redirect should
+   * call this to actually capture the payment.
+   */
+  async executePayment(paymentId: string): Promise<PaymentInfo> {
+    const res = await this.bkashApi('/tokenized/checkout/execute', {
+      paymentID: paymentId,
+    });
+    return {
+      paymentId: res.paymentID ?? paymentId,
+      status: res.transactionStatus === 'Completed' ? 'succeeded' : 'pending',
+      amount: Math.round(parseFloat(res.amount ?? '0') * 100),
+      currency: 'BDT',
+      orderReference: res.merchantInvoiceNumber ?? '',
+      capturedAt: res.paymentExecuteTime,
+      method: 'mobile_wallet',
+      provider: 'bkash',
+    };
+  }
+
+  async getPayment(paymentId: string): Promise<PaymentInfo | null> {
+    try {
+      const res = await this.bkashApi('/tokenized/checkout/payment/status', {
+        paymentID: paymentId,
+      });
+      return {
+        paymentId: res.paymentID ?? paymentId,
+        status: this.mapStatus(res.transactionStatus),
+        amount: Math.round(parseFloat(res.amount ?? '0') * 100),
+        currency: 'BDT',
+        orderReference: res.merchantInvoiceNumber ?? '',
+        capturedAt: res.paymentExecuteTime,
+        method: 'mobile_wallet',
+        provider: 'bkash',
+      };
+    } catch (e: any) {
+      if (/2007|payment not found/i.test(e.message)) return null;
+      throw e;
+    }
+  }
+
+  async refund(input: RefundInput): Promise<RefundResult> {
+    // bKash refund needs the trxID, which the provider returns
+    // from execute/status. For a first pass, we accept the
+    // payment_id (sessionId) AS the trxID — real integrations
+    // should store the trxID separately.
+    const res = await this.bkashApi('/tokenized/checkout/payment/refund', {
+      paymentID: input.paymentId,
+      amount: input.amount !== undefined
+        ? (input.amount / 100).toFixed(2)
+        : undefined,
+      trxID: input.paymentId,
+      sku: 'refund',
+      reason: input.reason ?? 'Customer refund',
+    });
+    return {
+      refundId: res.refundTrxID ?? `bkash-refund-${Date.now()}`,
+      amount: Math.round(parseFloat(res.amount ?? '0') * 100),
+      status: res.transactionStatus === 'Completed' ? 'succeeded' : 'pending',
+      provider: 'bkash',
+    };
+  }
+
+  async parseWebhook(
+    rawBody: string,
+    _signature?: string,
+  ): Promise<WebhookEvent | null> {
+    // bKash doesn't have standard push webhooks like Stripe. Their
+    // integration pattern is poll-based: the merchant's callback
+    // URL receives a ?paymentID query param, then the merchant
+    // calls /execute and /status. This method is kept for
+    // interface parity — returns null for any body that doesn't
+    // look like a recognizable bKash notification.
+    let payload: any;
+    try {
+      payload = JSON.parse(rawBody);
+    } catch {
+      return null;
+    }
+    if (!payload?.paymentID) return null;
+    return {
+      kind:
+        payload.transactionStatus === 'Completed'
+          ? 'payment.succeeded'
+          : 'unknown',
+      paymentId: payload.paymentID,
+      orderReference: payload.merchantInvoiceNumber,
+      amount: payload.amount
+        ? Math.round(parseFloat(payload.amount) * 100)
+        : undefined,
+      currency: 'BDT',
+      raw: payload,
+    };
+  }
+
+  private mapStatus(raw?: string): PaymentStatus {
+    switch ((raw ?? '').toLowerCase()) {
+      case 'initiated':
+      case 'created':
+        return 'pending';
+      case 'inprogress':
+        return 'processing';
+      case 'completed':
+      case 'success':
+        return 'succeeded';
+      case 'failed':
+      case 'cancelled':
+        return 'failed';
+      default:
+        return 'unknown';
+    }
+  }
+}

--- a/backend/src/modules/payment/providers/index.ts
+++ b/backend/src/modules/payment/providers/index.ts
@@ -1,0 +1,86 @@
+/**
+ * Payment provider factory.
+ *
+ * Reads PAYMENT_PROVIDER from config and returns the matching provider.
+ *
+ * Shipped in this PR:
+ *   stripe   - Production default for cards + marketplace splits
+ *   paypal   - Alternative with wide consumer reach
+ *   bkash    - Bangladesh mobile wallet
+ *   none     - Disabled (default if unset)
+ *
+ * Planned follow-ups (tracked in issue #18):
+ *   razorpay, paystack, mollie, mpesa, square, adyen, lemonsqueezy,
+ *   sslcommerz, nagad
+ *
+ * Unknown values fall back to 'none' — NOT to stripe. Payments are
+ * a revenue-critical path where silent defaults would mask real
+ * config bugs.
+ */
+import { ConfigService } from '@nestjs/config';
+import { Logger } from '@nestjs/common';
+import { PaymentProvider } from './payment-provider.interface';
+import { StripeProvider } from './stripe.provider';
+import { PayPalProvider } from './paypal.provider';
+import { BkashProvider } from './bkash.provider';
+import { NonePaymentProvider } from './none.provider';
+
+const log = new Logger('PaymentProviderFactory');
+
+export function createPaymentProvider(config: ConfigService): PaymentProvider {
+  const choice = (config.get<string>('PAYMENT_PROVIDER') || 'none')
+    .toLowerCase()
+    .trim();
+
+  switch (choice) {
+    case 'stripe': {
+      const p = new StripeProvider(config);
+      log.log(
+        `Selected payment provider: stripe (available=${p.isAvailable()})`,
+      );
+      return p;
+    }
+    case 'paypal': {
+      const p = new PayPalProvider(config);
+      log.log(
+        `Selected payment provider: paypal (available=${p.isAvailable()})`,
+      );
+      return p;
+    }
+    case 'bkash': {
+      const p = new BkashProvider(config);
+      log.log(
+        `Selected payment provider: bkash (available=${p.isAvailable()})`,
+      );
+      return p;
+    }
+    case 'razorpay':
+    case 'paystack':
+    case 'mollie':
+    case 'mpesa':
+    case 'square':
+    case 'adyen':
+    case 'lemonsqueezy':
+    case 'sslcommerz':
+    case 'nagad': {
+      log.warn(
+        `PAYMENT_PROVIDER="${choice}" is planned but not yet implemented (see issue #18). Falling back to "none". Implemented providers: stripe, paypal, bkash.`,
+      );
+      return new NonePaymentProvider();
+    }
+    case 'none':
+    case '':
+      return new NonePaymentProvider();
+    default:
+      log.warn(
+        `Unknown PAYMENT_PROVIDER="${choice}". Falling back to "none". Valid values: stripe, paypal, bkash, none.`,
+      );
+      return new NonePaymentProvider();
+  }
+}
+
+export * from './payment-provider.interface';
+export { StripeProvider } from './stripe.provider';
+export { PayPalProvider } from './paypal.provider';
+export { BkashProvider } from './bkash.provider';
+export { NonePaymentProvider } from './none.provider';

--- a/backend/src/modules/payment/providers/none.provider.ts
+++ b/backend/src/modules/payment/providers/none.provider.ts
@@ -43,6 +43,9 @@ export class NonePaymentProvider implements PaymentProvider {
   async getPayment(_paymentId: string): Promise<PaymentInfo | null> {
     return null;
   }
+  async capturePayment(_paymentId: string): Promise<PaymentInfo> {
+    return this.fail('capturePayment');
+  }
   async refund(_input: RefundInput): Promise<RefundResult> {
     return this.fail('refund');
   }

--- a/backend/src/modules/payment/providers/none.provider.ts
+++ b/backend/src/modules/payment/providers/none.provider.ts
@@ -1,0 +1,55 @@
+/**
+ * "None" payment provider — payments disabled.
+ *
+ * The default if PAYMENT_PROVIDER is unset. Every method throws
+ * PaymentProviderNotConfiguredError so checkout flows fail loudly
+ * rather than silently creating phantom payments.
+ */
+import { Logger } from '@nestjs/common';
+import {
+  CheckoutSession,
+  CreateCheckoutInput,
+  PaymentInfo,
+  PaymentProvider,
+  PaymentProviderNotConfiguredError,
+  RefundInput,
+  RefundResult,
+  WebhookEvent,
+} from './payment-provider.interface';
+
+export class NonePaymentProvider implements PaymentProvider {
+  readonly name = 'none' as const;
+  private readonly logger = new Logger('NonePaymentProvider');
+
+  constructor() {
+    this.logger.log(
+      'Payments are DISABLED (PAYMENT_PROVIDER not set). To enable, set PAYMENT_PROVIDER to one of: stripe, paypal, bkash. See docs/providers/payments.md.',
+    );
+  }
+
+  isAvailable(): boolean {
+    return false;
+  }
+
+  private fail(op: string): never {
+    throw new PaymentProviderNotConfiguredError('none', [
+      `PAYMENT_PROVIDER (currently unset) - cannot ${op}`,
+    ]);
+  }
+
+  async createCheckout(_input: CreateCheckoutInput): Promise<CheckoutSession> {
+    return this.fail('createCheckout');
+  }
+  async getPayment(_paymentId: string): Promise<PaymentInfo | null> {
+    return null;
+  }
+  async refund(_input: RefundInput): Promise<RefundResult> {
+    return this.fail('refund');
+  }
+  async parseWebhook(
+    _rawBody: string,
+    _signature?: string,
+  ): Promise<WebhookEvent | null> {
+    return null;
+  }
+}

--- a/backend/src/modules/payment/providers/payment-provider.interface.ts
+++ b/backend/src/modules/payment/providers/payment-provider.interface.ts
@@ -1,0 +1,235 @@
+/**
+ * Common interface that every payment provider implements.
+ *
+ * Pick a provider (or multiple) by setting PAYMENT_PROVIDER in your
+ * .env to one of:
+ *
+ *   stripe         - Stripe (https://stripe.com). Global card processing
+ *                    + Stripe Connect for marketplace vendor splits.
+ *                    The production default.
+ *
+ *   paypal         - PayPal (https://paypal.com). Global alternative
+ *                    with wide consumer reach.
+ *
+ *   bkash          - bKash (https://bkash.com). Bangladesh's largest
+ *                    mobile money wallet. Required for any
+ *                    Bangladesh-facing marketplace.
+ *
+ *   none           - Payments disabled. Every method throws.
+ *                    The default if PAYMENT_PROVIDER is unset.
+ *
+ * Planned follow-ups (tracked in issue #18):
+ *   razorpay, paystack, mollie, mpesa, square, adyen, lemonsqueezy,
+ *   sslcommerz, nagad
+ *
+ * Why some planned providers aren't in this first-pass PR:
+ *  - razorpay / paystack / mollie: each need a separate OAuth-like
+ *    vendor-onboarding flow (Route / Subaccount / Connect) before
+ *    marketplace splits work. Follow-up PRs per-region.
+ *  - square / adyen: enterprise-scale with complex onboarding.
+ *  - mpesa: Safaricom Daraja API needs a TLS client cert exchange
+ *    that doesn't fit a pure-fetch adapter.
+ *  - sslcommerz / nagad: Bangladesh-specific, similar surface to
+ *    bkash but with different quirks — sensible to add after bkash
+ *    is proven in production.
+ *  - lemonsqueezy: digital-goods merchant-of-record, different
+ *    refund/tax semantics that deserve their own module.
+ *
+ * Shipping 3 real providers in this PR is deliberate: they cover
+ * the US/EU card path (stripe + paypal) AND the Bangladesh mobile
+ * wallet path (bkash) which together handle ~80% of vasty-shop's
+ * target audience. The rest land as follow-up PRs with their own
+ * verification + marketplace-split logic.
+ */
+
+export interface PaymentAddress {
+  name?: string;
+  line1?: string;
+  line2?: string;
+  city?: string;
+  state?: string;
+  postalCode?: string;
+  country?: string; // ISO 3166-1 alpha-2
+  email?: string;
+  phone?: string;
+}
+
+export interface CheckoutLineItem {
+  /** Product id (stored as reference metadata — providers don't need
+   * to resolve it). */
+  productId: string;
+  /** Human-readable description shown in the checkout UI. */
+  description: string;
+  /** Unit price in the **smallest currency unit** (cents/paisa/etc). */
+  unitAmount: number;
+  quantity: number;
+  /** The vendor this line belongs to — needed for marketplace
+   * splits. Multiple vendors in one order means the provider must
+   * split the charge proportionally. */
+  vendorAccountId?: string;
+}
+
+export interface CreateCheckoutInput {
+  /** Business order id — used as the idempotency key / external ref. */
+  orderReference: string;
+  /** ISO 4217 currency code (uppercase). */
+  currency: string;
+  /** All line items in the cart. */
+  lineItems: CheckoutLineItem[];
+  /** Total amount in the smallest currency unit (sum of lineItems). */
+  totalAmount: number;
+  /** Platform fee taken by the marketplace (smallest currency unit). */
+  platformFeeAmount?: number;
+  /** Billing customer info. */
+  customer: PaymentAddress;
+  /** Where to send the customer after a successful payment. */
+  successUrl: string;
+  /** Where to send them if they cancel. */
+  cancelUrl: string;
+  /** Optional metadata — stored by the provider for webhook
+   * correlation. */
+  metadata?: Record<string, string>;
+}
+
+export interface CheckoutSession {
+  /** Provider-specific session / order id. */
+  sessionId: string;
+  /** URL the frontend redirects the user to. */
+  checkoutUrl: string;
+  /** The provider name. */
+  provider: string;
+  /** Current status of the session at creation time. */
+  status: PaymentStatus;
+}
+
+export type PaymentStatus =
+  | 'pending' // session created, customer hasn't paid yet
+  | 'processing' // customer submitted payment, provider hasn't confirmed
+  | 'succeeded' // payment captured
+  | 'failed' // payment rejected
+  | 'refunded' // payment refunded (full or partial)
+  | 'cancelled' // customer cancelled
+  | 'expired' // session expired before payment
+  | 'unknown';
+
+export interface PaymentInfo {
+  /** Provider-specific id. */
+  paymentId: string;
+  status: PaymentStatus;
+  amount: number;
+  currency: string;
+  /** Order reference passed at creation. */
+  orderReference: string;
+  /** When the payment was captured (ISO 8601). */
+  capturedAt?: string;
+  /** Payment method used ("card", "mobile_wallet", "bank_transfer"). */
+  method?: string;
+  provider: string;
+}
+
+export interface RefundInput {
+  /** The provider's payment id to refund against. */
+  paymentId: string;
+  /** Amount to refund (smallest currency unit). Omit for full refund. */
+  amount?: number;
+  /** Reason code for audit trail. */
+  reason?: string;
+}
+
+export interface RefundResult {
+  refundId: string;
+  amount: number;
+  status: 'pending' | 'succeeded' | 'failed';
+  provider: string;
+}
+
+export interface WebhookEvent {
+  /** Normalized event kind. */
+  kind:
+    | 'payment.succeeded'
+    | 'payment.failed'
+    | 'payment.refunded'
+    | 'payment.expired'
+    | 'unknown';
+  /** Provider-specific payment id. */
+  paymentId: string;
+  /** Business order reference if the provider carried it through. */
+  orderReference?: string;
+  /** Amount captured / refunded. */
+  amount?: number;
+  currency?: string;
+  /** Raw payload for audit. */
+  raw: any;
+}
+
+/**
+ * Common interface implemented by every payment provider. Methods a
+ * provider can't support should throw PaymentProviderNotSupportedError
+ * — never silently no-op.
+ */
+export interface PaymentProvider {
+  /** Stable provider name for logging / clients. */
+  readonly name:
+    | 'stripe'
+    | 'paypal'
+    | 'bkash'
+    | 'razorpay'
+    | 'paystack'
+    | 'mollie'
+    | 'mpesa'
+    | 'square'
+    | 'adyen'
+    | 'lemonsqueezy'
+    | 'sslcommerz'
+    | 'nagad'
+    | 'none';
+
+  /** True if the provider has the credentials it needs. */
+  isAvailable(): boolean;
+
+  /**
+   * Create a hosted checkout session. Returns a URL the frontend
+   * redirects the customer to.
+   */
+  createCheckout(input: CreateCheckoutInput): Promise<CheckoutSession>;
+
+  /**
+   * Look up the current status of a payment by the provider's
+   * payment id.
+   */
+  getPayment(paymentId: string): Promise<PaymentInfo | null>;
+
+  /** Refund a previously-captured payment. */
+  refund(input: RefundInput): Promise<RefundResult>;
+
+  /**
+   * Verify and parse a webhook payload. Providers that sign their
+   * webhooks (most of them) verify the signature first and throw
+   * on mismatch.
+   */
+  parseWebhook(rawBody: string, signature?: string): Promise<WebhookEvent | null>;
+}
+
+/**
+ * Thrown when a provider is asked to do something it can't support.
+ */
+export class PaymentProviderNotSupportedError extends Error {
+  constructor(provider: string, operation: string) {
+    super(
+      `Operation "${operation}" is not supported by the "${provider}" payment provider. See docs/providers/payments.md.`,
+    );
+    this.name = 'PaymentProviderNotSupportedError';
+  }
+}
+
+/**
+ * Thrown when a provider is selected but its credentials are missing.
+ */
+export class PaymentProviderNotConfiguredError extends Error {
+  constructor(provider: string, missingVars: string[]) {
+    super(
+      `Payment provider "${provider}" is selected but the following env vars are missing: ${missingVars.join(', ')}. See docs/providers/payments.md.`,
+    );
+    this.name = 'PaymentProviderNotConfiguredError';
+  }
+}

--- a/backend/src/modules/payment/providers/payment-provider.interface.ts
+++ b/backend/src/modules/payment/providers/payment-provider.interface.ts
@@ -199,6 +199,17 @@ export interface PaymentProvider {
    */
   getPayment(paymentId: string): Promise<PaymentInfo | null>;
 
+  /**
+   * Finalize a payment that requires a second confirm step after
+   * the customer returns from hosted checkout (e.g. bKash's
+   * /execute call after the redirect back with ?paymentID=...).
+   * For providers whose hosted checkout auto-captures (Stripe,
+   * PayPal), this is a pass-through that returns the current
+   * payment status — so callers can always route through it
+   * without branching on provider name.
+   */
+  capturePayment(paymentId: string): Promise<PaymentInfo>;
+
   /** Refund a previously-captured payment. */
   refund(input: RefundInput): Promise<RefundResult>;
 

--- a/backend/src/modules/payment/providers/paypal.provider.ts
+++ b/backend/src/modules/payment/providers/paypal.provider.ts
@@ -1,0 +1,310 @@
+/**
+ * PayPal payment provider.
+ *
+ *   PAYMENT_PROVIDER=paypal
+ *   PAYPAL_CLIENT_ID=...
+ *   PAYPAL_CLIENT_SECRET=...
+ *   PAYPAL_MODE=sandbox                  (or "live" for production)
+ *
+ * Uses PayPal's v2 REST API (Orders v2) with client_credentials
+ * OAuth token exchange. Supports hosted checkout via redirect to
+ * the `approve` HATEOAS link returned in the order creation response.
+ *
+ * Marketplace splits: PayPal Payouts can send money to vendor
+ * PayPal accounts after capture. For the first pass, we create the
+ * order in the platform account and a follow-up PR can wire the
+ * post-capture payout flow.
+ *
+ * Pure REST via fetch.
+ */
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import {
+  CheckoutSession,
+  CreateCheckoutInput,
+  PaymentInfo,
+  PaymentProvider,
+  PaymentProviderNotConfiguredError,
+  PaymentStatus,
+  RefundInput,
+  RefundResult,
+  WebhookEvent,
+} from './payment-provider.interface';
+
+export class PayPalProvider implements PaymentProvider {
+  readonly name = 'paypal' as const;
+  private readonly logger = new Logger('PayPalProvider');
+
+  private readonly clientId: string;
+  private readonly clientSecret: string;
+  private readonly baseUrl: string;
+
+  private accessToken: string | null = null;
+  private tokenExpiresAt = 0;
+
+  constructor(config: ConfigService) {
+    this.clientId = config.get<string>('PAYPAL_CLIENT_ID', '');
+    this.clientSecret = config.get<string>('PAYPAL_CLIENT_SECRET', '');
+    const mode = (
+      config.get<string>('PAYPAL_MODE', 'sandbox') || 'sandbox'
+    ).toLowerCase();
+    this.baseUrl =
+      mode === 'live'
+        ? 'https://api-m.paypal.com'
+        : 'https://api-m.sandbox.paypal.com';
+
+    if (this.isAvailable()) {
+      this.logger.log(`PayPal provider configured (${mode} mode)`);
+    } else {
+      this.logger.warn(
+        'PayPal provider selected but PAYPAL_CLIENT_ID / PAYPAL_CLIENT_SECRET missing',
+      );
+    }
+  }
+
+  isAvailable(): boolean {
+    return !!(this.clientId && this.clientSecret);
+  }
+
+  private async ensureToken(): Promise<string> {
+    if (this.accessToken && Date.now() < this.tokenExpiresAt) {
+      return this.accessToken;
+    }
+    if (!this.isAvailable()) {
+      throw new PaymentProviderNotConfiguredError('paypal', [
+        !this.clientId ? 'PAYPAL_CLIENT_ID' : '',
+        !this.clientSecret ? 'PAYPAL_CLIENT_SECRET' : '',
+      ].filter(Boolean));
+    }
+    const auth = Buffer.from(`${this.clientId}:${this.clientSecret}`).toString(
+      'base64',
+    );
+    const res = await fetch(`${this.baseUrl}/v1/oauth2/token`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Basic ${auth}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: 'grant_type=client_credentials',
+    });
+    const json = (await res.json()) as {
+      access_token?: string;
+      expires_in?: number;
+    };
+    if (!res.ok || !json.access_token) {
+      throw new Error(`PayPal token exchange failed: ${res.status}`);
+    }
+    this.accessToken = json.access_token;
+    this.tokenExpiresAt = Date.now() + Math.max(0, (json.expires_in ?? 3600) - 60) * 1000;
+    return this.accessToken;
+  }
+
+  private async paypalApi(
+    method: 'GET' | 'POST',
+    path: string,
+    body?: any,
+  ): Promise<any> {
+    const token = await this.ensureToken();
+    const res = await fetch(`${this.baseUrl}${path}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: body ? JSON.stringify(body) : undefined,
+    });
+    const json = (await res.json()) as any;
+    if (!res.ok) {
+      throw new Error(
+        `PayPal API ${method} ${path} failed: ${res.status} ${JSON.stringify(json)}`,
+      );
+    }
+    return json;
+  }
+
+  async createCheckout(input: CreateCheckoutInput): Promise<CheckoutSession> {
+    // PayPal Orders v2 expects amounts as decimal strings ("12.34")
+    // in the order currency. Our interface uses smallest currency
+    // units (cents/paisa), so divide by 100 for JPY-like currencies
+    // without decimal places this would need adjustment, but the
+    // common case (USD/EUR/BDT) works correctly.
+    const formatAmount = (minorUnit: number) =>
+      (minorUnit / 100).toFixed(2);
+
+    const order = await this.paypalApi('POST', '/v2/checkout/orders', {
+      intent: 'CAPTURE',
+      purchase_units: [
+        {
+          reference_id: input.orderReference,
+          amount: {
+            currency_code: input.currency.toUpperCase(),
+            value: formatAmount(input.totalAmount),
+            breakdown: {
+              item_total: {
+                currency_code: input.currency.toUpperCase(),
+                value: formatAmount(input.totalAmount),
+              },
+            },
+          },
+          items: input.lineItems.map((li) => ({
+            name: li.description.slice(0, 127),
+            quantity: String(li.quantity),
+            unit_amount: {
+              currency_code: input.currency.toUpperCase(),
+              value: formatAmount(li.unitAmount),
+            },
+          })),
+        },
+      ],
+      application_context: {
+        return_url: input.successUrl,
+        cancel_url: input.cancelUrl,
+        user_action: 'PAY_NOW',
+      },
+    });
+
+    const approveLink = order.links?.find((l: any) => l.rel === 'approve');
+    if (!approveLink) {
+      throw new Error('PayPal order creation did not return an approve URL');
+    }
+
+    return {
+      sessionId: order.id,
+      checkoutUrl: approveLink.href,
+      provider: 'paypal',
+      status: 'pending',
+    };
+  }
+
+  async getPayment(paymentId: string): Promise<PaymentInfo | null> {
+    try {
+      const order = await this.paypalApi(
+        'GET',
+        `/v2/checkout/orders/${encodeURIComponent(paymentId)}`,
+      );
+      const unit = order.purchase_units?.[0];
+      return {
+        paymentId: order.id,
+        status: this.mapStatus(order.status),
+        amount: Math.round(parseFloat(unit?.amount?.value ?? '0') * 100),
+        currency: unit?.amount?.currency_code ?? 'USD',
+        orderReference: unit?.reference_id ?? '',
+        capturedAt:
+          unit?.payments?.captures?.[0]?.create_time ?? undefined,
+        method: 'paypal',
+        provider: 'paypal',
+      };
+    } catch (e: any) {
+      if (/404/.test(e.message)) return null;
+      throw e;
+    }
+  }
+
+  async refund(input: RefundInput): Promise<RefundResult> {
+    // PayPal refunds happen against a capture id, not the order id.
+    // Look up the order first to find the capture id.
+    const order = await this.paypalApi(
+      'GET',
+      `/v2/checkout/orders/${encodeURIComponent(input.paymentId)}`,
+    );
+    const captureId = order.purchase_units?.[0]?.payments?.captures?.[0]?.id;
+    if (!captureId) {
+      throw new Error(`PayPal order ${input.paymentId} has no captures to refund`);
+    }
+
+    const body: any = {};
+    if (input.amount !== undefined) {
+      body.amount = {
+        value: (input.amount / 100).toFixed(2),
+        currency_code:
+          order.purchase_units?.[0]?.amount?.currency_code ?? 'USD',
+      };
+    }
+    if (input.reason) body.note_to_payer = input.reason;
+
+    const refund = await this.paypalApi(
+      'POST',
+      `/v2/payments/captures/${captureId}/refund`,
+      body,
+    );
+
+    return {
+      refundId: refund.id,
+      amount: Math.round(parseFloat(refund.amount?.value ?? '0') * 100),
+      status:
+        refund.status === 'COMPLETED'
+          ? 'succeeded'
+          : refund.status === 'FAILED'
+            ? 'failed'
+            : 'pending',
+      provider: 'paypal',
+    };
+  }
+
+  async parseWebhook(
+    rawBody: string,
+    _signature?: string,
+  ): Promise<WebhookEvent | null> {
+    // PayPal webhook signature verification requires multiple
+    // headers (paypal-transmission-id, -time, -sig, cert-url,
+    // algo, webhook_id) and a server-side verify call to
+    // /notifications/verify-webhook-signature. That's more
+    // infrastructure than this first-pass PR wants. For now,
+    // parse the payload without verification — production
+    // deployments MUST add signature verification before
+    // trusting any webhook. Documented.
+    let payload: any;
+    try {
+      payload = JSON.parse(rawBody);
+    } catch {
+      return null;
+    }
+
+    const kind = this.mapEventKind(payload.event_type);
+    if (kind === 'unknown') return null;
+
+    const resource = payload.resource ?? {};
+    return {
+      kind,
+      paymentId: resource.id ?? resource.supplementary_data?.related_ids?.order_id ?? '',
+      orderReference: resource.custom_id ?? resource.invoice_id,
+      amount: resource.amount?.value
+        ? Math.round(parseFloat(resource.amount.value) * 100)
+        : undefined,
+      currency: resource.amount?.currency_code,
+      raw: payload,
+    };
+  }
+
+  private mapStatus(raw?: string): PaymentStatus {
+    switch ((raw ?? '').toUpperCase()) {
+      case 'CREATED':
+      case 'SAVED':
+      case 'APPROVED':
+        return 'pending';
+      case 'PAYER_ACTION_REQUIRED':
+        return 'processing';
+      case 'COMPLETED':
+        return 'succeeded';
+      case 'VOIDED':
+        return 'cancelled';
+      default:
+        return 'unknown';
+    }
+  }
+
+  private mapEventKind(raw?: string): WebhookEvent['kind'] {
+    switch (raw) {
+      case 'CHECKOUT.ORDER.APPROVED':
+      case 'PAYMENT.CAPTURE.COMPLETED':
+        return 'payment.succeeded';
+      case 'PAYMENT.CAPTURE.DENIED':
+      case 'PAYMENT.CAPTURE.FAILED':
+        return 'payment.failed';
+      case 'PAYMENT.CAPTURE.REFUNDED':
+        return 'payment.refunded';
+      default:
+        return 'unknown';
+    }
+  }
+}

--- a/backend/src/modules/payment/providers/paypal.provider.ts
+++ b/backend/src/modules/payment/providers/paypal.provider.ts
@@ -237,6 +237,19 @@ export class PayPalProvider implements PaymentProvider {
     }
   }
 
+  /**
+   * PayPal hosted checkout auto-captures on PAYMENT.CAPTURE.COMPLETED.
+   * capturePayment is a pass-through to getPayment so callers can use
+   * the uniform PaymentProvider interface without branching.
+   */
+  async capturePayment(paymentId: string): Promise<PaymentInfo> {
+    const info = await this.getPayment(paymentId);
+    if (!info) {
+      throw new Error(`PayPal payment ${paymentId} not found`);
+    }
+    return info;
+  }
+
   async refund(input: RefundInput): Promise<RefundResult> {
     // PayPal refunds happen against a capture id, not the order id.
     // Look up the order first to find the capture id.

--- a/backend/src/modules/payment/providers/paypal.provider.ts
+++ b/backend/src/modules/payment/providers/paypal.provider.ts
@@ -38,6 +38,7 @@ export class PayPalProvider implements PaymentProvider {
   private readonly clientId: string;
   private readonly clientSecret: string;
   private readonly baseUrl: string;
+  private readonly webhookId: string;
 
   private accessToken: string | null = null;
   private tokenExpiresAt = 0;
@@ -45,6 +46,7 @@ export class PayPalProvider implements PaymentProvider {
   constructor(config: ConfigService) {
     this.clientId = config.get<string>('PAYPAL_CLIENT_ID', '');
     this.clientSecret = config.get<string>('PAYPAL_CLIENT_SECRET', '');
+    this.webhookId = config.get<string>('PAYPAL_WEBHOOK_ID', '');
     const mode = (
       config.get<string>('PAYPAL_MODE', 'sandbox') || 'sandbox'
     ).toLowerCase();
@@ -55,6 +57,11 @@ export class PayPalProvider implements PaymentProvider {
 
     if (this.isAvailable()) {
       this.logger.log(`PayPal provider configured (${mode} mode)`);
+      if (!this.webhookId) {
+        this.logger.warn(
+          'PAYPAL_WEBHOOK_ID is not set — parseWebhook will reject every inbound event to prevent forged notifications. Set PAYPAL_WEBHOOK_ID from your PayPal developer dashboard before enabling webhook handling.',
+        );
+      }
     } else {
       this.logger.warn(
         'PayPal provider selected but PAYPAL_CLIENT_ID / PAYPAL_CLIENT_SECRET missing',
@@ -122,14 +129,43 @@ export class PayPalProvider implements PaymentProvider {
     return json;
   }
 
+  /**
+   * Currencies that PayPal accepts with zero decimal places. Our
+   * interface uses integer minor units (cents/paisa) throughout, so
+   * a JPY "¥1000" amount arrives as `1000` and must be emitted as
+   * "1000" — NOT "10.00" (which would be 100× lower). ISO 4217 lists
+   * the decimal count for every currency; we hardcode the zero-
+   * decimal list since it's stable and small.
+   */
+  private static readonly ZERO_DECIMAL_CURRENCIES = new Set<string>([
+    'BIF', 'CLP', 'DJF', 'GNF', 'JPY', 'KMF', 'KRW', 'MGA', 'PYG',
+    'RWF', 'UGX', 'VND', 'VUV', 'XAF', 'XOF', 'XPF',
+  ]);
+
+  private formatAmount(minorUnit: number, currency: string): string {
+    const iso = currency.toUpperCase();
+    if (PayPalProvider.ZERO_DECIMAL_CURRENCIES.has(iso)) {
+      return String(Math.round(minorUnit));
+    }
+    return (minorUnit / 100).toFixed(2);
+  }
+
+  private parseAmount(value: string, currency: string): number {
+    const iso = currency.toUpperCase();
+    if (PayPalProvider.ZERO_DECIMAL_CURRENCIES.has(iso)) {
+      return Math.round(parseFloat(value));
+    }
+    return Math.round(parseFloat(value) * 100);
+  }
+
   async createCheckout(input: CreateCheckoutInput): Promise<CheckoutSession> {
-    // PayPal Orders v2 expects amounts as decimal strings ("12.34")
-    // in the order currency. Our interface uses smallest currency
-    // units (cents/paisa), so divide by 100 for JPY-like currencies
-    // without decimal places this would need adjustment, but the
-    // common case (USD/EUR/BDT) works correctly.
+    // PayPal Orders v2 expects amounts as decimal strings in the
+    // order currency. For 2-decimal currencies that's "12.34"; for
+    // zero-decimal currencies (JPY/KRW/VND/...) that's the integer
+    // as a string. Our interface uses integer minor units, so the
+    // formatAmount() helper dispatches on ISO 4217.
     const formatAmount = (minorUnit: number) =>
-      (minorUnit / 100).toFixed(2);
+      this.formatAmount(minorUnit, input.currency);
 
     const order = await this.paypalApi('POST', '/v2/checkout/orders', {
       intent: 'CAPTURE',
@@ -183,11 +219,12 @@ export class PayPalProvider implements PaymentProvider {
         `/v2/checkout/orders/${encodeURIComponent(paymentId)}`,
       );
       const unit = order.purchase_units?.[0];
+      const currency = unit?.amount?.currency_code ?? 'USD';
       return {
         paymentId: order.id,
         status: this.mapStatus(order.status),
-        amount: Math.round(parseFloat(unit?.amount?.value ?? '0') * 100),
-        currency: unit?.amount?.currency_code ?? 'USD',
+        amount: this.parseAmount(unit?.amount?.value ?? '0', currency),
+        currency,
         orderReference: unit?.reference_id ?? '',
         capturedAt:
           unit?.payments?.captures?.[0]?.create_time ?? undefined,
@@ -212,12 +249,13 @@ export class PayPalProvider implements PaymentProvider {
       throw new Error(`PayPal order ${input.paymentId} has no captures to refund`);
     }
 
+    const currency =
+      order.purchase_units?.[0]?.amount?.currency_code ?? 'USD';
     const body: any = {};
     if (input.amount !== undefined) {
       body.amount = {
-        value: (input.amount / 100).toFixed(2),
-        currency_code:
-          order.purchase_units?.[0]?.amount?.currency_code ?? 'USD',
+        value: this.formatAmount(input.amount, currency),
+        currency_code: currency,
       };
     }
     if (input.reason) body.note_to_payer = input.reason;
@@ -230,7 +268,7 @@ export class PayPalProvider implements PaymentProvider {
 
     return {
       refundId: refund.id,
-      amount: Math.round(parseFloat(refund.amount?.value ?? '0') * 100),
+      amount: this.parseAmount(refund.amount?.value ?? '0', currency),
       status:
         refund.status === 'COMPLETED'
           ? 'succeeded'
@@ -243,21 +281,96 @@ export class PayPalProvider implements PaymentProvider {
 
   async parseWebhook(
     rawBody: string,
-    _signature?: string,
+    signature?: string,
   ): Promise<WebhookEvent | null> {
-    // PayPal webhook signature verification requires multiple
-    // headers (paypal-transmission-id, -time, -sig, cert-url,
-    // algo, webhook_id) and a server-side verify call to
-    // /notifications/verify-webhook-signature. That's more
-    // infrastructure than this first-pass PR wants. For now,
-    // parse the payload without verification — production
-    // deployments MUST add signature verification before
-    // trusting any webhook. Documented.
+    // PayPal webhook signature verification requires calling
+    //   POST /v1/notifications/verify-webhook-signature
+    // with the webhook_id from PayPal's dashboard + the five
+    // transmission headers + the raw body. We receive those
+    // headers from the controller as a JSON-encoded bundle in
+    // the `signature` parameter:
+    //
+    //   signature = JSON.stringify({
+    //     'paypal-transmission-id': req.headers['paypal-transmission-id'],
+    //     'paypal-transmission-time': ...,
+    //     'paypal-transmission-sig': ...,
+    //     'paypal-cert-url': ...,
+    //     'paypal-auth-algo': ...,
+    //   })
+    //
+    // Fail-closed: if PAYPAL_WEBHOOK_ID is unset OR any header is
+    // missing OR the verify call returns SUCCESS:false, reject.
+
+    if (!this.webhookId) {
+      throw new Error(
+        'PayPal webhook verification requires PAYPAL_WEBHOOK_ID (get it from https://developer.paypal.com/dashboard/webhooks). Webhook handler is disabled until this env var is set.',
+      );
+    }
+
+    if (!signature) {
+      throw new Error(
+        'PayPal webhook signature bundle missing. Controller must forward paypal-transmission-* headers as a JSON-encoded string in the signature parameter.',
+      );
+    }
+
+    let headers: Record<string, string>;
+    try {
+      headers = JSON.parse(signature);
+    } catch {
+      throw new Error('PayPal webhook signature bundle is not valid JSON');
+    }
+
+    const normalize = (obj: Record<string, string>): Record<string, string> => {
+      const out: Record<string, string> = {};
+      for (const [k, v] of Object.entries(obj)) out[k.toLowerCase()] = v;
+      return out;
+    };
+    const h = normalize(headers);
+    const required = [
+      'paypal-transmission-id',
+      'paypal-transmission-time',
+      'paypal-transmission-sig',
+      'paypal-cert-url',
+      'paypal-auth-algo',
+    ];
+    const missing = required.filter((k) => !h[k]);
+    if (missing.length > 0) {
+      throw new Error(
+        `PayPal webhook headers missing: ${missing.join(', ')}`,
+      );
+    }
+
+    // Parse the body FIRST so we can pass the parsed webhook_event
+    // to the verify endpoint as PayPal expects.
     let payload: any;
     try {
       payload = JSON.parse(rawBody);
     } catch {
-      return null;
+      throw new Error('PayPal webhook body is not valid JSON');
+    }
+
+    // Call PayPal's verification endpoint. This is fail-closed —
+    // any non-200, any non-SUCCESS verification_status, or any
+    // network error throws and prevents the event from being
+    // returned to downstream code.
+    const verifyRes = await this.paypalApi(
+      'POST',
+      '/v1/notifications/verify-webhook-signature',
+      {
+        auth_algo: h['paypal-auth-algo'],
+        cert_url: h['paypal-cert-url'],
+        transmission_id: h['paypal-transmission-id'],
+        transmission_sig: h['paypal-transmission-sig'],
+        transmission_time: h['paypal-transmission-time'],
+        webhook_id: this.webhookId,
+        webhook_event: payload,
+      },
+    );
+
+    if (verifyRes?.verification_status !== 'SUCCESS') {
+      throw new Error(
+        `PayPal webhook signature verification failed: verification_status=${verifyRes?.verification_status ?? 'unknown'}`,
+      );
     }
 
     const kind = this.mapEventKind(payload.event_type);
@@ -269,7 +382,10 @@ export class PayPalProvider implements PaymentProvider {
       paymentId: resource.id ?? resource.supplementary_data?.related_ids?.order_id ?? '',
       orderReference: resource.custom_id ?? resource.invoice_id,
       amount: resource.amount?.value
-        ? Math.round(parseFloat(resource.amount.value) * 100)
+        ? this.parseAmount(
+            resource.amount.value,
+            resource.amount.currency_code ?? 'USD',
+          )
         : undefined,
       currency: resource.amount?.currency_code,
       raw: payload,

--- a/backend/src/modules/payment/providers/stripe.provider.ts
+++ b/backend/src/modules/payment/providers/stripe.provider.ts
@@ -220,6 +220,19 @@ export class StripeProvider implements PaymentProvider {
     };
   }
 
+  /**
+   * Stripe hosted checkout auto-captures on checkout.session.completed.
+   * This method is a pass-through to getPayment so callers can use
+   * the uniform PaymentProvider.capturePayment shape without branching.
+   */
+  async capturePayment(paymentId: string): Promise<PaymentInfo> {
+    const info = await this.getPayment(paymentId);
+    if (!info) {
+      throw new Error(`Stripe payment ${paymentId} not found`);
+    }
+    return info;
+  }
+
   async refund(input: RefundInput): Promise<RefundResult> {
     const body: Record<string, any> = { payment_intent: input.paymentId };
     if (input.amount !== undefined) body.amount = input.amount;

--- a/backend/src/modules/payment/providers/stripe.provider.ts
+++ b/backend/src/modules/payment/providers/stripe.provider.ts
@@ -1,0 +1,325 @@
+/**
+ * Stripe payment provider — the production default.
+ *
+ *   PAYMENT_PROVIDER=stripe
+ *   STRIPE_SECRET_KEY=sk_live_...       (or sk_test_...)
+ *   STRIPE_WEBHOOK_SECRET=whsec_...
+ *
+ * Uses Stripe Checkout Sessions for the payment flow — the simplest
+ * path to a working checkout that supports cards, Apple Pay, Google
+ * Pay, and every other payment method the customer's region allows.
+ *
+ * **Marketplace splits** are supported via Stripe Connect
+ * `transfer_data.destination` — the line items include a
+ * `vendorAccountId` (connected account id), and the provider
+ * automatically splits the charge. For orders spanning multiple
+ * vendors, the simplification here is: the first vendor gets the
+ * full transfer minus the platform fee, and manual reconciliation
+ * handles the rest. A follow-up PR can add proper multi-vendor
+ * PaymentIntents with `transfer_group` + separate transfers.
+ *
+ * Pure REST via fetch — no SDK dep. Stripe's REST API uses
+ * form-urlencoded bodies with nested keys like
+ * `line_items[0][price_data][unit_amount]=1000`. The provider
+ * builds the nested form encoding from a flat object via a
+ * recursive walker (same pattern as the tax adapter's
+ * stripe-tax provider).
+ */
+import { Logger } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as crypto from 'crypto';
+import {
+  CheckoutSession,
+  CreateCheckoutInput,
+  PaymentInfo,
+  PaymentProvider,
+  PaymentProviderNotConfiguredError,
+  PaymentStatus,
+  RefundInput,
+  RefundResult,
+  WebhookEvent,
+} from './payment-provider.interface';
+
+const STRIPE_API_BASE = 'https://api.stripe.com/v1';
+
+export class StripeProvider implements PaymentProvider {
+  readonly name = 'stripe' as const;
+  private readonly logger = new Logger('StripeProvider');
+
+  private readonly secretKey: string;
+  private readonly webhookSecret: string;
+
+  constructor(config: ConfigService) {
+    this.secretKey = config.get<string>('STRIPE_SECRET_KEY', '');
+    this.webhookSecret = config.get<string>('STRIPE_WEBHOOK_SECRET', '');
+
+    if (this.isAvailable()) {
+      this.logger.log(
+        `Stripe provider configured (${this.secretKey.startsWith('sk_test') ? 'test mode' : 'production'})`,
+      );
+    } else {
+      this.logger.warn('Stripe provider selected but STRIPE_SECRET_KEY missing');
+    }
+  }
+
+  isAvailable(): boolean {
+    return !!this.secretKey;
+  }
+
+  /**
+   * Build Stripe-style form-urlencoded body with nested keys:
+   *   { line_items: [{ price_data: { currency: 'usd' } }] }
+   *   → "line_items[0][price_data][currency]=usd"
+   */
+  private encodeForm(data: Record<string, any>): string {
+    const params = new URLSearchParams();
+    const walk = (prefix: string, value: any) => {
+      if (value === undefined || value === null) return;
+      if (Array.isArray(value)) {
+        value.forEach((v, i) => walk(`${prefix}[${i}]`, v));
+      } else if (typeof value === 'object') {
+        for (const [k, v] of Object.entries(value)) {
+          walk(`${prefix}[${k}]`, v);
+        }
+      } else {
+        params.append(prefix, String(value));
+      }
+    };
+    for (const [k, v] of Object.entries(data)) walk(k, v);
+    return params.toString();
+  }
+
+  private async stripeApi(
+    method: 'GET' | 'POST',
+    path: string,
+    body?: Record<string, any>,
+  ): Promise<any> {
+    if (!this.isAvailable()) {
+      throw new PaymentProviderNotConfiguredError('stripe', [
+        'STRIPE_SECRET_KEY',
+      ]);
+    }
+    const res = await fetch(`${STRIPE_API_BASE}${path}`, {
+      method,
+      headers: {
+        Authorization: `Bearer ${this.secretKey}`,
+        'Content-Type': 'application/x-www-form-urlencoded',
+      },
+      body: body ? this.encodeForm(body) : undefined,
+    });
+    const json = (await res.json()) as any;
+    if (!res.ok) {
+      throw new Error(
+        `Stripe API ${method} ${path} failed: ${res.status} ${json.error?.message ?? JSON.stringify(json)}`,
+      );
+    }
+    return json;
+  }
+
+  async createCheckout(input: CreateCheckoutInput): Promise<CheckoutSession> {
+    // Marketplace split: if all line items share a single
+    // vendorAccountId, use Stripe Connect `transfer_data.destination`
+    // + `application_fee_amount` to split the charge automatically.
+    // For multi-vendor carts, we use transfer_group and leave
+    // reconciliation to a follow-up PR.
+    const vendorIds = new Set(
+      input.lineItems
+        .map((li) => li.vendorAccountId)
+        .filter((v): v is string => !!v),
+    );
+    const singleVendor = vendorIds.size === 1 ? [...vendorIds][0] : undefined;
+
+    const body: Record<string, any> = {
+      mode: 'payment',
+      success_url: input.successUrl,
+      cancel_url: input.cancelUrl,
+      client_reference_id: input.orderReference,
+      customer_email: input.customer.email,
+      line_items: input.lineItems.map((li) => ({
+        price_data: {
+          currency: input.currency.toLowerCase(),
+          product_data: { name: li.description, metadata: { productId: li.productId } },
+          unit_amount: li.unitAmount,
+        },
+        quantity: li.quantity,
+      })),
+      metadata: {
+        order_reference: input.orderReference,
+        ...input.metadata,
+      },
+    };
+
+    if (singleVendor && input.platformFeeAmount !== undefined) {
+      body.payment_intent_data = {
+        application_fee_amount: input.platformFeeAmount,
+        transfer_data: { destination: singleVendor },
+      };
+    } else if (vendorIds.size > 1) {
+      // Multi-vendor → use a transfer_group so a follow-up job can
+      // create individual transfers after capture.
+      body.payment_intent_data = {
+        transfer_group: `order_${input.orderReference}`,
+      };
+    }
+
+    const session = await this.stripeApi('POST', '/checkout/sessions', body);
+    return {
+      sessionId: session.id,
+      checkoutUrl: session.url,
+      provider: 'stripe',
+      status: 'pending',
+    };
+  }
+
+  async getPayment(paymentId: string): Promise<PaymentInfo | null> {
+    try {
+      // paymentId here is the Checkout Session id OR a PaymentIntent id.
+      // Try Checkout Session first.
+      let session: any = null;
+      if (paymentId.startsWith('cs_')) {
+        session = await this.stripeApi(
+          'GET',
+          `/checkout/sessions/${encodeURIComponent(paymentId)}`,
+        );
+        if (session.payment_intent) {
+          const pi = await this.stripeApi(
+            'GET',
+            `/payment_intents/${session.payment_intent}`,
+          );
+          return this.translatePaymentIntent(pi, session.client_reference_id);
+        }
+      } else if (paymentId.startsWith('pi_')) {
+        const pi = await this.stripeApi(
+          'GET',
+          `/payment_intents/${encodeURIComponent(paymentId)}`,
+        );
+        return this.translatePaymentIntent(pi);
+      }
+      return null;
+    } catch (e: any) {
+      if (/404/.test(e.message)) return null;
+      throw e;
+    }
+  }
+
+  private translatePaymentIntent(
+    pi: any,
+    orderReference?: string,
+  ): PaymentInfo {
+    return {
+      paymentId: pi.id,
+      status: this.mapStatus(pi.status),
+      amount: pi.amount,
+      currency: pi.currency?.toUpperCase() ?? 'USD',
+      orderReference: orderReference ?? pi.metadata?.order_reference ?? '',
+      capturedAt: pi.charges?.data?.[0]?.created
+        ? new Date(pi.charges.data[0].created * 1000).toISOString()
+        : undefined,
+      method: pi.payment_method_types?.[0] ?? 'card',
+      provider: 'stripe',
+    };
+  }
+
+  async refund(input: RefundInput): Promise<RefundResult> {
+    const body: Record<string, any> = { payment_intent: input.paymentId };
+    if (input.amount !== undefined) body.amount = input.amount;
+    if (input.reason) body.reason = input.reason;
+
+    const refund = await this.stripeApi('POST', '/refunds', body);
+    return {
+      refundId: refund.id,
+      amount: refund.amount ?? 0,
+      status:
+        refund.status === 'succeeded'
+          ? 'succeeded'
+          : refund.status === 'failed'
+            ? 'failed'
+            : 'pending',
+      provider: 'stripe',
+    };
+  }
+
+  async parseWebhook(
+    rawBody: string,
+    signature?: string,
+  ): Promise<WebhookEvent | null> {
+    // Stripe uses Stripe-Signature header with scheme:
+    //   t=<timestamp>,v1=<hmac_sha256_of_timestamp.rawBody>
+    if (this.webhookSecret && signature) {
+      const parts = Object.fromEntries(
+        signature.split(',').map((s) => {
+          const [k, v] = s.split('=');
+          return [k, v];
+        }),
+      );
+      const timestamp = parts.t;
+      const v1 = parts.v1;
+      if (!timestamp || !v1) {
+        throw new Error('Stripe webhook signature malformed');
+      }
+      const expected = crypto
+        .createHmac('sha256', this.webhookSecret)
+        .update(`${timestamp}.${rawBody}`)
+        .digest('hex');
+      if (!crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(v1))) {
+        throw new Error('Stripe webhook signature mismatch');
+      }
+    }
+
+    let payload: any;
+    try {
+      payload = JSON.parse(rawBody);
+    } catch {
+      return null;
+    }
+
+    const kind = this.mapEventKind(payload.type);
+    if (kind === 'unknown') return null;
+
+    const obj = payload.data?.object ?? {};
+    return {
+      kind,
+      paymentId: obj.id ?? '',
+      orderReference:
+        obj.client_reference_id ?? obj.metadata?.order_reference,
+      amount: obj.amount_total ?? obj.amount,
+      currency: obj.currency?.toUpperCase(),
+      raw: payload,
+    };
+  }
+
+  private mapStatus(raw?: string): PaymentStatus {
+    switch (raw) {
+      case 'requires_payment_method':
+      case 'requires_confirmation':
+      case 'requires_action':
+        return 'pending';
+      case 'processing':
+        return 'processing';
+      case 'succeeded':
+        return 'succeeded';
+      case 'canceled':
+        return 'cancelled';
+      default:
+        return 'unknown';
+    }
+  }
+
+  private mapEventKind(raw?: string): WebhookEvent['kind'] {
+    switch (raw) {
+      case 'checkout.session.completed':
+      case 'payment_intent.succeeded':
+        return 'payment.succeeded';
+      case 'payment_intent.payment_failed':
+      case 'checkout.session.async_payment_failed':
+        return 'payment.failed';
+      case 'charge.refunded':
+      case 'refund.created':
+        return 'payment.refunded';
+      case 'checkout.session.expired':
+        return 'payment.expired';
+      default:
+        return 'unknown';
+    }
+  }
+}

--- a/backend/src/modules/payment/providers/stripe.provider.ts
+++ b/backend/src/modules/payment/providers/stripe.provider.ts
@@ -239,17 +239,31 @@ export class StripeProvider implements PaymentProvider {
     };
   }
 
+  // Stripe recommends rejecting events whose timestamp is older than
+  // 5 minutes to block replay attacks using a captured signed payload.
+  private static readonly WEBHOOK_TOLERANCE_SECONDS = 300;
+
   async parseWebhook(
     rawBody: string,
     signature?: string,
   ): Promise<WebhookEvent | null> {
     // Stripe uses Stripe-Signature header with scheme:
     //   t=<timestamp>,v1=<hmac_sha256_of_timestamp.rawBody>
-    if (this.webhookSecret && signature) {
+    //
+    // Fail-closed: if the operator configured STRIPE_WEBHOOK_SECRET we
+    // REQUIRE the signature header. An attacker who finds the webhook
+    // URL must not be able to forge events by POSTing unsigned payloads.
+    if (this.webhookSecret) {
+      if (!signature) {
+        throw new Error(
+          'Stripe webhook signature missing (STRIPE_WEBHOOK_SECRET is set). ' +
+            'Verify upstream proxy is forwarding the Stripe-Signature header.',
+        );
+      }
       const parts = Object.fromEntries(
         signature.split(',').map((s) => {
-          const [k, v] = s.split('=');
-          return [k, v];
+          const idx = s.indexOf('=');
+          return idx >= 0 ? [s.slice(0, idx), s.slice(idx + 1)] : [s, ''];
         }),
       );
       const timestamp = parts.t;
@@ -257,11 +271,33 @@ export class StripeProvider implements PaymentProvider {
       if (!timestamp || !v1) {
         throw new Error('Stripe webhook signature malformed');
       }
+
+      // Replay protection. Stripe timestamps are Unix seconds.
+      const eventTs = Number(timestamp);
+      if (!Number.isFinite(eventTs)) {
+        throw new Error('Stripe webhook timestamp not a number');
+      }
+      const now = Math.floor(Date.now() / 1000);
+      if (Math.abs(now - eventTs) > StripeProvider.WEBHOOK_TOLERANCE_SECONDS) {
+        throw new Error(
+          `Stripe webhook timestamp outside tolerance window (|now-t|=${Math.abs(now - eventTs)}s, max=${StripeProvider.WEBHOOK_TOLERANCE_SECONDS}s)`,
+        );
+      }
+
       const expected = crypto
         .createHmac('sha256', this.webhookSecret)
         .update(`${timestamp}.${rawBody}`)
         .digest('hex');
-      if (!crypto.timingSafeEqual(Buffer.from(expected), Buffer.from(v1))) {
+
+      // timingSafeEqual throws RangeError on length mismatch — that
+      // must NOT bubble up as a 500. Length-check first and reject
+      // cleanly.
+      const expectedBuf = Buffer.from(expected, 'hex');
+      const providedBuf = Buffer.from(v1, 'hex');
+      if (
+        expectedBuf.length !== providedBuf.length ||
+        !crypto.timingSafeEqual(expectedBuf, providedBuf)
+      ) {
         throw new Error('Stripe webhook signature mismatch');
       }
     }


### PR DESCRIPTION
## Summary

First-pass of **#35**. Direct port of vasty-shop PR #37. Team@Once gets the same pluggable payment adapter alongside the existing Stripe-hardcoded `StripeService` (subscriptions) + `PaymentService` (milestone escrow).

## What's in it

**4 real providers** + 9 planned stubs:

- **stripe** — Checkout Sessions + Connect marketplace splits, HMAC-SHA256 webhook verification
- **paypal** — Orders v2 API with OAuth token exchange
- **bkash** — Bangladesh mobile wallet, 2-legged auth with raw username/password headers
- **none** — default, throws loudly

**`PaymentProviderService`** façade added to `PaymentModule` alongside the legacy services.

## Team@Once-specific deltas vs vasty #37

- Team@Once's existing payment surface is more complex: `StripeService` handles subscription billing (platform fee for the marketplace), `PaymentService` handles milestone escrow for projects. Both stay Stripe-hardcoded in this PR.
- New code — especially the escrow flow — should inject the new façade. A follow-up will migrate the legacy services.
- No circular-dependency `OnModuleInit` wiring needed (Team@Once's services don't have the OrdersService back-reference that vasty has).

## Verification status (honest)

Identical to vasty-shop #37:

| Provider | Status |
|---|---|
| **stripe** | written, **smoke-tested** (nested form encoding + single/multi-vendor splits + HMAC webhook verification). NOT tested against real Stripe |
| **paypal** | written, **smoke-tested**. NOT tested. Webhook verification NOT implemented — must add before prod |
| **bkash** | written, **smoke-tested** (raw-header auth + BDT decimals). NOT tested against real sandbox |
| **none** | written, **smoke-tested** |
| **9 planned providers** | NOT implemented; fall back to none with warning |

Full TypeScript compile: **0 errors**.

Smoke test: **65/65 assertions pass** on teamatonce.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx ts-node scripts/smoke-test-payment-providers.ts` 65/65 pass
- [ ] Manual: Stripe test mode end-to-end against the escrow flow
- [ ] Manual: PayPal sandbox
- [ ] Manual: bKash sandbox
- [ ] Follow-up: PayPal webhook signature verification BEFORE prod

## Out of scope

- Migrate legacy `StripeService` + `PaymentService` to delegate to `PaymentProviderService`
- PayPal webhook signature verification
- Each of the 9 planned providers as its own focused PR
- Multi-vendor split reconciliation

## Related

- vasty-shop PR #37 — the identical adapter on the sibling repo
- Tracking issue #38 (pluggable providers meta)

🤖 Generated with [Claude Code](https://claude.com/claude-code)