### PR TITLE
feat(currency): add multi-currency support module

### DIFF
--- a/backend/migrations/007_multi_currency.sql
+++ b/backend/migrations/007_multi_currency.sql
@@ -1,0 +1,11 @@
+-- =====================================================
+-- Multi-Currency Support Migration
+-- Closes: GitHub issue #55
+-- Generated: 2026-04-11
+-- =====================================================
+
+-- Add preferred_currency column to users table
+ALTER TABLE "users"
+  ADD COLUMN IF NOT EXISTS "preferred_currency" VARCHAR(3) DEFAULT 'USD';
+
+CREATE INDEX IF NOT EXISTS "idx_users_preferred_currency" ON "users" ("preferred_currency");

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -51,6 +51,7 @@ import { SchedulerModule } from './modules/scheduler/scheduler.module';
 import { DataEngineModule } from './modules/data-engine/data-engine.module';
 import { QdrantModule } from './modules/qdrant/qdrant.module';
 import { QueueModule } from './modules/queue/queue.module';
+import { CurrencyModule } from './modules/currency/currency.module';
 
 @Module({
   imports: [
@@ -106,6 +107,9 @@ import { QueueModule } from './modules/queue/queue.module';
     HireRequestModule,
     SchedulerModule,
     DataEngineModule,
+
+    // Multi-currency support
+    CurrencyModule,
 
     // Infrastructure modules (Global)
     QdrantModule,

--- a/backend/src/modules/currency/currency.controller.ts
+++ b/backend/src/modules/currency/currency.controller.ts
@@ -1,0 +1,130 @@
+import {
+  Controller,
+  Get,
+  Post,
+  Patch,
+  Body,
+  Query,
+  UseGuards,
+  Request,
+  HttpStatus,
+} from '@nestjs/common';
+import {
+  ApiTags,
+  ApiOperation,
+  ApiResponse,
+  ApiBearerAuth,
+  ApiQuery,
+  ApiBody,
+} from '@nestjs/swagger';
+import { JwtAuthGuard } from '../auth/guards/jwt-auth.guard';
+import { CurrencyService } from './currency.service';
+
+@ApiTags('Multi-Currency')
+@Controller()
+export class CurrencyController {
+  constructor(private readonly currencyService: CurrencyService) {}
+
+  // ============================================
+  // PUBLIC ENDPOINTS
+  // ============================================
+
+  @Get('currencies')
+  @ApiOperation({ summary: 'List supported currencies' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Supported currencies retrieved',
+  })
+  getSupportedCurrencies() {
+    return this.currencyService.getSupportedCurrencies();
+  }
+
+  @Get('currencies/rates')
+  @ApiOperation({ summary: 'Get current exchange rates' })
+  @ApiQuery({
+    name: 'base',
+    required: false,
+    type: String,
+    description: 'Base currency code (default: USD)',
+    example: 'USD',
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Exchange rates retrieved',
+  })
+  async getExchangeRates(@Query('base') base: string = 'USD') {
+    return this.currencyService.getExchangeRates(base);
+  }
+
+  @Post('currencies/convert')
+  @ApiOperation({ summary: 'Convert amount between currencies' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        amount: { type: 'number', example: 100, description: 'Amount to convert' },
+        from: { type: 'string', example: 'USD', description: 'Source currency code' },
+        to: { type: 'string', example: 'EUR', description: 'Target currency code' },
+      },
+      required: ['amount', 'from', 'to'],
+    },
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Conversion result',
+  })
+  async convert(
+    @Body('amount') amount: number,
+    @Body('from') from: string,
+    @Body('to') to: string,
+  ) {
+    return this.currencyService.convert(amount, from, to);
+  }
+
+  // ============================================
+  // AUTHENTICATED ENDPOINTS
+  // ============================================
+
+  @Patch('users/me/currency')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Set my preferred display currency' })
+  @ApiBody({
+    schema: {
+      type: 'object',
+      properties: {
+        currency: {
+          type: 'string',
+          example: 'EUR',
+          description: 'Preferred currency code (one of the 15 supported currencies)',
+        },
+      },
+      required: ['currency'],
+    },
+  })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Preferred currency updated',
+  })
+  async setPreferredCurrency(
+    @Request() req: any,
+    @Body('currency') currency: string,
+  ) {
+    const userId = req.user.sub || req.user.userId;
+    return this.currencyService.setUserPreferredCurrency(userId, currency);
+  }
+
+  @Get('users/me/currency')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth()
+  @ApiOperation({ summary: 'Get my preferred display currency' })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    description: 'Preferred currency retrieved',
+  })
+  async getPreferredCurrency(@Request() req: any) {
+    const userId = req.user.sub || req.user.userId;
+    const currency = await this.currencyService.getUserPreferredCurrency(userId);
+    return { preferredCurrency: currency };
+  }
+}

