### PR TITLE
feat: portfolio showcase for developer profiles

### DIFF
--- a/backend/migrations/005_portfolio.sql
+++ b/backend/migrations/005_portfolio.sql
@@ -1,0 +1,46 @@
+-- =====================================================
+-- Portfolio Showcase Migration
+-- Closes: GitHub issue #51
+-- Generated: 2026-04-11
+-- =====================================================
+
+-- ==================== PORTFOLIO ITEMS ====================
+CREATE TABLE IF NOT EXISTS "portfolio_items" (
+  "id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "user_id" VARCHAR(255) NOT NULL,
+  "title" VARCHAR(200) NOT NULL,
+  "description" TEXT NOT NULL,
+  "category" VARCHAR(20) NOT NULL CHECK ("category" IN ('web-app', 'mobile-app', 'api', 'design', 'data', 'devops', 'other')),
+  "tech_stack" JSONB DEFAULT '[]'::jsonb,
+  "images" JSONB DEFAULT '[]'::jsonb,
+  "live_demo_url" TEXT,
+  "github_url" TEXT,
+  "client_name" VARCHAR(200),
+  "outcomes" TEXT,
+  "start_date" DATE,
+  "end_date" DATE,
+  "is_featured" BOOLEAN DEFAULT false,
+  "source" VARCHAR(20) DEFAULT 'manual' CHECK ("source" IN ('manual', 'github_import')),
+  "github_repo_url" TEXT,
+  "github_stars" INTEGER DEFAULT 0,
+  "created_at" TIMESTAMPTZ DEFAULT now(),
+  "updated_at" TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "idx_portfolio_items_user_id" ON "portfolio_items" ("user_id");
+CREATE INDEX IF NOT EXISTS "idx_portfolio_items_category" ON "portfolio_items" ("category");
+CREATE INDEX IF NOT EXISTS "idx_portfolio_items_is_featured" ON "portfolio_items" ("is_featured");
+CREATE INDEX IF NOT EXISTS "idx_portfolio_items_source" ON "portfolio_items" ("source");
+CREATE INDEX IF NOT EXISTS "idx_portfolio_items_created_at" ON "portfolio_items" ("created_at");
+
+-- ==================== PORTFOLIO SNIPPETS ====================
+CREATE TABLE IF NOT EXISTS "portfolio_snippets" (
+  "id" UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  "portfolio_item_id" UUID NOT NULL REFERENCES "portfolio_items" ("id") ON DELETE CASCADE,
+  "language" VARCHAR(50) NOT NULL,
+  "filename" VARCHAR(255) NOT NULL,
+  "code" TEXT NOT NULL,
+  "created_at" TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS "idx_portfolio_snippets_item_id" ON "portfolio_snippets" ("portfolio_item_id");

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -47,6 +47,7 @@ import { NotesModule } from './modules/teamatonce/notes/notes.module';
 import { DeveloperModule } from './modules/teamatonce/developer/developer.module';
 import { PublicModule } from './modules/public/public.module';
 import { HireRequestModule } from './modules/teamatonce/hire-request/hire-request.module';
+import { PortfolioModule } from './modules/portfolio/portfolio.module';
 import { SchedulerModule } from './modules/scheduler/scheduler.module';
 import { DataEngineModule } from './modules/data-engine/data-engine.module';
 import { QdrantModule } from './modules/qdrant/qdrant.module';
@@ -104,6 +105,7 @@ import { QueueModule } from './modules/queue/queue.module';
     DeveloperModule,
     PublicModule,
     HireRequestModule,
+    PortfolioModule,
     SchedulerModule,
     DataEngineModule,
 

--- a/backend/src/modules/portfolio/dto/portfolio.dto.ts
+++ b/backend/src/modules/portfolio/dto/portfolio.dto.ts
@@ -1,0 +1,206 @@
+import {
+  IsString,
+  IsOptional,
+  IsBoolean,
+  IsEnum,
+  IsUrl,
+  IsArray,
+  IsDateString,
+  MaxLength,
+  MinLength,
+  ArrayMaxSize,
+} from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+/**
+ * Portfolio item category enum
+ */
+export enum PortfolioCategory {
+  WEB_APP = 'web-app',
+  MOBILE_APP = 'mobile-app',
+  API = 'api',
+  DESIGN = 'design',
+  DATA = 'data',
+  DEVOPS = 'devops',
+  OTHER = 'other',
+}
+
+/**
+ * Portfolio item source enum
+ */
+export enum PortfolioSource {
+  MANUAL = 'manual',
+  GITHUB_IMPORT = 'github_import',
+}
+
+/**
+ * DTO for creating a portfolio item
+ */
+export class CreatePortfolioItemDto {
+  @ApiProperty({ description: 'Title of the portfolio item', example: 'E-commerce Platform' })
+  @IsString()
+  @MinLength(2)
+  @MaxLength(200)
+  title: string;
+
+  @ApiProperty({ description: 'Description of the portfolio item' })
+  @IsString()
+  @MinLength(10)
+  @MaxLength(5000)
+  description: string;
+
+  @ApiProperty({ enum: PortfolioCategory, description: 'Category of the portfolio item' })
+  @IsEnum(PortfolioCategory)
+  category: PortfolioCategory;
+
+  @ApiProperty({ description: 'Technologies used', example: ['React', 'Node.js', 'PostgreSQL'], type: [String] })
+  @IsArray()
+  @IsString({ each: true })
+  tech_stack: string[];
+
+  @ApiPropertyOptional({ description: 'Screenshot URLs (max 5)', type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  @ArrayMaxSize(5)
+  images?: string[];
+
+  @ApiPropertyOptional({ description: 'Live demo URL' })
+  @IsOptional()
+  @IsUrl()
+  live_demo_url?: string;
+
+  @ApiPropertyOptional({ description: 'GitHub repository URL' })
+  @IsOptional()
+  @IsUrl()
+  github_url?: string;
+
+  @ApiPropertyOptional({ description: 'Client name (for case studies)' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  client_name?: string;
+
+  @ApiPropertyOptional({ description: 'Project outcomes', example: 'Reduced load time by 60%' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  outcomes?: string;
+
+  @ApiProperty({ description: 'Project start date' })
+  @IsDateString()
+  start_date: string;
+
+  @ApiPropertyOptional({ description: 'Project end date' })
+  @IsOptional()
+  @IsDateString()
+  end_date?: string;
+
+  @ApiPropertyOptional({ description: 'Whether this item is featured on the profile', default: false })
+  @IsOptional()
+  @IsBoolean()
+  is_featured?: boolean;
+}
+
+/**
+ * DTO for updating a portfolio item
+ */
+export class UpdatePortfolioItemDto {
+  @ApiPropertyOptional({ description: 'Title of the portfolio item' })
+  @IsOptional()
+  @IsString()
+  @MinLength(2)
+  @MaxLength(200)
+  title?: string;
+
+  @ApiPropertyOptional({ description: 'Description of the portfolio item' })
+  @IsOptional()
+  @IsString()
+  @MinLength(10)
+  @MaxLength(5000)
+  description?: string;
+
+  @ApiPropertyOptional({ enum: PortfolioCategory })
+  @IsOptional()
+  @IsEnum(PortfolioCategory)
+  category?: PortfolioCategory;
+
+  @ApiPropertyOptional({ description: 'Technologies used', type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  tech_stack?: string[];
+
+  @ApiPropertyOptional({ description: 'Screenshot URLs (max 5)', type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  @ArrayMaxSize(5)
+  images?: string[];
+
+  @ApiPropertyOptional({ description: 'Live demo URL' })
+  @IsOptional()
+  @IsUrl()
+  live_demo_url?: string;
+
+  @ApiPropertyOptional({ description: 'GitHub repository URL' })
+  @IsOptional()
+  @IsUrl()
+  github_url?: string;
+
+  @ApiPropertyOptional({ description: 'Client name' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  client_name?: string;
+
+  @ApiPropertyOptional({ description: 'Project outcomes' })
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  outcomes?: string;
+
+  @ApiPropertyOptional({ description: 'Project start date' })
+  @IsOptional()
+  @IsDateString()
+  start_date?: string;
+
+  @ApiPropertyOptional({ description: 'Project end date' })
+  @IsOptional()
+  @IsDateString()
+  end_date?: string;
+
+  @ApiPropertyOptional({ description: 'Whether this item is featured on the profile' })
+  @IsOptional()
+  @IsBoolean()
+  is_featured?: boolean;
+}
+
+/**
+ * DTO for importing from GitHub
+ */
+export class ImportGitHubDto {
+  @ApiProperty({ description: 'GitHub personal access token' })
+  @IsString()
+  github_token: string;
+}
+
+/**
+ * DTO for creating a code snippet
+ */
+export class CreateCodeSnippetDto {
+  @ApiProperty({ description: 'Programming language', example: 'typescript' })
+  @IsString()
+  @MaxLength(50)
+  language: string;
+
+  @ApiProperty({ description: 'Filename', example: 'auth.service.ts' })
+  @IsString()
+  @MaxLength(255)
+  filename: string;
+
+  @ApiProperty({ description: 'Code content (max 5000 chars)' })
+  @IsString()
+  @MaxLength(5000)
+  code: string;
+}

--- a/backend/src/modules/portfolio/portfolio.controller.ts
+++ b/backend/src/modules/portfolio/portfolio.controller.ts
@@ -1,0 +1,191 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Put,
+  Delete,
+  Body,
+  Param,
+  Query,
+  UseGuards,
+  Request,
+  HttpCode,
+  HttpStatus,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiParam,
+  ApiQuery,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { PortfolioService } from './portfolio.service';
+import {
+  CreatePortfolioItemDto,
+  UpdatePortfolioItemDto,
+  ImportGitHubDto,
+  CreateCodeSnippetDto,
+} from './dto/portfolio.dto';
+
+@ApiTags('Portfolio')
+@Controller('portfolio')
+export class PortfolioController {
+  constructor(private readonly portfolioService: PortfolioService) {}
+
+  // ============================================
+  // PORTFOLIO ITEM ENDPOINTS
+  // ============================================
+
+  @Post()
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Create a portfolio item',
+    description: 'Create a new portfolio item for the authenticated user.',
+  })
+  @ApiResponse({ status: 201, description: 'Portfolio item created successfully' })
+  @ApiResponse({ status: 401, description: 'Unauthorized' })
+  async createPortfolioItem(@Request() req: any, @Body() dto: CreatePortfolioItemDto) {
+    const userId = req.user.sub || req.user.userId;
+    return this.portfolioService.createPortfolioItem(userId, dto);
+  }
+
+  @Get('user/:userId')
+  @ApiOperation({
+    summary: 'Get portfolio items for a user',
+    description: 'Retrieve all portfolio items for a specific user (public, paginated).',
+  })
+  @ApiParam({ name: 'userId', description: 'User ID' })
+  @ApiQuery({ name: 'page', required: false, type: Number, description: 'Page number (default: 1)' })
+  @ApiQuery({ name: 'limit', required: false, type: Number, description: 'Items per page (default: 20, max: 50)' })
+  @ApiQuery({ name: 'category', required: false, description: 'Filter by category' })
+  @ApiResponse({ status: 200, description: 'Portfolio items retrieved successfully' })
+  async getPortfolioByUser(
+    @Param('userId') userId: string,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+    @Query('category') category?: string,
+  ) {
+    return this.portfolioService.getPortfolioByUser(userId, {
+      page: page ? parseInt(page, 10) : undefined,
+      limit: limit ? parseInt(limit, 10) : undefined,
+      category,
+    });
+  }
+
+  @Get('user/:userId/featured')
+  @ApiOperation({
+    summary: 'Get featured portfolio items',
+    description: 'Retrieve featured portfolio items for a user (for profile cards).',
+  })
+  @ApiParam({ name: 'userId', description: 'User ID' })
+  @ApiResponse({ status: 200, description: 'Featured portfolio items retrieved' })
+  async getFeaturedPortfolio(@Param('userId') userId: string) {
+    return this.portfolioService.getFeaturedPortfolio(userId);
+  }
+
+  @Get(':id')
+  @ApiOperation({
+    summary: 'Get a single portfolio item',
+    description: 'Retrieve a portfolio item by its ID (public).',
+  })
+  @ApiParam({ name: 'id', description: 'Portfolio item ID' })
+  @ApiResponse({ status: 200, description: 'Portfolio item retrieved' })
+  @ApiResponse({ status: 404, description: 'Portfolio item not found' })
+  async getPortfolioItem(@Param('id') id: string) {
+    return this.portfolioService.getPortfolioItem(id);
+  }
+
+  @Put(':id')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Update a portfolio item',
+    description: 'Update an existing portfolio item (must be owner).',
+  })
+  @ApiParam({ name: 'id', description: 'Portfolio item ID' })
+  @ApiResponse({ status: 200, description: 'Portfolio item updated' })
+  @ApiResponse({ status: 403, description: 'Not the owner' })
+  @ApiResponse({ status: 404, description: 'Portfolio item not found' })
+  async updatePortfolioItem(
+    @Param('id') id: string,
+    @Request() req: any,
+    @Body() dto: UpdatePortfolioItemDto,
+  ) {
+    const userId = req.user.sub || req.user.userId;
+    return this.portfolioService.updatePortfolioItem(id, userId, dto);
+  }
+
+  @Delete(':id')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @HttpCode(HttpStatus.OK)
+  @ApiOperation({
+    summary: 'Delete a portfolio item',
+    description: 'Delete a portfolio item and its associated snippets (must be owner).',
+  })
+  @ApiParam({ name: 'id', description: 'Portfolio item ID' })
+  @ApiResponse({ status: 200, description: 'Portfolio item deleted' })
+  @ApiResponse({ status: 403, description: 'Not the owner' })
+  @ApiResponse({ status: 404, description: 'Portfolio item not found' })
+  async deletePortfolioItem(@Param('id') id: string, @Request() req: any) {
+    const userId = req.user.sub || req.user.userId;
+    return this.portfolioService.deletePortfolioItem(id, userId);
+  }
+
+  // ============================================
+  // GITHUB IMPORT
+  // ============================================
+
+  @Post('import/github')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Import portfolio items from GitHub',
+    description: 'Import pinned/top repositories from GitHub as portfolio items.',
+  })
+  @ApiResponse({ status: 201, description: 'GitHub repos imported successfully' })
+  @ApiResponse({ status: 400, description: 'Invalid token or import failed' })
+  async importFromGitHub(@Request() req: any, @Body() dto: ImportGitHubDto) {
+    const userId = req.user.sub || req.user.userId;
+    return this.portfolioService.importFromGitHub(userId, dto.github_token);
+  }
+
+  // ============================================
+  // CODE SNIPPETS
+  // ============================================
+
+  @Post(':id/snippets')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({
+    summary: 'Add a code snippet to a portfolio item',
+    description: 'Add a code snippet with language and filename to a portfolio item (must be owner).',
+  })
+  @ApiParam({ name: 'id', description: 'Portfolio item ID' })
+  @ApiResponse({ status: 201, description: 'Code snippet added' })
+  @ApiResponse({ status: 403, description: 'Not the owner' })
+  @ApiResponse({ status: 404, description: 'Portfolio item not found' })
+  async addCodeSnippet(
+    @Param('id') id: string,
+    @Request() req: any,
+    @Body() dto: CreateCodeSnippetDto,
+  ) {
+    const userId = req.user.sub || req.user.userId;
+    return this.portfolioService.addCodeSnippet(id, userId, dto);
+  }
+
+  @Get(':id/snippets')
+  @ApiOperation({
+    summary: 'Get code snippets for a portfolio item',
+    description: 'List all code snippets for a portfolio item (public).',
+  })
+  @ApiParam({ name: 'id', description: 'Portfolio item ID' })
+  @ApiResponse({ status: 200, description: 'Code snippets retrieved' })
+  @ApiResponse({ status: 404, description: 'Portfolio item not found' })
+  async getSnippets(@Param('id') id: string) {
+    return this.portfolioService.getSnippets(id);
+  }
+}

--- a/backend/src/modules/portfolio/portfolio.module.ts
+++ b/backend/src/modules/portfolio/portfolio.module.ts
@@ -1,0 +1,24 @@
+import { Module } from '@nestjs/common';
+import { PortfolioController } from './portfolio.controller';
+import { PortfolioService } from './portfolio.service';
+import { AuthModule } from '../auth/auth.module';
+
+/**
+ * Portfolio Module
+ *
+ * Manages developer and company portfolio showcases including:
+ * - Portfolio item CRUD (projects, case studies, demos)
+ * - GitHub repository import (pinned/top repos)
+ * - Code snippet showcase with syntax highlighting metadata
+ * - Featured items for profile cards
+ * - Paginated public portfolio browsing
+ *
+ * Closes: GitHub issue #51
+ */
+@Module({
+  imports: [AuthModule],
+  controllers: [PortfolioController],
+  providers: [PortfolioService],
+  exports: [PortfolioService],
+})
+export class PortfolioModule {}

--- a/backend/src/modules/portfolio/portfolio.service.ts
+++ b/backend/src/modules/portfolio/portfolio.service.ts
@@ -1,0 +1,372 @@
+import {
+  Injectable,
+  NotFoundException,
+  ForbiddenException,
+  BadRequestException,
+  Logger,
+} from '@nestjs/common';
+import { DatabaseService } from '../database/database.service';
+import {
+  CreatePortfolioItemDto,
+  UpdatePortfolioItemDto,
+  CreateCodeSnippetDto,
+  PortfolioSource,
+} from './dto/portfolio.dto';
+
+@Injectable()
+export class PortfolioService {
+  private readonly logger = new Logger(PortfolioService.name);
+
+  constructor(private readonly db: DatabaseService) {}
+
+  // ============================================
+  // PORTFOLIO ITEM CRUD
+  // ============================================
+
+  /**
+   * Create a new portfolio item
+   */
+  async createPortfolioItem(userId: string, dto: CreatePortfolioItemDto) {
+    const data = {
+      user_id: userId,
+      title: dto.title,
+      description: dto.description,
+      category: dto.category,
+      tech_stack: JSON.stringify(dto.tech_stack),
+      images: JSON.stringify(dto.images || []),
+      live_demo_url: dto.live_demo_url || null,
+      github_url: dto.github_url || null,
+      client_name: dto.client_name || null,
+      outcomes: dto.outcomes || null,
+      start_date: dto.start_date,
+      end_date: dto.end_date || null,
+      is_featured: dto.is_featured || false,
+      source: PortfolioSource.MANUAL,
+    };
+
+    const item = await this.db.insert('portfolio_items', data);
+    return this.parsePortfolioItem(item);
+  }
+
+  /**
+   * Update a portfolio item (must be owned by the user)
+   */
+  async updatePortfolioItem(id: string, userId: string, dto: UpdatePortfolioItemDto) {
+    const existing = await this.db.findOne('portfolio_items', { id });
+    if (!existing) {
+      throw new NotFoundException('Portfolio item not found');
+    }
+    if (existing.user_id !== userId) {
+      throw new ForbiddenException('You can only update your own portfolio items');
+    }
+
+    const data: Record<string, any> = { updated_at: new Date().toISOString() };
+
+    if (dto.title !== undefined) data.title = dto.title;
+    if (dto.description !== undefined) data.description = dto.description;
+    if (dto.category !== undefined) data.category = dto.category;
+    if (dto.tech_stack !== undefined) data.tech_stack = JSON.stringify(dto.tech_stack);
+    if (dto.images !== undefined) data.images = JSON.stringify(dto.images);
+    if (dto.live_demo_url !== undefined) data.live_demo_url = dto.live_demo_url;
+    if (dto.github_url !== undefined) data.github_url = dto.github_url;
+    if (dto.client_name !== undefined) data.client_name = dto.client_name;
+    if (dto.outcomes !== undefined) data.outcomes = dto.outcomes;
+    if (dto.start_date !== undefined) data.start_date = dto.start_date;
+    if (dto.end_date !== undefined) data.end_date = dto.end_date;
+    if (dto.is_featured !== undefined) data.is_featured = dto.is_featured;
+
+    const updated = await this.db.update('portfolio_items', id, data);
+    return this.parsePortfolioItem(updated);
+  }
+
+  /**
+   * Delete a portfolio item (must be owned by the user)
+   */
+  async deletePortfolioItem(id: string, userId: string) {
+    const existing = await this.db.findOne('portfolio_items', { id });
+    if (!existing) {
+      throw new NotFoundException('Portfolio item not found');
+    }
+    if (existing.user_id !== userId) {
+      throw new ForbiddenException('You can only delete your own portfolio items');
+    }
+
+    // Delete associated snippets first
+    await this.db.deleteMany('portfolio_snippets', { portfolio_item_id: id });
+    await this.db.delete('portfolio_items', id);
+
+    return { message: 'Portfolio item deleted successfully' };
+  }
+
+  /**
+   * Get a single portfolio item by ID (public)
+   */
+  async getPortfolioItem(id: string) {
+    const item = await this.db.findOne('portfolio_items', { id });
+    if (!item) {
+      throw new NotFoundException('Portfolio item not found');
+    }
+    return this.parsePortfolioItem(item);
+  }
+
+  /**
+   * Get all portfolio items for a user (paginated, public)
+   */
+  async getPortfolioByUser(
+    userId: string,
+    options: { page?: number; limit?: number; category?: string } = {},
+  ) {
+    const page = options.page || 1;
+    const limit = Math.min(options.limit || 20, 50);
+    const offset = (page - 1) * limit;
+
+    const conditions: Record<string, any> = { user_id: userId };
+    if (options.category) {
+      conditions.category = options.category;
+    }
+
+    const result = await this.db.find('portfolio_items', conditions, {
+      orderBy: 'created_at',
+      order: 'desc',
+      limit,
+      offset,
+    });
+
+    return {
+      data: (result.data || result).map((item: any) => this.parsePortfolioItem(item)),
+      total: result.count || 0,
+      page,
+      limit,
+    };
+  }
+
+  /**
+   * Get featured portfolio items for a user (for profile card)
+   */
+  async getFeaturedPortfolio(userId: string) {
+    const items = await this.db.findMany('portfolio_items', {
+      user_id: userId,
+      is_featured: true,
+    }, {
+      orderBy: 'created_at',
+      order: 'desc',
+    });
+
+    return (items.data || items).map((item: any) => this.parsePortfolioItem(item));
+  }
+
+  // ============================================
+  // GITHUB IMPORT
+  // ============================================
+
+  /**
+   * Import pinned repositories from GitHub
+   */
+  async importFromGitHub(userId: string, githubToken: string) {
+    try {
+      // Fetch the authenticated user's login
+      const userResponse = await fetch('https://api.github.com/user', {
+        headers: {
+          Authorization: `Bearer ${githubToken}`,
+          Accept: 'application/vnd.github.v3+json',
+        },
+      });
+
+      if (!userResponse.ok) {
+        throw new BadRequestException('Invalid GitHub token or API error');
+      }
+
+      const githubUser = (await userResponse.json()) as any;
+      const login = githubUser.login;
+
+      // Fetch pinned repos via GitHub GraphQL API
+      const graphqlResponse = await fetch('https://api.github.com/graphql', {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${githubToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          query: `{
+            user(login: "${login}") {
+              pinnedItems(first: 6, types: REPOSITORY) {
+                nodes {
+                  ... on Repository {
+                    name
+                    description
+                    url
+                    stargazerCount
+                    primaryLanguage { name }
+                    languages(first: 10) { nodes { name } }
+                  }
+                }
+              }
+            }
+          }`,
+        }),
+      });
+
+      if (!graphqlResponse.ok) {
+        // Fallback: fetch top repos via REST API if GraphQL fails
+        return this.importFromGitHubRest(userId, githubToken);
+      }
+
+      const graphqlData = (await graphqlResponse.json()) as any;
+      const pinnedRepos = graphqlData?.data?.user?.pinnedItems?.nodes || [];
+
+      if (pinnedRepos.length === 0) {
+        // Fallback to top starred repos
+        return this.importFromGitHubRest(userId, githubToken);
+      }
+
+      const imported = [];
+      for (const repo of pinnedRepos) {
+        const techStack = repo.languages?.nodes?.map((l: any) => l.name) || [];
+        if (repo.primaryLanguage?.name && !techStack.includes(repo.primaryLanguage.name)) {
+          techStack.unshift(repo.primaryLanguage.name);
+        }
+
+        const item = await this.db.insert('portfolio_items', {
+          user_id: userId,
+          title: repo.name,
+          description: repo.description || `GitHub repository: ${repo.name}`,
+          category: 'other',
+          tech_stack: JSON.stringify(techStack),
+          images: JSON.stringify([]),
+          github_url: repo.url,
+          github_repo_url: repo.url,
+          github_stars: repo.stargazerCount || 0,
+          is_featured: false,
+          source: PortfolioSource.GITHUB_IMPORT,
+          start_date: new Date().toISOString().split('T')[0],
+        });
+
+        imported.push(this.parsePortfolioItem(item));
+      }
+
+      return { imported: imported.length, items: imported };
+    } catch (error) {
+      if (error instanceof BadRequestException) throw error;
+      this.logger.error('GitHub import failed', error);
+      throw new BadRequestException('Failed to import from GitHub: ' + (error as Error).message);
+    }
+  }
+
+  /**
+   * Fallback: import top starred repos via REST API
+   */
+  private async importFromGitHubRest(userId: string, githubToken: string) {
+    const reposResponse = await fetch(
+      'https://api.github.com/user/repos?sort=stars&direction=desc&per_page=6&type=owner',
+      {
+        headers: {
+          Authorization: `Bearer ${githubToken}`,
+          Accept: 'application/vnd.github.v3+json',
+        },
+      },
+    );
+
+    if (!reposResponse.ok) {
+      throw new BadRequestException('Failed to fetch GitHub repositories');
+    }
+
+    const repos = (await reposResponse.json()) as any[];
+    const imported = [];
+
+    for (const repo of repos) {
+      const techStack = repo.language ? [repo.language] : [];
+
+      const item = await this.db.insert('portfolio_items', {
+        user_id: userId,
+        title: repo.name,
+        description: repo.description || `GitHub repository: ${repo.name}`,
+        category: 'other',
+        tech_stack: JSON.stringify(techStack),
+        images: JSON.stringify([]),
+        github_url: repo.html_url,
+        github_repo_url: repo.html_url,
+        github_stars: repo.stargazers_count || 0,
+        is_featured: false,
+        source: PortfolioSource.GITHUB_IMPORT,
+        start_date: repo.created_at?.split('T')[0] || new Date().toISOString().split('T')[0],
+      });
+
+      imported.push(this.parsePortfolioItem(item));
+    }
+
+    return { imported: imported.length, items: imported };
+  }
+
+  // ============================================
+  // CODE SNIPPETS
+  // ============================================
+
+  /**
+   * Add a code snippet to a portfolio item
+   */
+  async addCodeSnippet(portfolioItemId: string, userId: string, dto: CreateCodeSnippetDto) {
+    const item = await this.db.findOne('portfolio_items', { id: portfolioItemId });
+    if (!item) {
+      throw new NotFoundException('Portfolio item not found');
+    }
+    if (item.user_id !== userId) {
+      throw new ForbiddenException('You can only add snippets to your own portfolio items');
+    }
+
+    const snippet = await this.db.insert('portfolio_snippets', {
+      portfolio_item_id: portfolioItemId,
+      language: dto.language,
+      filename: dto.filename,
+      code: dto.code,
+    });
+
+    return snippet;
+  }
+
+  /**
+   * List code snippets for a portfolio item (public)
+   */
+  async getSnippets(portfolioItemId: string) {
+    const item = await this.db.findOne('portfolio_items', { id: portfolioItemId });
+    if (!item) {
+      throw new NotFoundException('Portfolio item not found');
+    }
+
+    const snippets = await this.db.findMany('portfolio_snippets', {
+      portfolio_item_id: portfolioItemId,
+    }, {
+      orderBy: 'created_at',
+      order: 'asc',
+    });
+
+    return snippets.data || snippets;
+  }
+
+  // ============================================
+  // HELPERS
+  // ============================================
+
+  /**
+   * Parse JSONB fields from DB rows
+   */
+  private parsePortfolioItem(item: any) {
+    if (!item) return item;
+    return {
+      ...item,
+      tech_stack: this.parseJsonField(item.tech_stack, []),
+      images: this.parseJsonField(item.images, []),
+    };
+  }
+
+  private parseJsonField(value: any, fallback: any) {
+    if (value === null || value === undefined) return fallback;
+    if (typeof value === 'string') {
+      try {
+        return JSON.parse(value);
+      } catch {
+        return fallback;
+      }
+    }
+    return value;
+  }
+}


### PR DESCRIPTION
## Summary
- Add portfolio module with full CRUD for portfolio items (projects, case studies, demos) with categories, tech stacks, images, live demo URLs, and featured flags
- Implement GitHub repo import via GraphQL (pinned repos) with REST API fallback for top starred repos
- Add code snippet showcase (language, filename, code) linked to portfolio items
- Create DB migration for `portfolio_items` and `portfolio_snippets` tables with proper indexes and FK constraints
- Wire `PortfolioModule` into `app.module.ts`

Closes #51

## Endpoints
| Method | Route | Auth | Description |
|--------|-------|------|-------------|
| POST | `/portfolio` | Yes | Create portfolio item |
| GET | `/portfolio/user/:userId` | No | List user's portfolio (paginated) |
| GET | `/portfolio/user/:userId/featured` | No | Featured items for profile card |
| GET | `/portfolio/:id` | No | Single item |
| PUT | `/portfolio/:id` | Yes | Update item |
| DELETE | `/portfolio/:id` | Yes | Delete item + snippets |
| POST | `/portfolio/import/github` | Yes | Import from GitHub |
| POST | `/portfolio/:id/snippets` | Yes | Add code snippet |
| GET | `/portfolio/:id/snippets` | No | List snippets |

## Test plan
- [ ] `cd backend && npx tsc --noEmit` passes with 0 errors
- [ ] Create a portfolio item via POST `/portfolio`
- [ ] Verify pagination on GET `/portfolio/user/:userId`
- [ ] Test featured filter on GET `/portfolio/user/:userId/featured`
- [ ] Update and delete portfolio items (verify ownership check)
- [ ] Import GitHub repos with a valid token
- [ ] Add and retrieve code snippets

🤖 Generated with [Claude Code](https://claude.com/claude-code)