### PR TITLE
feat(invoicing): automated invoicing with tax document generation

### DIFF
--- a/backend/migrations/005_invoicing.sql
+++ b/backend/migrations/005_invoicing.sql
@@ -1,0 +1,56 @@
+-- Migration: 005_invoicing
+-- Description: Add invoicing and tax document tables for Team@Once
+-- Created: 2026-04-11
+
+-- Invoices table
+CREATE TABLE IF NOT EXISTS invoices (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  invoice_number VARCHAR(50) NOT NULL UNIQUE,
+  project_id UUID NOT NULL REFERENCES projects(id),
+  milestone_id UUID,
+  payment_id UUID,
+  client_id VARCHAR(255) NOT NULL,
+  contractor_id VARCHAR(255) NOT NULL,
+  amount NUMERIC NOT NULL,
+  currency VARCHAR(10) DEFAULT 'USD',
+  tax_amount NUMERIC DEFAULT 0,
+  tax_withholding_percent NUMERIC DEFAULT 0,
+  issue_date TIMESTAMPTZ NOT NULL DEFAULT now(),
+  due_date TIMESTAMPTZ,
+  paid_at TIMESTAMPTZ,
+  status VARCHAR(20) NOT NULL DEFAULT 'paid',
+  line_items JSONB DEFAULT '[]',
+  client_details JSONB DEFAULT '{}',
+  contractor_details JSONB DEFAULT '{}',
+  payment_method VARCHAR(50),
+  payment_reference VARCHAR(255),
+  notes TEXT,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_invoices_project_id ON invoices(project_id);
+CREATE INDEX IF NOT EXISTS idx_invoices_client_id ON invoices(client_id);
+CREATE INDEX IF NOT EXISTS idx_invoices_contractor_id ON invoices(contractor_id);
+CREATE INDEX IF NOT EXISTS idx_invoices_milestone_id ON invoices(milestone_id);
+CREATE INDEX IF NOT EXISTS idx_invoices_payment_id ON invoices(payment_id);
+CREATE INDEX IF NOT EXISTS idx_invoices_status ON invoices(status);
+CREATE INDEX IF NOT EXISTS idx_invoices_issue_date ON invoices(issue_date);
+CREATE INDEX IF NOT EXISTS idx_invoices_invoice_number ON invoices(invoice_number);
+
+-- Contractor tax info table
+CREATE TABLE IF NOT EXISTS contractor_tax_info (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id VARCHAR(255) NOT NULL,
+  legal_name VARCHAR(255) NOT NULL,
+  country VARCHAR(100) NOT NULL,
+  tax_id_encrypted TEXT,
+  form_type VARCHAR(20) NOT NULL DEFAULT 'W-8BEN',
+  submitted_at TIMESTAMPTZ DEFAULT now(),
+  verified BOOLEAN DEFAULT false,
+  created_at TIMESTAMPTZ DEFAULT now(),
+  updated_at TIMESTAMPTZ DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_contractor_tax_info_user_id ON contractor_tax_info(user_id);
+CREATE INDEX IF NOT EXISTS idx_contractor_tax_info_form_type ON contractor_tax_info(form_type);

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -51,6 +51,7 @@ import { SchedulerModule } from './modules/scheduler/scheduler.module';
 import { DataEngineModule } from './modules/data-engine/data-engine.module';
 import { QdrantModule } from './modules/qdrant/qdrant.module';
 import { QueueModule } from './modules/queue/queue.module';
+import { InvoicingModule } from './modules/invoicing/invoicing.module';
 
 @Module({
   imports: [
@@ -106,6 +107,9 @@ import { QueueModule } from './modules/queue/queue.module';
     HireRequestModule,
     SchedulerModule,
     DataEngineModule,
+
+    // Invoicing & Tax Documents
+    InvoicingModule,
 
     // Infrastructure modules (Global)
     QdrantModule,

--- a/backend/src/database/schema.ts
+++ b/backend/src/database/schema.ts
@@ -2049,5 +2049,66 @@ export const schema = {
       { columns: ['email'], unique: true },
       { columns: ['reason'] }
     ]
+  },
+
+  // ============================================
+  // INVOICING & TAX DOCUMENTS
+  // ============================================
+
+  invoices: {
+    columns: [
+      { name: 'id', type: 'uuid', primaryKey: true, default: 'gen_random_uuid()' },
+      { name: 'invoice_number', type: 'string', nullable: false }, // UNIQUE, sequential: INV-2026-00001
+      { name: 'project_id', type: 'uuid', nullable: false },
+      { name: 'milestone_id', type: 'uuid', nullable: true },
+      { name: 'payment_id', type: 'uuid', nullable: true },
+      { name: 'client_id', type: 'string', nullable: false }, // payer user ID
+      { name: 'contractor_id', type: 'string', nullable: false }, // payee user ID
+      { name: 'amount', type: 'numeric', nullable: false },
+      { name: 'currency', type: 'string', default: 'USD' },
+      { name: 'tax_amount', type: 'numeric', default: 0 },
+      { name: 'tax_withholding_percent', type: 'numeric', default: 0 },
+      { name: 'issue_date', type: 'timestamptz', default: 'now()' },
+      { name: 'due_date', type: 'timestamptz', nullable: true },
+      { name: 'paid_at', type: 'timestamptz', nullable: true },
+      { name: 'status', type: 'string', default: 'paid' }, // draft, sent, paid, cancelled
+      { name: 'line_items', type: 'jsonb', default: '[]' },
+      { name: 'client_details', type: 'jsonb', default: '{}' },
+      { name: 'contractor_details', type: 'jsonb', default: '{}' },
+      { name: 'payment_method', type: 'string', nullable: true },
+      { name: 'payment_reference', type: 'string', nullable: true }, // Stripe charge ID
+      { name: 'notes', type: 'text', nullable: true },
+      { name: 'created_at', type: 'timestamptz', default: 'now()' },
+      { name: 'updated_at', type: 'timestamptz', default: 'now()' }
+    ],
+    indexes: [
+      { columns: ['invoice_number'], unique: true },
+      { columns: ['project_id'] },
+      { columns: ['client_id'] },
+      { columns: ['contractor_id'] },
+      { columns: ['milestone_id'] },
+      { columns: ['payment_id'] },
+      { columns: ['status'] },
+      { columns: ['issue_date'] }
+    ]
+  },
+
+  contractor_tax_info: {
+    columns: [
+      { name: 'id', type: 'uuid', primaryKey: true, default: 'gen_random_uuid()' },
+      { name: 'user_id', type: 'string', nullable: false },
+      { name: 'legal_name', type: 'string', nullable: false },
+      { name: 'country', type: 'string', nullable: false },
+      { name: 'tax_id_encrypted', type: 'text', nullable: true },
+      { name: 'form_type', type: 'string', default: 'W-8BEN' }, // W-8BEN or W-9
+      { name: 'submitted_at', type: 'timestamptz', default: 'now()' },
+      { name: 'verified', type: 'boolean', default: false },
+      { name: 'created_at', type: 'timestamptz', default: 'now()' },
+      { name: 'updated_at', type: 'timestamptz', default: 'now()' }
+    ],
+    indexes: [
+      { columns: ['user_id'] },
+      { columns: ['form_type'] }
+    ]
   }
 };

--- a/backend/src/modules/escrow/escrow.module.ts
+++ b/backend/src/modules/escrow/escrow.module.ts
@@ -10,6 +10,7 @@ import { StripeConnectService } from './stripe-connect.service';
 import { EscrowAutomationService } from './escrow-automation.service';
 import { EscrowController, EscrowWebhookController } from './escrow.controller';
 import { AuthModule } from '../auth/auth.module';
+import { InvoicingModule } from '../invoicing/invoicing.module';
 
 @Module({
   imports: [
@@ -19,6 +20,7 @@ import { AuthModule } from '../auth/auth.module';
     TeamAtOnceWebSocketModule, // Import WebSocket for real-time notifications
     ScheduleModule.forRoot(), // Enable cron jobs
     AuthModule,
+    forwardRef(() => InvoicingModule), // Import for auto-invoice generation on escrow release
   ],
   providers: [
     EscrowService,

--- a/backend/src/modules/escrow/escrow.service.ts
+++ b/backend/src/modules/escrow/escrow.service.ts
@@ -14,6 +14,7 @@ import { NotificationsService } from '../notifications/notifications.service';
 import { NotificationType, NotificationPriority } from '../notifications/dto';
 import { TeamAtOnceGateway } from '../../websocket/teamatonce.gateway';
 import { StripeConnectService } from './stripe-connect.service';
+import { InvoicingService } from '../invoicing/invoicing.service';
 
 /**
  * Escrow Service
@@ -54,6 +55,8 @@ export class EscrowService {
     @Inject(forwardRef(() => TeamAtOnceGateway))
     private readonly teamAtOnceGateway: TeamAtOnceGateway,
     private readonly stripeConnect: StripeConnectService,
+    @Inject(forwardRef(() => InvoicingService))
+    private readonly invoicingService: InvoicingService,
   ) {
     // Load configuration from environment variables
     this.PLATFORM_FEE_PERCENT = this.config.get<number>('PLATFORM_FEE_PERCENT', 0);
@@ -670,6 +673,15 @@ export class EscrowService {
       }
     } catch (error) {
       this.logger.error(`Failed to send payment released notification: ${error.message}`);
+    }
+
+    // Auto-generate invoice after successful escrow release
+    try {
+      await this.invoicingService.generateInvoice(payment.id, milestoneId);
+      this.logger.log(`Invoice generated for payment ${payment.id}, milestone ${milestoneId}`);
+    } catch (error) {
+      this.logger.error(`Failed to generate invoice: ${error.message}`);
+      // Non-blocking: invoice generation failure should not block the release flow
     }
 
     return {

--- a/backend/src/modules/invoicing/dto/invoicing.dto.ts
+++ b/backend/src/modules/invoicing/dto/invoicing.dto.ts
@@ -1,0 +1,59 @@
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+import { IsString, IsOptional, IsNumber, IsDateString, IsEnum } from 'class-validator';
+
+export class InvoiceFilterDto {
+  @ApiPropertyOptional({ description: 'Filter by project ID' })
+  @IsOptional()
+  @IsString()
+  projectId?: string;
+
+  @ApiPropertyOptional({ description: 'Filter by status' })
+  @IsOptional()
+  @IsString()
+  status?: string;
+
+  @ApiPropertyOptional({ description: 'Filter start date (ISO)' })
+  @IsOptional()
+  @IsDateString()
+  startDate?: string;
+
+  @ApiPropertyOptional({ description: 'Filter end date (ISO)' })
+  @IsOptional()
+  @IsDateString()
+  endDate?: string;
+
+  @ApiPropertyOptional({ description: 'Page number', default: 1 })
+  @IsOptional()
+  @IsNumber()
+  page?: number;
+
+  @ApiPropertyOptional({ description: 'Items per page', default: 20 })
+  @IsOptional()
+  @IsNumber()
+  limit?: number;
+}
+
+export class TaxYearQueryDto {
+  @ApiProperty({ description: 'Tax year', example: 2026 })
+  @IsString()
+  year: string;
+}
+
+export class SubmitW8BENDto {
+  @ApiProperty({ description: 'Legal name as shown on tax documents' })
+  @IsString()
+  legalName: string;
+
+  @ApiProperty({ description: 'Country of residence' })
+  @IsString()
+  countryOfResidence: string;
+
+  @ApiProperty({ description: 'Foreign tax identifying number' })
+  @IsString()
+  taxId: string;
+
+  @ApiPropertyOptional({ description: 'Signature date (ISO)' })
+  @IsOptional()
+  @IsDateString()
+  signatureDate?: string;
+}

--- a/backend/src/modules/invoicing/invoicing.controller.ts
+++ b/backend/src/modules/invoicing/invoicing.controller.ts
@@ -1,0 +1,238 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Body,
+  Param,
+  Query,
+  Req,
+  Res,
+  UseGuards,
+  HttpException,
+  HttpStatus,
+} from '@nestjs/common';
+import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse, ApiQuery } from '@nestjs/swagger';
+import { Response } from 'express';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { InvoicingService } from './invoicing.service';
+import { SubmitW8BENDto } from './dto/invoicing.dto';
+
+@ApiTags('invoices')
+@ApiBearerAuth()
+@Controller('invoices')
+@UseGuards(JwtAuthGuard)
+export class InvoicingController {
+  constructor(private readonly invoicingService: InvoicingService) {}
+
+  /**
+   * List invoices for the authenticated user (as client or contractor).
+   */
+  @Get()
+  @ApiOperation({ summary: 'List my invoices' })
+  @ApiResponse({ status: 200, description: 'Invoices retrieved successfully' })
+  @ApiQuery({ name: 'projectId', required: false })
+  @ApiQuery({ name: 'status', required: false })
+  @ApiQuery({ name: 'startDate', required: false })
+  @ApiQuery({ name: 'endDate', required: false })
+  @ApiQuery({ name: 'page', required: false })
+  @ApiQuery({ name: 'limit', required: false })
+  async listInvoices(
+    @Req() req: any,
+    @Query('projectId') projectId?: string,
+    @Query('status') status?: string,
+    @Query('startDate') startDate?: string,
+    @Query('endDate') endDate?: string,
+    @Query('page') page?: string,
+    @Query('limit') limit?: string,
+  ) {
+    try {
+      const userId = req.user?.sub || req.user?.userId;
+      if (!userId) {
+        throw new HttpException('User not authenticated', HttpStatus.UNAUTHORIZED);
+      }
+
+      const result = await this.invoicingService.listInvoices(userId, {
+        projectId,
+        status,
+        startDate,
+        endDate,
+        page: page ? parseInt(page, 10) : undefined,
+        limit: limit ? parseInt(limit, 10) : undefined,
+      });
+
+      return {
+        success: true,
+        data: result,
+      };
+    } catch (error) {
+      throw new HttpException(
+        error.message || 'Failed to list invoices',
+        error.status || HttpStatus.BAD_REQUEST,
+      );
+    }
+  }
+
+  /**
+   * Get invoice summary stats.
+   */
+  @Get('stats')
+  @ApiOperation({ summary: 'Get invoice summary stats' })
+  @ApiResponse({ status: 200, description: 'Stats retrieved successfully' })
+  async getInvoiceStats(@Req() req: any) {
+    try {
+      const userId = req.user?.sub || req.user?.userId;
+      if (!userId) {
+        throw new HttpException('User not authenticated', HttpStatus.UNAUTHORIZED);
+      }
+
+      const stats = await this.invoicingService.getInvoiceStats(userId);
+      return {
+        success: true,
+        data: stats,
+      };
+    } catch (error) {
+      throw new HttpException(
+        error.message || 'Failed to get invoice stats',
+        error.status || HttpStatus.BAD_REQUEST,
+      );
+    }
+  }
+
+  /**
+   * Get 1099 summary for a tax year (for clients).
+   */
+  @Get('tax/1099-summary')
+  @ApiOperation({ summary: 'Get 1099 summary for a tax year' })
+  @ApiResponse({ status: 200, description: '1099 summary retrieved successfully' })
+  @ApiQuery({ name: 'year', required: true, example: '2026' })
+  async get1099Summary(@Req() req: any, @Query('year') year: string) {
+    try {
+      const userId = req.user?.sub || req.user?.userId;
+      if (!userId) {
+        throw new HttpException('User not authenticated', HttpStatus.UNAUTHORIZED);
+      }
+
+      if (!year) {
+        throw new HttpException('Year parameter is required', HttpStatus.BAD_REQUEST);
+      }
+
+      const summary = await this.invoicingService.generate1099Summary(userId, year);
+      return {
+        success: true,
+        data: summary,
+      };
+    } catch (error) {
+      throw new HttpException(
+        error.message || 'Failed to generate 1099 summary',
+        error.status || HttpStatus.BAD_REQUEST,
+      );
+    }
+  }
+
+  /**
+   * Submit W-8BEN tax information.
+   */
+  @Post('tax/w8ben')
+  @ApiOperation({ summary: 'Submit W-8BEN tax information' })
+  @ApiResponse({ status: 201, description: 'W-8BEN information submitted successfully' })
+  async submitW8BEN(@Req() req: any, @Body() dto: SubmitW8BENDto) {
+    try {
+      const userId = req.user?.sub || req.user?.userId;
+      if (!userId) {
+        throw new HttpException('User not authenticated', HttpStatus.UNAUTHORIZED);
+      }
+
+      const result = await this.invoicingService.collectW8BEN(userId, dto);
+      return {
+        success: true,
+        message: 'W-8BEN information submitted successfully',
+        data: result,
+      };
+    } catch (error) {
+      throw new HttpException(
+        error.message || 'Failed to submit W-8BEN information',
+        error.status || HttpStatus.BAD_REQUEST,
+      );
+    }
+  }
+
+  /**
+   * Get W-8BEN status.
+   */
+  @Get('tax/w8ben')
+  @ApiOperation({ summary: 'Get W-8BEN status' })
+  @ApiResponse({ status: 200, description: 'W-8BEN status retrieved successfully' })
+  async getW8BENStatus(@Req() req: any) {
+    try {
+      const userId = req.user?.sub || req.user?.userId;
+      if (!userId) {
+        throw new HttpException('User not authenticated', HttpStatus.UNAUTHORIZED);
+      }
+
+      const status = await this.invoicingService.getW8BENStatus(userId);
+      return {
+        success: true,
+        data: status,
+      };
+    } catch (error) {
+      throw new HttpException(
+        error.message || 'Failed to get W-8BEN status',
+        error.status || HttpStatus.BAD_REQUEST,
+      );
+    }
+  }
+
+  /**
+   * Get single invoice details.
+   */
+  @Get(':id')
+  @ApiOperation({ summary: 'Get invoice details' })
+  @ApiResponse({ status: 200, description: 'Invoice retrieved successfully' })
+  @ApiResponse({ status: 404, description: 'Invoice not found' })
+  async getInvoice(@Param('id') id: string, @Req() req: any) {
+    try {
+      const userId = req.user?.sub || req.user?.userId;
+      if (!userId) {
+        throw new HttpException('User not authenticated', HttpStatus.UNAUTHORIZED);
+      }
+
+      const invoice = await this.invoicingService.getInvoice(id, userId);
+      return {
+        success: true,
+        data: invoice,
+      };
+    } catch (error) {
+      throw new HttpException(
+        error.message || 'Failed to get invoice',
+        error.status || HttpStatus.NOT_FOUND,
+      );
+    }
+  }
+
+  /**
+   * Download invoice as HTML (PDF placeholder).
+   */
+  @Get(':id/pdf')
+  @ApiOperation({ summary: 'Download invoice as HTML' })
+  @ApiResponse({ status: 200, description: 'Invoice HTML generated successfully' })
+  @ApiResponse({ status: 404, description: 'Invoice not found' })
+  async getInvoicePdf(@Param('id') id: string, @Req() req: any, @Res() res: Response) {
+    try {
+      const userId = req.user?.sub || req.user?.userId;
+      if (!userId) {
+        throw new HttpException('User not authenticated', HttpStatus.UNAUTHORIZED);
+      }
+
+      const html = await this.invoicingService.getInvoicePdf(id, userId);
+
+      res.setHeader('Content-Type', 'text/html; charset=utf-8');
+      res.setHeader('Content-Disposition', `inline; filename="invoice-${id}.html"`);
+      res.send(html);
+    } catch (error) {
+      throw new HttpException(
+        error.message || 'Failed to generate invoice PDF',
+        error.status || HttpStatus.NOT_FOUND,
+      );
+    }
+  }
+}

--- a/backend/src/modules/invoicing/invoicing.module.ts
+++ b/backend/src/modules/invoicing/invoicing.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { InvoicingService } from './invoicing.service';
+import { InvoicingController } from './invoicing.controller';
+import { AuthModule } from '../auth/auth.module';
+
+@Module({
+  imports: [
+    ConfigModule,
+    AuthModule,
+  ],
+  controllers: [InvoicingController],
+  providers: [InvoicingService],
+  exports: [InvoicingService],
+})
+export class InvoicingModule {}

--- a/backend/src/modules/invoicing/invoicing.service.ts
+++ b/backend/src/modules/invoicing/invoicing.service.ts
@@ -1,0 +1,596 @@
+import { Injectable, Logger, NotFoundException, ForbiddenException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import * as crypto from 'crypto';
+import { DatabaseService } from '../database/database.service';
+import { SubmitW8BENDto } from './dto/invoicing.dto';
+
+@Injectable()
+export class InvoicingService {
+  private readonly logger = new Logger(InvoicingService.name);
+  private readonly encryptionKey: Buffer;
+  private readonly encryptionAlgorithm = 'aes-256-cbc';
+
+  constructor(
+    private readonly db: DatabaseService,
+    private readonly config: ConfigService,
+  ) {
+    // Derive a 32-byte key from the configured secret (or fallback)
+    const secret = this.config.get<string>('INVOICE_ENCRYPTION_KEY') ||
+                   this.config.get<string>('JWT_SECRET') ||
+                   'default-invoice-encryption-key-32';
+    this.encryptionKey = crypto.scryptSync(secret, 'salt', 32);
+    this.logger.log('InvoicingService initialized');
+  }
+
+  // ============================================
+  // INVOICE GENERATION
+  // ============================================
+
+  /**
+   * Auto-generate an invoice when an escrow milestone is released.
+   * Pulls data from project, milestone, payment, client, and contractor.
+   */
+  async generateInvoice(paymentId: string, milestoneId: string): Promise<any> {
+    this.logger.log(`Generating invoice for payment ${paymentId}, milestone ${milestoneId}`);
+
+    // Fetch payment
+    const payment = await this.db.findOne('payments', { id: paymentId });
+    if (!payment) {
+      throw new NotFoundException('Payment not found');
+    }
+
+    // Fetch milestone
+    const milestone = await this.db.findOne('project_milestones', { id: milestoneId });
+    if (!milestone) {
+      throw new NotFoundException('Milestone not found');
+    }
+
+    // Fetch project
+    const project = await this.db.findOne('projects', { id: payment.project_id });
+    if (!project) {
+      throw new NotFoundException('Project not found');
+    }
+
+    // Determine contractor (payee) from payment metadata or project
+    const paymentMetadata = this.safeJsonParse(payment.metadata);
+    let contractorId = paymentMetadata?.developer_id || project.team_lead_id;
+
+    // Fallback: find from assigned company
+    if (!contractorId && project.assigned_company_id) {
+      const member = await this.db.findOne('company_team_members', {
+        company_id: project.assigned_company_id,
+        role: 'owner',
+        status: 'active',
+      });
+      contractorId = member?.user_id;
+    }
+
+    if (!contractorId) {
+      contractorId = 'unknown';
+    }
+
+    const clientId = payment.client_id;
+
+    // Generate sequential invoice number
+    const invoiceNumber = await this.generateInvoiceNumber();
+
+    const now = new Date().toISOString();
+
+    // Build line items
+    const lineItems = [
+      {
+        description: `${milestone.name || 'Milestone'} - ${project.name || 'Project'}`,
+        quantity: 1,
+        unit_price: parseFloat(payment.amount) || 0,
+        amount: parseFloat(payment.amount) || 0,
+      },
+    ];
+
+    // Build client/contractor details snapshots
+    const clientDetails = {
+      user_id: clientId,
+      project_name: project.name,
+    };
+
+    const contractorDetails = {
+      user_id: contractorId,
+    };
+
+    const invoice = await this.db.insert('invoices', {
+      invoice_number: invoiceNumber,
+      project_id: payment.project_id,
+      milestone_id: milestoneId,
+      payment_id: paymentId,
+      client_id: clientId,
+      contractor_id: contractorId,
+      amount: payment.amount,
+      currency: payment.currency || 'USD',
+      tax_amount: 0,
+      tax_withholding_percent: 0,
+      issue_date: now,
+      due_date: now,
+      paid_at: now,
+      status: 'paid',
+      line_items: JSON.stringify(lineItems),
+      client_details: JSON.stringify(clientDetails),
+      contractor_details: JSON.stringify(contractorDetails),
+      payment_method: payment.payment_method || 'stripe',
+      payment_reference: payment.stripe_charge_id || payment.stripe_payment_intent_id || null,
+      notes: `Auto-generated invoice for milestone "${milestone.name}" release`,
+      created_at: now,
+      updated_at: now,
+    });
+
+    this.logger.log(`Invoice ${invoiceNumber} generated successfully`);
+    return this.parseInvoice(invoice);
+  }
+
+  // ============================================
+  // INVOICE PDF / HTML
+  // ============================================
+
+  /**
+   * Generate an HTML invoice document.
+   * Only accessible by the client or contractor on the invoice.
+   */
+  async getInvoicePdf(invoiceId: string, userId: string): Promise<string> {
+    const invoice = await this.db.findOne('invoices', { id: invoiceId });
+    if (!invoice) {
+      throw new NotFoundException('Invoice not found');
+    }
+
+    if (invoice.client_id !== userId && invoice.contractor_id !== userId) {
+      throw new ForbiddenException('You do not have access to this invoice');
+    }
+
+    const lineItems = this.safeJsonParse(invoice.line_items) || [];
+    const clientDetails = this.safeJsonParse(invoice.client_details) || {};
+    const contractorDetails = this.safeJsonParse(invoice.contractor_details) || {};
+
+    const lineItemsHtml = lineItems.map((item: any) => `
+      <tr>
+        <td style="padding: 10px; border-bottom: 1px solid #eee;">${this.escapeHtml(item.description || '')}</td>
+        <td style="padding: 10px; border-bottom: 1px solid #eee; text-align: center;">${item.quantity || 1}</td>
+        <td style="padding: 10px; border-bottom: 1px solid #eee; text-align: right;">$${(item.unit_price || 0).toFixed(2)}</td>
+        <td style="padding: 10px; border-bottom: 1px solid #eee; text-align: right;">$${(item.amount || 0).toFixed(2)}</td>
+      </tr>
+    `).join('');
+
+    const amount = parseFloat(invoice.amount) || 0;
+    const taxAmount = parseFloat(invoice.tax_amount) || 0;
+    const total = amount + taxAmount;
+
+    return `<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Invoice ${this.escapeHtml(invoice.invoice_number)}</title>
+  <style>
+    body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; margin: 0; padding: 40px; color: #333; }
+    .invoice-container { max-width: 800px; margin: 0 auto; }
+    .header { display: flex; justify-content: space-between; align-items: flex-start; margin-bottom: 40px; }
+    .logo { font-size: 28px; font-weight: bold; color: #2563eb; }
+    .invoice-title { text-align: right; }
+    .invoice-title h1 { margin: 0; color: #2563eb; font-size: 32px; }
+    .invoice-meta { margin-top: 8px; color: #666; }
+    .parties { display: flex; justify-content: space-between; margin-bottom: 40px; }
+    .party { width: 45%; }
+    .party h3 { color: #666; font-size: 12px; text-transform: uppercase; letter-spacing: 1px; margin-bottom: 8px; }
+    .party p { margin: 4px 0; }
+    table { width: 100%; border-collapse: collapse; margin-bottom: 30px; }
+    th { background: #f8fafc; padding: 12px 10px; text-align: left; font-size: 12px; text-transform: uppercase; letter-spacing: 0.5px; color: #666; border-bottom: 2px solid #e2e8f0; }
+    .totals { text-align: right; }
+    .totals .row { display: flex; justify-content: flex-end; padding: 6px 0; }
+    .totals .label { width: 150px; text-align: right; padding-right: 20px; color: #666; }
+    .totals .value { width: 120px; text-align: right; }
+    .totals .total-row { font-size: 18px; font-weight: bold; border-top: 2px solid #333; padding-top: 10px; margin-top: 6px; }
+    .status-badge { display: inline-block; padding: 4px 12px; border-radius: 12px; font-size: 12px; font-weight: 600; text-transform: uppercase; }
+    .status-paid { background: #dcfce7; color: #166534; }
+    .status-draft { background: #f3f4f6; color: #374151; }
+    .status-cancelled { background: #fef2f2; color: #991b1b; }
+    .footer { margin-top: 60px; padding-top: 20px; border-top: 1px solid #eee; color: #999; font-size: 12px; text-align: center; }
+  </style>
+</head>
+<body>
+  <div class="invoice-container">
+    <div class="header">
+      <div class="logo">Team@Once</div>
+      <div class="invoice-title">
+        <h1>INVOICE</h1>
+        <div class="invoice-meta">
+          <p><strong>${this.escapeHtml(invoice.invoice_number)}</strong></p>
+          <p>Issued: ${new Date(invoice.issue_date).toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' })}</p>
+          <p><span class="status-badge status-${invoice.status}">${invoice.status}</span></p>
+        </div>
+      </div>
+    </div>
+
+    <div class="parties">
+      <div class="party">
+        <h3>Bill From (Contractor)</h3>
+        <p><strong>User ID:</strong> ${this.escapeHtml(contractorDetails.user_id || invoice.contractor_id)}</p>
+      </div>
+      <div class="party">
+        <h3>Bill To (Client)</h3>
+        <p><strong>User ID:</strong> ${this.escapeHtml(clientDetails.user_id || invoice.client_id)}</p>
+        <p><strong>Project:</strong> ${this.escapeHtml(clientDetails.project_name || '')}</p>
+      </div>
+    </div>
+
+    <table>
+      <thead>
+        <tr>
+          <th>Description</th>
+          <th style="text-align: center;">Qty</th>
+          <th style="text-align: right;">Unit Price</th>
+          <th style="text-align: right;">Amount</th>
+        </tr>
+      </thead>
+      <tbody>
+        ${lineItemsHtml}
+      </tbody>
+    </table>
+
+    <div class="totals">
+      <div class="row">
+        <span class="label">Subtotal:</span>
+        <span class="value">$${amount.toFixed(2)}</span>
+      </div>
+      <div class="row">
+        <span class="label">Tax:</span>
+        <span class="value">$${taxAmount.toFixed(2)}</span>
+      </div>
+      <div class="row total-row">
+        <span class="label">Total (${this.escapeHtml(invoice.currency || 'USD')}):</span>
+        <span class="value">$${total.toFixed(2)}</span>
+      </div>
+    </div>
+
+    ${invoice.payment_reference ? `<p style="margin-top: 20px; color: #666;"><strong>Payment Reference:</strong> ${this.escapeHtml(invoice.payment_reference)}</p>` : ''}
+    ${invoice.notes ? `<p style="color: #666;"><strong>Notes:</strong> ${this.escapeHtml(invoice.notes)}</p>` : ''}
+
+    <div class="footer">
+      <p>This invoice was auto-generated by Team@Once. For questions, contact support@teamatonce.com</p>
+    </div>
+  </div>
+</body>
+</html>`;
+  }
+
+  // ============================================
+  // LIST & STATS
+  // ============================================
+
+  /**
+   * List invoices for a user (as payer or payee) with filters.
+   */
+  async listInvoices(userId: string, filters: {
+    projectId?: string;
+    status?: string;
+    startDate?: string;
+    endDate?: string;
+    page?: number;
+    limit?: number;
+  }): Promise<{ invoices: any[]; total: number; page: number; limit: number }> {
+    const page = filters.page || 1;
+    const limit = filters.limit || 20;
+    const offset = (page - 1) * limit;
+
+    // Build WHERE clause: user must be client OR contractor
+    let whereConditions = [`(client_id = $1 OR contractor_id = $1)`];
+    const params: any[] = [userId];
+    let paramIndex = 2;
+
+    if (filters.projectId) {
+      whereConditions.push(`project_id = $${paramIndex}`);
+      params.push(filters.projectId);
+      paramIndex++;
+    }
+
+    if (filters.status) {
+      whereConditions.push(`status = $${paramIndex}`);
+      params.push(filters.status);
+      paramIndex++;
+    }
+
+    if (filters.startDate) {
+      whereConditions.push(`issue_date >= $${paramIndex}`);
+      params.push(filters.startDate);
+      paramIndex++;
+    }
+
+    if (filters.endDate) {
+      whereConditions.push(`issue_date <= $${paramIndex}`);
+      params.push(filters.endDate);
+      paramIndex++;
+    }
+
+    const whereClause = whereConditions.join(' AND ');
+
+    // Count query
+    const countResult = await this.db.query(
+      `SELECT COUNT(*) as count FROM invoices WHERE ${whereClause}`,
+      params,
+    );
+    const total = parseInt(countResult.rows[0]?.count || '0', 10);
+
+    // Data query
+    const dataParams = [...params, limit, offset];
+    const result = await this.db.query(
+      `SELECT * FROM invoices WHERE ${whereClause} ORDER BY issue_date DESC LIMIT $${paramIndex} OFFSET $${paramIndex + 1}`,
+      dataParams,
+    );
+
+    return {
+      invoices: (result.rows || []).map((inv: any) => this.parseInvoice(inv)),
+      total,
+      page,
+      limit,
+    };
+  }
+
+  /**
+   * Get a single invoice by ID (with access check).
+   */
+  async getInvoice(invoiceId: string, userId: string): Promise<any> {
+    const invoice = await this.db.findOne('invoices', { id: invoiceId });
+    if (!invoice) {
+      throw new NotFoundException('Invoice not found');
+    }
+
+    if (invoice.client_id !== userId && invoice.contractor_id !== userId) {
+      throw new ForbiddenException('You do not have access to this invoice');
+    }
+
+    return this.parseInvoice(invoice);
+  }
+
+  /**
+   * Summary stats: total invoiced, total paid, this month, this year.
+   */
+  async getInvoiceStats(userId: string): Promise<any> {
+    const now = new Date();
+    const startOfMonth = new Date(now.getFullYear(), now.getMonth(), 1).toISOString();
+    const startOfYear = new Date(now.getFullYear(), 0, 1).toISOString();
+
+    // Total invoiced (as contractor - money earned)
+    const totalResult = await this.db.query(
+      `SELECT COALESCE(SUM(amount), 0) as total, COUNT(*) as count FROM invoices WHERE (client_id = $1 OR contractor_id = $1)`,
+      [userId],
+    );
+
+    // Total paid
+    const paidResult = await this.db.query(
+      `SELECT COALESCE(SUM(amount), 0) as total, COUNT(*) as count FROM invoices WHERE (client_id = $1 OR contractor_id = $1) AND status = 'paid'`,
+      [userId],
+    );
+
+    // This month
+    const monthResult = await this.db.query(
+      `SELECT COALESCE(SUM(amount), 0) as total, COUNT(*) as count FROM invoices WHERE (client_id = $1 OR contractor_id = $1) AND issue_date >= $2`,
+      [userId, startOfMonth],
+    );
+
+    // This year
+    const yearResult = await this.db.query(
+      `SELECT COALESCE(SUM(amount), 0) as total, COUNT(*) as count FROM invoices WHERE (client_id = $1 OR contractor_id = $1) AND issue_date >= $2`,
+      [userId, startOfYear],
+    );
+
+    return {
+      total_invoiced: parseFloat(totalResult.rows[0]?.total) || 0,
+      total_invoiced_count: parseInt(totalResult.rows[0]?.count) || 0,
+      total_paid: parseFloat(paidResult.rows[0]?.total) || 0,
+      total_paid_count: parseInt(paidResult.rows[0]?.count) || 0,
+      this_month: parseFloat(monthResult.rows[0]?.total) || 0,
+      this_month_count: parseInt(monthResult.rows[0]?.count) || 0,
+      this_year: parseFloat(yearResult.rows[0]?.total) || 0,
+      this_year_count: parseInt(yearResult.rows[0]?.count) || 0,
+    };
+  }
+
+  // ============================================
+  // TAX DOCUMENT STUBS
+  // ============================================
+
+  /**
+   * For US clients, summarize all payments to contractors in a given tax year.
+   * Groups by contractor and flags those who earned >$600 (1099-NEC threshold).
+   */
+  async generate1099Summary(clientId: string, year: string): Promise<any> {
+    const startDate = `${year}-01-01T00:00:00.000Z`;
+    const endDate = `${year}-12-31T23:59:59.999Z`;
+
+    const result = await this.db.query(
+      `SELECT contractor_id,
+              SUM(amount) as total_paid,
+              COUNT(*) as invoice_count,
+              MIN(issue_date) as first_payment,
+              MAX(issue_date) as last_payment
+       FROM invoices
+       WHERE client_id = $1
+         AND status = 'paid'
+         AND issue_date >= $2
+         AND issue_date <= $3
+       GROUP BY contractor_id
+       ORDER BY total_paid DESC`,
+      [clientId, startDate, endDate],
+    );
+
+    const contractors = (result.rows || []).map((row: any) => ({
+      contractor_id: row.contractor_id,
+      total_paid: parseFloat(row.total_paid) || 0,
+      invoice_count: parseInt(row.invoice_count) || 0,
+      first_payment: row.first_payment,
+      last_payment: row.last_payment,
+      requires_1099: (parseFloat(row.total_paid) || 0) >= 600,
+    }));
+
+    const totalPaid = contractors.reduce((sum: number, c: any) => sum + c.total_paid, 0);
+    const contractorsRequiring1099 = contractors.filter((c: any) => c.requires_1099);
+
+    return {
+      client_id: clientId,
+      tax_year: year,
+      total_paid_to_contractors: totalPaid,
+      total_contractors: contractors.length,
+      contractors_requiring_1099: contractorsRequiring1099.length,
+      threshold: 600,
+      contractors,
+      generated_at: new Date().toISOString(),
+      disclaimer: 'This is a summary for informational purposes. Consult a tax professional for actual 1099-NEC filing requirements.',
+    };
+  }
+
+  /**
+   * Store W-8BEN information for international contractors.
+   * Sensitive fields (tax ID) are encrypted.
+   */
+  async collectW8BEN(contractorId: string, dto: SubmitW8BENDto): Promise<any> {
+    const now = new Date().toISOString();
+
+    // Encrypt the tax ID
+    const encryptedTaxId = this.encrypt(dto.taxId);
+
+    // Check if existing record
+    const existing = await this.db.findOne('contractor_tax_info', { user_id: contractorId });
+
+    if (existing) {
+      // Update existing record
+      const updated = await this.db.update('contractor_tax_info', existing.id, {
+        legal_name: dto.legalName,
+        country: dto.countryOfResidence,
+        tax_id_encrypted: encryptedTaxId,
+        form_type: 'W-8BEN',
+        submitted_at: dto.signatureDate || now,
+        verified: false,
+        updated_at: now,
+      });
+      return this.sanitizeTaxInfo(updated);
+    }
+
+    // Insert new
+    const taxInfo = await this.db.insert('contractor_tax_info', {
+      user_id: contractorId,
+      legal_name: dto.legalName,
+      country: dto.countryOfResidence,
+      tax_id_encrypted: encryptedTaxId,
+      form_type: 'W-8BEN',
+      submitted_at: dto.signatureDate || now,
+      verified: false,
+      created_at: now,
+      updated_at: now,
+    });
+
+    return this.sanitizeTaxInfo(taxInfo);
+  }
+
+  /**
+   * Get W-8BEN status for a contractor (without exposing encrypted tax ID).
+   */
+  async getW8BENStatus(contractorId: string): Promise<any> {
+    const taxInfo = await this.db.findOne('contractor_tax_info', { user_id: contractorId });
+    if (!taxInfo) {
+      return {
+        submitted: false,
+        message: 'No W-8BEN information on file',
+      };
+    }
+
+    return {
+      submitted: true,
+      ...this.sanitizeTaxInfo(taxInfo),
+    };
+  }
+
+  // ============================================
+  // HELPERS
+  // ============================================
+
+  private async generateInvoiceNumber(): Promise<string> {
+    const year = new Date().getFullYear();
+    const prefix = `INV-${year}-`;
+
+    // Get the latest invoice number for this year
+    const result = await this.db.query(
+      `SELECT invoice_number FROM invoices WHERE invoice_number LIKE $1 ORDER BY invoice_number DESC LIMIT 1`,
+      [`${prefix}%`],
+    );
+
+    let sequence = 1;
+    if (result.rows && result.rows.length > 0) {
+      const lastNumber = result.rows[0].invoice_number;
+      const lastSequence = parseInt(lastNumber.replace(prefix, ''), 10);
+      if (!isNaN(lastSequence)) {
+        sequence = lastSequence + 1;
+      }
+    }
+
+    return `${prefix}${String(sequence).padStart(5, '0')}`;
+  }
+
+  private encrypt(text: string): string {
+    const iv = crypto.randomBytes(16);
+    const cipher = crypto.createCipheriv(this.encryptionAlgorithm, this.encryptionKey, iv);
+    let encrypted = cipher.update(text, 'utf8', 'hex');
+    encrypted += cipher.final('hex');
+    return iv.toString('hex') + ':' + encrypted;
+  }
+
+  private decrypt(encryptedText: string): string {
+    const parts = encryptedText.split(':');
+    const iv = Buffer.from(parts[0], 'hex');
+    const encrypted = parts[1];
+    const decipher = crypto.createDecipheriv(this.encryptionAlgorithm, this.encryptionKey, iv);
+    let decrypted = decipher.update(encrypted, 'hex', 'utf8');
+    decrypted += decipher.final('utf8');
+    return decrypted;
+  }
+
+  private sanitizeTaxInfo(taxInfo: any): any {
+    return {
+      id: taxInfo.id,
+      user_id: taxInfo.user_id,
+      legal_name: taxInfo.legal_name,
+      country: taxInfo.country,
+      form_type: taxInfo.form_type,
+      submitted_at: taxInfo.submitted_at,
+      verified: taxInfo.verified,
+      has_tax_id: !!taxInfo.tax_id_encrypted,
+      created_at: taxInfo.created_at,
+      updated_at: taxInfo.updated_at,
+    };
+  }
+
+  private parseInvoice(invoice: any): any {
+    return {
+      ...invoice,
+      line_items: this.safeJsonParse(invoice.line_items),
+      client_details: this.safeJsonParse(invoice.client_details),
+      contractor_details: this.safeJsonParse(invoice.contractor_details),
+      amount: parseFloat(invoice.amount) || 0,
+      tax_amount: parseFloat(invoice.tax_amount) || 0,
+      tax_withholding_percent: parseFloat(invoice.tax_withholding_percent) || 0,
+    };
+  }
+
+  private safeJsonParse(value: any): any {
+    if (!value) return null;
+    if (typeof value === 'object') return value;
+    try {
+      return JSON.parse(value);
+    } catch {
+      return value;
+    }
+  }
+
+  private escapeHtml(str: string): string {
+    if (!str) return '';
+    return str
+      .replace(/&/g, '&amp;')
+      .replace(/</g, '&lt;')
+      .replace(/>/g, '&gt;')
+      .replace(/"/g, '&quot;')
+      .replace(/'/g, '&#039;');
+  }
+}


### PR DESCRIPTION
## Summary

- Add complete invoicing module (`backend/src/modules/invoicing/`) with auto-invoice generation on escrow milestone release, HTML invoice rendering, invoice listing with filters, and summary stats
- Add tax document support: 1099-NEC summary for US clients (flags contractors earning >$600/year) and W-8BEN collection for international contractors with AES-256-CBC encrypted tax IDs
- Hook into `EscrowService.approveMilestoneAndRelease` to auto-generate invoices non-blockingly after payment capture
- Add DB migration (`005_invoicing.sql`) and schema definitions for `invoices` and `contractor_tax_info` tables

### API Endpoints
| Method | Endpoint | Description |
|--------|----------|-------------|
| GET | `/invoices` | List invoices (filterable by project, status, date range) |
| GET | `/invoices/stats` | Invoice summary stats |
| GET | `/invoices/:id` | Get invoice details |
| GET | `/invoices/:id/pdf` | Download invoice as HTML |
| GET | `/invoices/tax/1099-summary?year=2026` | 1099-NEC summary for clients |
| POST | `/invoices/tax/w8ben` | Submit W-8BEN info |
| GET | `/invoices/tax/w8ben` | Get W-8BEN status |

## Test plan
- [ ] Run `cd backend && npx tsc --noEmit` -- 0 errors (verified)
- [ ] Verify invoice auto-generation after escrow milestone release
- [ ] Test invoice list/filter endpoints with auth
- [ ] Test HTML invoice download renders correctly
- [ ] Test 1099 summary groups contractors and flags >$600 threshold
- [ ] Test W-8BEN submit encrypts tax ID and retrieval masks it
- [ ] Verify non-blocking: invoice generation failure does not block escrow release

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)