--- a/backend/src/modules/currency/currency.middleware.ts
+++ b/backend/src/modules/currency/currency.middleware.ts
@@ -1,0 +1,44 @@
+import { Injectable, NestMiddleware } from '@nestjs/common';
+import { Request, Response, NextFunction } from 'express';
+import { CurrencyService } from './currency.service';
+import * as jwt from 'jsonwebtoken';
+
+/**
+ * CurrencyMiddleware
+ *
+ * Reads the user's preferred currency from JWT/session and injects it
+ * into the request context as `req.preferredCurrency`.
+ *
+ * Contract amounts are stored in any currency; display conversion
+ * happens at read time using this middleware-provided currency preference.
+ */
+@Injectable()
+export class CurrencyMiddleware implements NestMiddleware {
+  constructor(private readonly currencyService: CurrencyService) {}
+
+  async use(req: Request, _res: Response, next: NextFunction) {
+    try {
+      const authHeader = req.headers.authorization;
+      if (authHeader && authHeader.startsWith('Bearer ')) {
+        const token = authHeader.split(' ')[1];
+        const decoded = jwt.decode(token) as any;
+
+        if (decoded) {
+          const userId = decoded.sub || decoded.userId || decoded.id || decoded.user_id;
+          if (userId) {
+            const currency = await this.currencyService.getUserPreferredCurrency(userId);
+            (req as any).preferredCurrency = currency;
+          }
+        }
+      }
+    } catch {
+      // Silently fail -- default to USD if anything goes wrong
+    }
+
+    if (!(req as any).preferredCurrency) {
+      (req as any).preferredCurrency = 'USD';
+    }
+
+    next();
+  }
+}

--- a/backend/src/modules/currency/currency.module.ts
+++ b/backend/src/modules/currency/currency.module.ts
@@ -1,0 +1,27 @@
+import { Module, MiddlewareConsumer, NestModule } from '@nestjs/common';
+import { ConfigModule } from '@nestjs/config';
+import { CurrencyService } from './currency.service';
+import { CurrencyController } from './currency.controller';
+import { CurrencyMiddleware } from './currency.middleware';
+import { AuthModule } from '../auth/auth.module';
+
+/**
+ * Multi-Currency Support Module
+ *
+ * Provides exchange rate fetching (with 1-hour cache), currency conversion,
+ * locale-aware formatting, user preference storage, and middleware that
+ * injects preferred currency into request context.
+ *
+ * Closes: GitHub issue #55
+ */
+@Module({
+  imports: [ConfigModule, AuthModule],
+  providers: [CurrencyService],
+  controllers: [CurrencyController],
+  exports: [CurrencyService],
+})
+export class CurrencyModule implements NestModule {
+  configure(consumer: MiddlewareConsumer) {
+    consumer.apply(CurrencyMiddleware).forRoutes('*');
+  }
+}

--- a/backend/src/modules/currency/currency.service.ts
+++ b/backend/src/modules/currency/currency.service.ts
@@ -1,0 +1,319 @@
+import { Injectable, Logger, BadRequestException } from '@nestjs/common';
+import { ConfigService } from '@nestjs/config';
+import { DatabaseService } from '../database/database.service';
+import axios from 'axios';
+
+export interface SupportedCurrency {
+  code: string;
+  name: string;
+  symbol: string;
+  decimalDigits: number;
+}
+
+export interface ExchangeRates {
+  base: string;
+  timestamp: number;
+  rates: Record<string, number>;
+}
+
+export interface ConvertResult {
+  from: string;
+  to: string;
+  amount: number;
+  convertedAmount: number;
+  rate: number;
+  timestamp: number;
+}
+
+/**
+ * Top 15 supported currencies
+ */
+const SUPPORTED_CURRENCIES: SupportedCurrency[] = [
+  { code: 'USD', name: 'US Dollar', symbol: '$', decimalDigits: 2 },
+  { code: 'EUR', name: 'Euro', symbol: '\u20AC', decimalDigits: 2 },
+  { code: 'GBP', name: 'British Pound', symbol: '\u00A3', decimalDigits: 2 },
+  { code: 'JPY', name: 'Japanese Yen', symbol: '\u00A5', decimalDigits: 0 },
+  { code: 'BDT', name: 'Bangladeshi Taka', symbol: '\u09F3', decimalDigits: 2 },
+  { code: 'INR', name: 'Indian Rupee', symbol: '\u20B9', decimalDigits: 2 },
+  { code: 'CAD', name: 'Canadian Dollar', symbol: 'CA$', decimalDigits: 2 },
+  { code: 'AUD', name: 'Australian Dollar', symbol: 'A$', decimalDigits: 2 },
+  { code: 'CHF', name: 'Swiss Franc', symbol: 'CHF', decimalDigits: 2 },
+  { code: 'CNY', name: 'Chinese Yuan', symbol: '\u00A5', decimalDigits: 2 },
+  { code: 'KRW', name: 'South Korean Won', symbol: '\u20A9', decimalDigits: 0 },
+  { code: 'BRL', name: 'Brazilian Real', symbol: 'R$', decimalDigits: 2 },
+  { code: 'SGD', name: 'Singapore Dollar', symbol: 'S$', decimalDigits: 2 },
+  { code: 'HKD', name: 'Hong Kong Dollar', symbol: 'HK$', decimalDigits: 2 },
+  { code: 'NZD', name: 'New Zealand Dollar', symbol: 'NZ$', decimalDigits: 2 },
+];
+
+/**
+ * Fallback hardcoded rates (USD base) for top currencies
+ * Used when the exchange rate API is unavailable
+ */
+const FALLBACK_RATES: Record<string, number> = {
+  USD: 1.0,
+  EUR: 0.92,
+  GBP: 0.79,
+  JPY: 154.5,
+  BDT: 121.5,
+  INR: 83.5,
+  CAD: 1.37,
+  AUD: 1.55,
+  CHF: 0.88,
+  CNY: 7.24,
+  KRW: 1345.0,
+  BRL: 5.05,
+  SGD: 1.35,
+  HKD: 7.82,
+  NZD: 1.68,
+};
+
+/**
+ * Locale mappings for currency formatting
+ */
+const CURRENCY_LOCALES: Record<string, string> = {
+  USD: 'en-US',
+  EUR: 'de-DE',
+  GBP: 'en-GB',
+  JPY: 'ja-JP',
+  BDT: 'bn-BD',
+  INR: 'en-IN',
+  CAD: 'en-CA',
+  AUD: 'en-AU',
+  CHF: 'de-CH',
+  CNY: 'zh-CN',
+  KRW: 'ko-KR',
+  BRL: 'pt-BR',
+  SGD: 'en-SG',
+  HKD: 'zh-HK',
+  NZD: 'en-NZ',
+};
+
+@Injectable()
+export class CurrencyService {
+  private readonly logger = new Logger(CurrencyService.name);
+
+  // In-memory cache for exchange rates (1 hour TTL)
+  private ratesCache: { data: ExchangeRates; expiresAt: number } | null = null;
+  private static readonly CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
+
+  constructor(
+    private readonly configService: ConfigService,
+    private readonly db: DatabaseService,
+  ) {}
+
+  /**
+   * Return list of supported currencies with symbols
+   */
+  getSupportedCurrencies(): SupportedCurrency[] {
+    return SUPPORTED_CURRENCIES;
+  }
+
+  /**
+   * Validate that a currency code is supported
+   */
+  private validateCurrency(code: string): void {
+    if (!SUPPORTED_CURRENCIES.find((c) => c.code === code)) {
+      throw new BadRequestException(
+        `Unsupported currency: ${code}. Supported: ${SUPPORTED_CURRENCIES.map((c) => c.code).join(', ')}`,
+      );
+    }
+  }
+
+  /**
+   * Get current exchange rates (cached for 1 hour)
+   * Uses Open Exchange Rates API with fallback to hardcoded rates
+   */
+  async getExchangeRates(base: string = 'USD'): Promise<ExchangeRates> {
+    this.validateCurrency(base);
+
+    // Check cache
+    if (this.ratesCache && Date.now() < this.ratesCache.expiresAt) {
+      // If requested base is USD, return cached directly
+      if (base === 'USD') {
+        return this.ratesCache.data;
+      }
+      // Otherwise rebase from cached USD rates
+      return this.rebaseRates(this.ratesCache.data, base);
+    }
+
+    // Fetch fresh rates (always in USD base)
+    const rates = await this.fetchRates();
+    this.ratesCache = {
+      data: rates,
+      expiresAt: Date.now() + CurrencyService.CACHE_TTL_MS,
+    };
+
+    if (base === 'USD') {
+      return rates;
+    }
+    return this.rebaseRates(rates, base);
+  }
+
+  /**
+   * Fetch exchange rates from API, fall back to hardcoded rates
+   */
+  private async fetchRates(): Promise<ExchangeRates> {
+    const apiKey = this.configService.get<string>('OPEN_EXCHANGE_RATES_APP_ID');
+    const apiUrl = 'https://openexchangerates.org/api/latest.json';
+
+    if (apiKey) {
+      try {
+        const response = await axios.get(apiUrl, {
+          params: { app_id: apiKey },
+          timeout: 5000,
+        });
+
+        const data = response.data;
+        // Filter to only supported currencies
+        const supportedCodes = SUPPORTED_CURRENCIES.map((c) => c.code);
+        const filteredRates: Record<string, number> = {};
+        for (const code of supportedCodes) {
+          if (data.rates[code] !== undefined) {
+            filteredRates[code] = data.rates[code];
+          }
+        }
+
+        this.logger.log('Fetched exchange rates from Open Exchange Rates API');
+        return {
+          base: 'USD',
+          timestamp: data.timestamp || Math.floor(Date.now() / 1000),
+          rates: filteredRates,
+        };
+      } catch (error) {
+        this.logger.warn(
+          `Failed to fetch exchange rates from API: ${error.message}. Using fallback rates.`,
+        );
+      }
+    } else {
+      this.logger.warn(
+        'OPEN_EXCHANGE_RATES_APP_ID not configured. Using fallback hardcoded rates.',
+      );
+    }
+
+    // Fallback to hardcoded rates
+    return {
+      base: 'USD',
+      timestamp: Math.floor(Date.now() / 1000),
+      rates: { ...FALLBACK_RATES },
+    };
+  }
+
+  /**
+   * Rebase exchange rates from USD to another base currency
+   */
+  private rebaseRates(usdRates: ExchangeRates, newBase: string): ExchangeRates {
+    const baseRate = usdRates.rates[newBase];
+    if (!baseRate) {
+      throw new BadRequestException(`No rate available for base currency: ${newBase}`);
+    }
+
+    const rebasedRates: Record<string, number> = {};
+    for (const [code, rate] of Object.entries(usdRates.rates)) {
+      rebasedRates[code] = rate / baseRate;
+    }
+
+    return {
+      base: newBase,
+      timestamp: usdRates.timestamp,
+      rates: rebasedRates,
+    };
+  }
+
+  /**
+   * Convert between currencies using cached rates
+   */
+  async convert(amount: number, from: string, to: string): Promise<ConvertResult> {
+    this.validateCurrency(from);
+    this.validateCurrency(to);
+
+    if (amount < 0) {
+      throw new BadRequestException('Amount must be non-negative');
+    }
+
+    if (from === to) {
+      return {
+        from,
+        to,
+        amount,
+        convertedAmount: amount,
+        rate: 1,
+        timestamp: Math.floor(Date.now() / 1000),
+      };
+    }
+
+    // Get rates with USD as base
+    const rates = await this.getExchangeRates('USD');
+
+    const fromRate = rates.rates[from];
+    const toRate = rates.rates[to];
+
+    if (!fromRate || !toRate) {
+      throw new BadRequestException(`Exchange rate not available for ${from} -> ${to}`);
+    }
+
+    // Convert: amount in "from" -> USD -> "to"
+    const rate = toRate / fromRate;
+    const convertedAmount = amount * rate;
+
+    // Round based on target currency decimal digits
+    const targetCurrency = SUPPORTED_CURRENCIES.find((c) => c.code === to);
+    const decimals = targetCurrency?.decimalDigits ?? 2;
+    const rounded = Math.round(convertedAmount * Math.pow(10, decimals)) / Math.pow(10, decimals);
+
+    return {
+      from,
+      to,
+      amount,
+      convertedAmount: rounded,
+      rate: Math.round(rate * 1000000) / 1000000,
+      timestamp: rates.timestamp,
+    };
+  }
+
+  /**
+   * Format for display (e.g., $1,234.56, JPY 1,234, EUR 1.234,56)
+   */
+  formatCurrency(amount: number, currency: string): string {
+    this.validateCurrency(currency);
+
+    const locale = CURRENCY_LOCALES[currency] || 'en-US';
+    try {
+      return new Intl.NumberFormat(locale, {
+        style: 'currency',
+        currency,
+      }).format(amount);
+    } catch {
+      // Fallback: basic formatting
+      const curr = SUPPORTED_CURRENCIES.find((c) => c.code === currency);
+      return `${curr?.symbol || currency} ${amount.toFixed(curr?.decimalDigits ?? 2)}`;
+    }
+  }
+
+  /**
+   * Read preferred currency from user preferences
+   */
+  async getUserPreferredCurrency(userId: string): Promise<string> {
+    try {
+      const user = await this.db.findOne('users', { id: userId });
+      return user?.preferred_currency || 'USD';
+    } catch {
+      return 'USD';
+    }
+  }
+
+  /**
+   * Store preferred currency in user preferences
+   */
+  async setUserPreferredCurrency(userId: string, currency: string): Promise<{ preferredCurrency: string }> {
+    this.validateCurrency(currency);
+
+    await this.db.update('users', userId, {
+      preferred_currency: currency,
+      updated_at: new Date().toISOString(),
+    });
+
+    this.logger.log(`Set preferred currency for user ${userId} to ${currency}`);
+    return { preferredCurrency: currency };
+  }
+}


### PR DESCRIPTION
## Summary
- Add multi-currency module (`backend/src/modules/currency/`) supporting 15 currencies: USD, EUR, GBP, JPY, BDT, INR, CAD, AUD, CHF, CNY, KRW, BRL, SGD, HKD, NZD
- Implement exchange rate fetching from Open Exchange Rates API with 1-hour in-memory cache and hardcoded fallback rates for resilience
- Add `CurrencyMiddleware` that reads user's preferred currency from JWT and injects it into request context for display-time conversion
- Add database migration adding `preferred_currency` column to users table

Closes #55

## API Endpoints
| Method | Path | Auth | Description |
|--------|------|------|-------------|
| GET | `/currencies` | Public | List supported currencies |
| GET | `/currencies/rates?base=USD` | Public | Current exchange rates |
| POST | `/currencies/convert` | Public | Convert amount between currencies |
| PATCH | `/users/me/currency` | JWT | Set preferred display currency |
| GET | `/users/me/currency` | JWT | Get preferred display currency |

## Test plan
- [ ] Verify `npx tsc --noEmit` passes with 0 errors
- [ ] Run migration against dev database
- [ ] Test currency list endpoint returns all 15 currencies
- [ ] Test exchange rate fetching (with and without API key)
- [ ] Test fallback to hardcoded rates when API is unavailable
- [ ] Test conversion accuracy between currency pairs
- [ ] Test locale-aware formatting for each currency
- [ ] Test user preference set/get round-trip
- [ ] Test CurrencyMiddleware injects `preferredCurrency` into requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)